### PR TITLE
Prepare 1.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.5.0
+
+February 16, 2017
+
+- Support Android TV SDK client engine
+
 ## 1.4.1
 
 February 1, 2017

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Maven version
-version = 1.4.1-SNAPSHOT
+version = 1.5.0-SNAPSHOT
 
 # Artifact paths
 mavenS3Bucket = optimizely-maven


### PR DESCRIPTION
February 16, 2017

- Support Android TV SDK client engine
