### PR TITLE
Change license header year back to 2016

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Please see [CONTRIBUTING](CONTRIBUTING.md).
 
 ## License
 ```
-   Copyright 2017, Optimizely
+   Copyright 2016, Optimizely
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/core-api/build.gradle
+++ b/core-api/build.gradle
@@ -1,19 +1,3 @@
-/*
- *    Copyright 2017, Optimizely
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
-
 plugins {
     id 'de.fuerstenau.buildconfig' version '1.1.7'
 }

--- a/core-api/src/jmh/java/com/optimizely/ab/BenchmarkUtils.java
+++ b/core-api/src/jmh/java/com/optimizely/ab/BenchmarkUtils.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/jmh/java/com/optimizely/ab/OptimizelyBenchmark.java
+++ b/core-api/src/jmh/java/com/optimizely/ab/OptimizelyBenchmark.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/jmh/java/com/optimizely/ab/OptimizelyBuilderBenchmark.java
+++ b/core-api/src/jmh/java/com/optimizely/ab/OptimizelyBuilderBenchmark.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/jmh/resources/benchmark.properties
+++ b/core-api/src/jmh/resources/benchmark.properties
@@ -1,19 +1,3 @@
-#
-#    Copyright 2017, Optimizely
-#
-#    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
-#
-
 datafilePathTemplate=config/profiling-test-data-%d-experiments.json
 activateGroupExperimentUserIdPropTemplate=activateGroupExperiment%dExperimentsUserId
 activateGroupExperiment10ExperimentsUserId=no

--- a/core-api/src/jmh/resources/logback.xml
+++ b/core-api/src/jmh/resources/logback.xml
@@ -1,19 +1,3 @@
-<!--
-  ~    Copyright 2017, Optimizely
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
-
 <configuration>
     <root level="warn"/>
 </configuration>

--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/OptimizelyRuntimeException.java
+++ b/core-api/src/main/java/com/optimizely/ab/OptimizelyRuntimeException.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/UnknownEventTypeException.java
+++ b/core-api/src/main/java/com/optimizely/ab/UnknownEventTypeException.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/UnknownExperimentException.java
+++ b/core-api/src/main/java/com/optimizely/ab/UnknownExperimentException.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/UnknownLiveVariableException.java
+++ b/core-api/src/main/java/com/optimizely/ab/UnknownLiveVariableException.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/annotations/VisibleForTesting.java
+++ b/core-api/src/main/java/com/optimizely/ab/annotations/VisibleForTesting.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/bucketing/Bucketer.java
+++ b/core-api/src/main/java/com/optimizely/ab/bucketing/Bucketer.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/bucketing/UserProfile.java
+++ b/core-api/src/main/java/com/optimizely/ab/bucketing/UserProfile.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/bucketing/internal/MurmurHash3.java
+++ b/core-api/src/main/java/com/optimizely/ab/bucketing/internal/MurmurHash3.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/Attribute.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/Attribute.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/EventType.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/EventType.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/Experiment.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/Experiment.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/Group.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/Group.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/IdKeyMapped.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/IdKeyMapped.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/IdMapped.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/IdMapped.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/LiveVariable.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/LiveVariable.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/LiveVariableUsageInstance.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/LiveVariableUsageInstance.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/ProjectConfig.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/ProjectConfig.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/ProjectConfigUtils.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/ProjectConfigUtils.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/TrafficAllocation.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/TrafficAllocation.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/Variation.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/Variation.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/AndCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/AndCondition.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/Audience.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/Audience.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/Condition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/Condition.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/NotCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/NotCondition.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/OrCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/OrCondition.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/UserAttribute.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/UserAttribute.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/AudienceGsonDeserializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/AudienceGsonDeserializer.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/AudienceJacksonDeserializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/AudienceJacksonDeserializer.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/ConfigParseException.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/ConfigParseException.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/ConfigParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/ConfigParser.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/DefaultConfigParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/DefaultConfigParser.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/ExperimentGsonDeserializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/ExperimentGsonDeserializer.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/GroupGsonDeserializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/GroupGsonDeserializer.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/GroupJacksonDeserializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/GroupJacksonDeserializer.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/GsonConfigParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/GsonConfigParser.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/GsonHelpers.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/GsonHelpers.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/JacksonConfigParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/JacksonConfigParser.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/JsonConfigParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/JsonConfigParser.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/JsonSimpleConfigParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/JsonSimpleConfigParser.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/MissingJsonParserException.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/MissingJsonParserException.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/ProjectConfigGsonDeserializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/ProjectConfigGsonDeserializer.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/ProjectConfigJacksonDeserializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/ProjectConfigJacksonDeserializer.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/error/ErrorHandler.java
+++ b/core-api/src/main/java/com/optimizely/ab/error/ErrorHandler.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/error/NoOpErrorHandler.java
+++ b/core-api/src/main/java/com/optimizely/ab/error/NoOpErrorHandler.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/error/RaiseExceptionErrorHandler.java
+++ b/core-api/src/main/java/com/optimizely/ab/error/RaiseExceptionErrorHandler.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/event/EventHandler.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/EventHandler.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/event/LogEvent.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/LogEvent.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/event/NoopEventHandler.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/NoopEventHandler.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/EventBuilder.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/EventBuilder.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/EventBuilderV1.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/EventBuilderV1.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/EventBuilderV2.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/EventBuilderV2.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/payload/Conversion.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/payload/Conversion.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/payload/Decision.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/payload/Decision.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/payload/Event.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/payload/Event.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/payload/EventMetric.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/payload/EventMetric.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/payload/Feature.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/payload/Feature.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/payload/Impression.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/payload/Impression.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/payload/LayerState.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/payload/LayerState.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/serializer/DefaultJsonSerializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/serializer/DefaultJsonSerializer.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/serializer/GsonSerializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/serializer/GsonSerializer.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/serializer/JacksonSerializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/serializer/JacksonSerializer.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/serializer/JsonSerializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/serializer/JsonSerializer.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/serializer/JsonSimpleSerializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/serializer/JsonSimpleSerializer.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/serializer/SerializationException.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/serializer/SerializationException.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/serializer/Serializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/serializer/Serializer.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/internal/ProjectValidationUtils.java
+++ b/core-api/src/main/java/com/optimizely/ab/internal/ProjectValidationUtils.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/notification/NotificationBroadcaster.java
+++ b/core-api/src/main/java/com/optimizely/ab/notification/NotificationBroadcaster.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/notification/NotificationListener.java
+++ b/core-api/src/main/java/com/optimizely/ab/notification/NotificationListener.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyBuilderTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyBuilderTest.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTestV1.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTestV1.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTestV2.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTestV2.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTestV3.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTestV3.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/bucketing/BucketerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/bucketing/BucketerTest.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/bucketing/internal/MurmurHash3Test.java
+++ b/core-api/src/test/java/com/optimizely/ab/bucketing/internal/MurmurHash3Test.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/categories/ExhaustiveTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/categories/ExhaustiveTest.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/config/ProjectConfigTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/ProjectConfigTest.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/config/ProjectConfigTestUtils.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/ProjectConfigTestUtils.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/config/VariationTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/VariationTest.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/config/audience/AudienceConditionEvaluationTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/audience/AudienceConditionEvaluationTest.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/DefaultConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/DefaultConfigParserTest.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/GsonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/GsonConfigParserTest.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/JacksonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/JacksonConfigParserTest.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/JsonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/JsonConfigParserTest.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/JsonSimpleConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/JsonSimpleConfigParserTest.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/event/NoopEventHandlerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/event/NoopEventHandlerTest.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/event/internal/EventBuilderV1Test.java
+++ b/core-api/src/test/java/com/optimizely/ab/event/internal/EventBuilderV1Test.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/event/internal/EventBuilderV2Test.java
+++ b/core-api/src/test/java/com/optimizely/ab/event/internal/EventBuilderV2Test.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/event/internal/serializer/GsonSerializerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/event/internal/serializer/GsonSerializerTest.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/event/internal/serializer/JacksonSerializerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/event/internal/serializer/JacksonSerializerTest.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/event/internal/serializer/JsonSerializerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/event/internal/serializer/JsonSerializerTest.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/event/internal/serializer/JsonSimpleSerializerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/event/internal/serializer/JsonSimpleSerializerTest.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/event/internal/serializer/SerializerTestUtils.java
+++ b/core-api/src/test/java/com/optimizely/ab/event/internal/serializer/SerializerTestUtils.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/internal/LogbackVerifier.java
+++ b/core-api/src/test/java/com/optimizely/ab/internal/LogbackVerifier.java
@@ -1,19 +1,3 @@
-/*
- *    Copyright 2017, Optimizely
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
-
 package com.optimizely.ab.internal;
 
 import ch.qos.logback.classic.Level;

--- a/core-api/src/test/java/com/optimizely/ab/internal/ProjectValidationUtilsTestV1.java
+++ b/core-api/src/test/java/com/optimizely/ab/internal/ProjectValidationUtilsTestV1.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/internal/ProjectValidationUtilsTestV2.java
+++ b/core-api/src/test/java/com/optimizely/ab/internal/ProjectValidationUtilsTestV2.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/notification/NotificationBroadcasterTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/notification/NotificationBroadcasterTest.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-httpclient-impl/build.gradle
+++ b/core-httpclient-impl/build.gradle
@@ -1,19 +1,3 @@
-/*
- *    Copyright 2017, Optimizely
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
-
 dependencies {
     compile project(':core-api')
 

--- a/core-httpclient-impl/gradle.properties
+++ b/core-httpclient-impl/gradle.properties
@@ -1,17 +1,1 @@
-#
-#    Copyright 2017, Optimizely
-#
-#    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
-#
-
 httpClientVersion = 4.5.2

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/HttpClientUtils.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/HttpClientUtils.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/NamedThreadFactory.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/NamedThreadFactory.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/event/AsyncEventHandler.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/event/AsyncEventHandler.java
@@ -1,5 +1,6 @@
-/*
- *    Copyright 2017, Optimizely
+/**
+ *
+ *    Copyright 2016, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/gradle/HEADER
+++ b/gradle/HEADER
@@ -1,5 +1,5 @@
 
-   Copyright ${year}, Optimizely
+   Copyright ${year}, Optimizely and contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/gradle/license.gradle
+++ b/gradle/license.gradle
@@ -4,6 +4,6 @@ subprojects {
         header rootProject.file('gradle/HEADER')
         excludes(['**/*.properties', '**/*.txt', '**/*.conf', '**/*.xml', '**/*.json', '**/LogbackVerifier.java',
                   '**/BuildConfig.java'])
-        ext.year = Calendar.getInstance().get(Calendar.YEAR)
+        ext.year = '2016' // year that the project was created
     }
 }


### PR DESCRIPTION
@optimizely/fullstack-devs 

- Updates the gradle license plugin template to always use 2016 (project inception)