### PR TITLE
`filterAttributes` returns an empty if `attributes` parameter is null for OASIS-740

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -624,10 +624,16 @@ public class Optimizely {
      *
      * @param projectConfig the current project config
      * @param attributes the attributes map to validate and potentially filter
-     * @return the filtered attributes map (containing only attributes that are present in the project config)
-     *
+     * @return the filtered attributes map (containing only attributes that are present in the project config) or an
+     * empty map if a null object was passed in
      */
-    private Map<String, String> filterAttributes(ProjectConfig projectConfig, Map<String, String> attributes) {
+    private Map<String, String> filterAttributes(@Nonnull ProjectConfig projectConfig,
+                                                 @Nonnull Map<String, String> attributes) {
+        if (attributes == null) {
+            logger.warn("Attributes is null. Was expecting a non-null value.");
+            return Collections.<String, String>emptyMap();
+        }
+
         List<String> unknownAttributes = null;
 
         Map<String, Attribute> attributeKeyMapping = projectConfig.getAttributeKeyMapping();


### PR DESCRIPTION
@mikeng13 @onufryk 

`filterAttributes` is used by both `activate` and `track`

I'm looking for tests for `Optimizely.java` but don't see any. I'll add some later today