### PR TITLE
Adds support for new events endpoint

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/config/ProjectConfig.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/ProjectConfig.java
@@ -21,12 +21,11 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.optimizely.ab.config.audience.Audience;
 import com.optimizely.ab.config.audience.Condition;
 
+import javax.annotation.concurrent.Immutable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * Represents the Optimizely Project configuration.
@@ -40,7 +39,8 @@ public class ProjectConfig {
     public enum Version {
         V1 ("1"),
         V2 ("2"),
-        V3 ("3");
+        V3 ("3"),
+        V4 ("4");
 
         private final String version;
 

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/EventBuilderV2.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/EventBuilderV2.java
@@ -153,7 +153,7 @@ public class EventBuilderV2 extends EventBuilder {
      * @param attributes the {@code {attributeKey -> value}} mapping
      * @param projectConfig the current project config
      */
-    private List<Feature> createUserFeatures(Map<String, String> attributes, ProjectConfig projectConfig) {
+    static List<Feature> createUserFeatures(Map<String, String> attributes, ProjectConfig projectConfig) {
         Map<String, Attribute> attributeKeyMapping = projectConfig.getAttributeKeyMapping();
         List<Feature> features = new ArrayList<Feature>();
 
@@ -210,7 +210,7 @@ public class EventBuilderV2 extends EventBuilder {
      * @param eventKey the goal that the bucket map will be filtered by
      * @param attributes the user's attributes
      */
-    private List<LayerState> createLayerStates(ProjectConfig projectConfig, Bucketer bucketer, String userId,
+    static List<LayerState> createLayerStates(ProjectConfig projectConfig, Bucketer bucketer, String userId,
                                                String eventKey, Map<String, String> attributes) {
         List<Experiment> allExperiments = projectConfig.getExperiments();
         List<String> experimentIds = projectConfig.getExperimentIdsForGoal(eventKey);

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/EventBuilderV3.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/EventBuilderV3.java
@@ -1,0 +1,171 @@
+/**
+ *
+ *    Copyright 2016-2017, Optimizely and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.optimizely.ab.event.internal;
+
+import com.optimizely.ab.annotations.VisibleForTesting;
+import com.optimizely.ab.bucketing.Bucketer;
+import com.optimizely.ab.config.Experiment;
+import com.optimizely.ab.config.ProjectConfig;
+import com.optimizely.ab.config.Variation;
+import com.optimizely.ab.event.LogEvent;
+import com.optimizely.ab.event.internal.payload.*;
+import com.optimizely.ab.event.internal.payload.Event.ClientEngine;
+import com.optimizely.ab.event.internal.payload.batch.*;
+import com.optimizely.ab.event.internal.payload.batch.Decision;
+import com.optimizely.ab.event.internal.payload.batch.Event;
+import com.optimizely.ab.event.internal.serializer.DefaultJsonSerializer;
+import com.optimizely.ab.event.internal.serializer.Serializer;
+import com.optimizely.ab.internal.EventTagUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.util.*;
+
+import static com.optimizely.ab.event.internal.EventBuilderV2.createUserFeatures;
+
+public class EventBuilderV3 extends EventBuilder {
+
+    private static final Logger logger = LoggerFactory.getLogger(EventBuilderV3.class);
+
+    static final String BATCH_ENDPOINT = "https://logx.optimizely.com/v1/events";
+    static final String KEY_CAMPAIGN_ACTIVATED = "campaign_activated";
+
+    @VisibleForTesting
+    public final ClientEngine clientEngine;
+
+    @VisibleForTesting
+    public final String clientVersion;
+
+    private Serializer serializer;
+
+    public EventBuilderV3() {
+        this(ClientEngine.JAVA_SDK, BuildVersionInfo.VERSION);
+    }
+
+    public EventBuilderV3(ClientEngine clientEngine, String clientVersion) {
+        this.clientEngine = clientEngine;
+        this.clientVersion = clientVersion;
+        this.serializer = DefaultJsonSerializer.getInstance();
+    }
+
+    public LogEvent createImpressionEvent(@Nonnull ProjectConfig projectConfig,
+                                          @Nonnull Experiment activatedExperiment,
+                                          @Nonnull Variation variation,
+                                          @Nonnull String userId,
+                                          @Nonnull Map<String, String> attributes) {
+        Decision decision = new Decision(
+                        activatedExperiment.getLayerId());
+        decision.setExperimentId(activatedExperiment.getId());
+        decision.setVariationId(variation.getId());
+        List<Decision> decisions = Collections.singletonList(decision);
+
+        Event event = new Event(
+                        KEY_CAMPAIGN_ACTIVATED,
+                        System.currentTimeMillis(),
+                        UUID.randomUUID().toString());
+        event.setEntityId(activatedExperiment.getLayerId());
+        List<Event> events = Collections.singletonList(event);
+
+        Snapshot snapshot = new Snapshot(decisions, events);
+        List<Snapshot> snapshots = Collections.singletonList(snapshot);
+
+        Visitor visitor = new Visitor(userId);
+        List<Attribute> batchAttributes
+                = createUserAttributes(projectConfig, attributes);
+        visitor.setAttributes(batchAttributes);
+        visitor.setSnapshots(snapshots);
+        List<Visitor> visitors = Collections.singletonList(visitor);
+
+        Batch impressionPayload = new Batch(projectConfig.getAccountId());
+        impressionPayload.setAnonymizeIp(projectConfig.getAnonymizeIP());
+        impressionPayload.setClientName(clientEngine.getClientEngineValue());
+        impressionPayload.setClientVersion(clientVersion);
+        impressionPayload.setVisitors(visitors);
+        impressionPayload.setProjectId(projectConfig.getProjectId());
+
+        String payload = this.serializer.serialize(impressionPayload);
+        return new LogEvent(LogEvent.RequestMethod.POST, BATCH_ENDPOINT, Collections.<String, String>emptyMap(), payload);
+    }
+
+
+    // TODO remove conversion for performance gain
+    private List<Attribute> createUserAttributes(@Nonnull ProjectConfig projectConfig, @Nonnull Map<String, String> attributes) {
+        List<Feature> features = createUserFeatures(attributes, projectConfig);
+        List<Attribute> batchAttributes = new ArrayList<Attribute>();
+        for (Feature feature : features) {
+            batchAttributes.add(new Attribute(feature));
+        }
+        return batchAttributes;
+    }
+
+    // TODO remove conversion for performance gain
+    static List<Decision> createDecisions(ProjectConfig projectConfig, Bucketer bucketer, String visitorId,
+                                               String eventKey, Map<String, String> attributes) {
+        List<LayerState> layerStates = EventBuilderV2.createLayerStates(projectConfig, bucketer, visitorId, eventKey,
+                attributes);
+        List<Decision> decisions = new ArrayList<Decision>();
+        for (LayerState layerState : layerStates) {
+            com.optimizely.ab.event.internal.payload.Decision decision = layerState.getDecision();
+            Decision batchDecision = new Decision(layerState.getLayerId());
+            batchDecision.setVariationId(decision.getVariationId());
+            batchDecision.setExperimentId(decision.getExperimentId());
+            decisions.add(batchDecision);
+        }
+
+        return decisions;
+    }
+
+    public LogEvent createConversionEvent(@Nonnull ProjectConfig projectConfig,
+                                          @Nonnull Bucketer bucketer,
+                                          @Nonnull String userId,
+                                          @Nonnull String eventId,
+                                          @Nonnull String eventName,
+                                          @Nonnull Map<String, String> attributes,
+                                          @Nonnull Map<String, ?> eventTags) {
+        Long revenue = EventTagUtils.getRevenueValue(eventTags);
+
+        eventTags.remove(EventMetric.REVENUE_METRIC_TYPE);
+        Event event = new Event(eventName, System.currentTimeMillis(), UUID.randomUUID().toString());
+        event.setTags(eventTags);
+        event.setEntityId(eventId);
+        event.setRevenue(revenue);
+
+        List<Event> events = Collections.singletonList(event);
+
+        List<Decision> decisions = createDecisions(projectConfig, bucketer, userId, eventName, attributes);
+        Snapshot snapshot = new Snapshot(decisions, events);
+        List<Snapshot> snapshots = Collections.singletonList(snapshot);
+
+        Visitor visitor = new Visitor(userId);
+        List<com.optimizely.ab.event.internal.payload.batch.Attribute> batchAttributes
+                = createUserAttributes(projectConfig, attributes);
+        visitor.setAttributes(batchAttributes);
+        visitor.setSnapshots(snapshots);
+        List<Visitor> visitors = Collections.singletonList(visitor);
+
+        Batch conversionPayload = new Batch(projectConfig.getAccountId());
+        conversionPayload.setProjectId(projectConfig.getProjectId());
+        conversionPayload.setClientName(clientEngine.getClientEngineValue());
+        conversionPayload.setClientVersion(clientVersion);
+        conversionPayload.setAnonymizeIp(projectConfig.getAnonymizeIP());
+        conversionPayload.setVisitors(visitors);
+
+        String payload = this.serializer.serialize(conversionPayload);
+        return new LogEvent(LogEvent.RequestMethod.POST, BATCH_ENDPOINT, Collections.<String, String>emptyMap(), payload);
+    }
+}

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/payload/batch/Attribute.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/payload/batch/Attribute.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2016-2017, Optimizely and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.optimizely.ab.event.internal.payload.batch;
+
+import com.optimizely.ab.event.internal.payload.Feature;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class Attribute {
+
+    public static final String CUSTOM_ATTRIBUTE_FEATURE_TYPE = "custom";
+    public static final String EVENT_FEATURE_TYPE = "custom";
+
+    @Nullable private String entityId;
+    @Nullable private String key;
+    @Nonnull private String type;
+    @Nonnull private Object value;
+
+    public Attribute(@Nonnull String type, @Nonnull Object value) {
+        this.type = type;
+        this.value = value;
+    }
+
+    public Attribute(@Nullable String entityId, @Nullable String key, @Nonnull String type, @Nonnull Object value) {
+        this.entityId = entityId;
+        this.key = key;
+        this.type = type;
+        this.value = value;
+    }
+
+    public Attribute(@Nonnull Feature feature) {
+        this.entityId = feature.getId();
+        this.key = feature.getName();
+        this.type = feature.getType();
+        this.value = feature.getValue();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Attribute attribute = (Attribute) o;
+
+        if (entityId != null ? !entityId.equals(attribute.entityId) : attribute.entityId != null) return false;
+        if (key != null ? !key.equals(attribute.key) : attribute.key != null) return false;
+        if (!type.equals(attribute.type)) return false;
+        return value.equals(attribute.value);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = entityId != null ? entityId.hashCode() : 0;
+        result = 31 * result + (key != null ? key.hashCode() : 0);
+        result = 31 * result + type.hashCode();
+        result = 31 * result + value.hashCode();
+        return result;
+    }
+
+    @Nullable
+    public String getEntityId() {
+
+        return entityId;
+    }
+
+    public void setEntityId(@Nullable String entityId) {
+        this.entityId = entityId;
+    }
+
+    @Nullable
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(@Nullable String key) {
+        this.key = key;
+    }
+
+    @Nonnull
+    public String getType() {
+        return type;
+    }
+
+    public void setType(@Nonnull String type) {
+        this.type = type;
+    }
+
+    @Nonnull
+    public Object getValue() {
+        return value;
+    }
+
+    public void setValue(@Nonnull Object value) {
+        this.value = value;
+    }
+}

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/payload/batch/Batch.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/payload/batch/Batch.java
@@ -1,0 +1,114 @@
+/*
+ *
+ *    Copyright 2016-2017, Optimizely and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.optimizely.ab.event.internal.payload.batch;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Batch extends com.optimizely.ab.event.internal.payload.Event{
+
+    @Nonnull private String accountId;
+    @Nullable private Boolean anonymizeIp;
+    @Nullable private String clientName;
+    @Nullable private String projectId;
+    @Nonnull private List<Visitor> visitors = new ArrayList<Visitor>();
+
+    public Batch(@Nonnull String accountId) {
+        this.accountId = accountId;
+    }
+
+    public Batch(@Nonnull String accountId, @Nullable Boolean anonymizeIp, @Nullable String clientName,
+                 @Nullable String projectId, @Nonnull List<Visitor> visitors) {
+        this.accountId = accountId;
+        this.anonymizeIp = anonymizeIp;
+        this.clientName = clientName;
+        this.projectId = projectId;
+        this.visitors = visitors;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Batch batch = (Batch) o;
+
+        if (!accountId.equals(batch.accountId)) return false;
+        if (anonymizeIp != null ? !anonymizeIp.equals(batch.anonymizeIp) : batch.anonymizeIp != null) return false;
+        if (clientName != null ? !clientName.equals(batch.clientName) : batch.clientName != null) return false;
+        if (projectId != null ? !projectId.equals(batch.projectId) : batch.projectId != null) return false;
+        return visitors.equals(batch.visitors);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = accountId.hashCode();
+        result = 31 * result + (anonymizeIp != null ? anonymizeIp.hashCode() : 0);
+        result = 31 * result + (clientName != null ? clientName.hashCode() : 0);
+        result = 31 * result + (projectId != null ? projectId.hashCode() : 0);
+        result = 31 * result + visitors.hashCode();
+        return result;
+    }
+
+    @Nonnull
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public void setAccountId(@Nonnull String accountId) {
+        this.accountId = accountId;
+    }
+
+    @Nullable
+    public Boolean getAnonymizeIp() {
+        return anonymizeIp;
+    }
+
+    public void setAnonymizeIp(@Nullable Boolean anonymizeIp) {
+        this.anonymizeIp = anonymizeIp;
+    }
+
+    @Nullable
+    public String getClientName() {
+        return clientName;
+    }
+
+    public void setClientName(@Nullable String clientName) {
+        this.clientName = clientName;
+    }
+
+    @Nullable
+    public String getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(@Nullable String projectId) {
+        this.projectId = projectId;
+    }
+
+    @Nonnull
+    public List<Visitor> getVisitors() {
+        return visitors;
+    }
+
+    public void setVisitors(@Nonnull List<Visitor> visitors) {
+        this.visitors = visitors;
+    }
+}

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/payload/batch/Decision.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/payload/batch/Decision.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2016-2017, Optimizely and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.optimizely.ab.event.internal.payload.batch;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class Decision {
+
+    @Nonnull private String campaignId;
+    @Nullable private String experimentId;
+    @Nullable private Boolean isCampaignHoldback;
+    @Nullable private String variationId;
+
+    public Decision(@Nonnull String campaignId) {
+        this.campaignId = campaignId;
+
+    }
+
+    public Decision(@Nonnull String campaignId, @Nullable String experimentId, @Nullable Boolean isCampaignHoldback,
+                    @Nullable String variationId) {
+
+        this.campaignId = campaignId;
+        this.experimentId = experimentId;
+        this.isCampaignHoldback = isCampaignHoldback;
+        this.variationId = variationId;
+    }
+
+    @Nonnull
+    public String getCampaignId() {
+        return campaignId;
+    }
+
+    public void setCampaignId(@Nonnull String campaignId) {
+        this.campaignId = campaignId;
+    }
+
+    @Nullable
+    public String getExperimentId() {
+        return experimentId;
+    }
+
+    public void setExperimentId(@Nullable String experimentId) {
+        this.experimentId = experimentId;
+    }
+
+    @Nullable
+    public Boolean getCampaignHoldback() {
+        return isCampaignHoldback;
+    }
+
+    public void setCampaignHoldback(@Nullable Boolean campaignHoldback) {
+        isCampaignHoldback = campaignHoldback;
+    }
+
+    @Nullable
+    public String getVariationId() {
+        return variationId;
+    }
+
+    public void setVariationId(@Nullable String variationId) {
+        this.variationId = variationId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Decision decision = (Decision) o;
+
+        if (!campaignId.equals(decision.campaignId)) return false;
+        if (experimentId != null ? !experimentId.equals(decision.experimentId) : decision.experimentId != null)
+            return false;
+        if (isCampaignHoldback != null ? !isCampaignHoldback.equals(decision.isCampaignHoldback) :
+                decision.isCampaignHoldback != null)
+            return false;
+        return variationId != null ? variationId.equals(decision.variationId) : decision.variationId == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = campaignId.hashCode();
+        result = 31 * result + (experimentId != null ? experimentId.hashCode() : 0);
+        result = 31 * result + (isCampaignHoldback != null ? isCampaignHoldback.hashCode() : 0);
+        result = 31 * result + (variationId != null ? variationId.hashCode() : 0);
+        return result;
+    }
+}

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/payload/batch/Event.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/payload/batch/Event.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2016-2017, Optimizely and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.optimizely.ab.event.internal.payload.batch;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Map;
+
+public class Event {
+
+    @Nullable private String entityId;
+    @Nonnull private String key;
+    @Nullable private Long quantity;
+    @Nullable private Long revenue;
+    @Nullable private Map<String, ?> tags;
+    @Nonnull private Long timestamp;
+    @Nonnull private String uuid;
+    @Nullable private Double value;
+
+    public Event(@Nonnull String key, @Nonnull Long timestamp, @Nonnull String uuid) {
+        this.timestamp = timestamp;
+        this.uuid = uuid;
+        this.key = key;
+    }
+
+    public Event(@Nullable String entityId, @Nonnull String key, @Nullable Long quantity, @Nullable Long revenue,
+                 @Nullable Map<String, Object> tags, @Nonnull Long timestamp, @Nonnull String uuid, @Nullable Double value) {
+        this.entityId = entityId;
+        this.key = key;
+        this.quantity = quantity;
+        this.revenue = revenue;
+        this.tags = tags;
+        this.timestamp = timestamp;
+        this.uuid = uuid;
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Event event = (Event) o;
+
+        if (entityId != null ? !entityId.equals(event.entityId) : event.entityId != null) return false;
+        if (!key.equals(event.key)) return false;
+        if (quantity != null ? !quantity.equals(event.quantity) : event.quantity != null) return false;
+        if (revenue != null ? !revenue.equals(event.revenue) : event.revenue != null) return false;
+        if (tags != null ? !tags.equals(event.tags) : event.tags != null) return false;
+        if (!timestamp.equals(event.timestamp)) return false;
+        if (!uuid.equals(event.uuid)) return false;
+        return value != null ? value.equals(event.value) : event.value == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = entityId != null ? entityId.hashCode() : 0;
+        result = 31 * result + key.hashCode();
+        result = 31 * result + (quantity != null ? quantity.hashCode() : 0);
+        result = 31 * result + (revenue != null ? revenue.hashCode() : 0);
+        result = 31 * result + (tags != null ? tags.hashCode() : 0);
+        result = 31 * result + timestamp.hashCode();
+        result = 31 * result + uuid.hashCode();
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        return result;
+    }
+
+    @Nullable
+    public String getEntityId() {
+        return entityId;
+    }
+
+    public void setEntityId(@Nullable String entityId) {
+        this.entityId = entityId;
+    }
+
+    @Nonnull
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(@Nonnull String key) {
+        this.key = key;
+    }
+
+    @Nullable
+    public Long getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(@Nullable Long quantity) {
+        this.quantity = quantity;
+    }
+
+    @Nullable
+    public Long getRevenue() {
+        return revenue;
+    }
+
+    public void setRevenue(@Nullable Long revenue) {
+        this.revenue = revenue;
+    }
+
+    @Nullable
+    public Map<String, ?> getTags() {
+        return tags;
+    }
+
+    public void setTags(@Nullable Map<String, ?> tags) {
+        this.tags = tags;
+    }
+
+    @Nonnull
+    public Long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(@Nonnull Long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    @Nonnull
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(@Nonnull String uuid) {
+        this.uuid = uuid;
+    }
+
+    @Nullable
+    public Double getValue() {
+        return value;
+    }
+
+    public void setValue(@Nullable Double value) {
+        this.value = value;
+    }
+}

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/payload/batch/Snapshot.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/payload/batch/Snapshot.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016-2017, Optimizely and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.optimizely.ab.event.internal.payload.batch;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Snapshot {
+
+    @Nonnull private List<Decision> decisions = new ArrayList<Decision>();
+    @Nonnull private List<Event> events = new ArrayList<Event>();
+
+    public Snapshot(@Nonnull List<Decision> decisions, @Nonnull List<Event> events) {
+
+        this.decisions = decisions;
+        this.events = events;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Snapshot snapshot = (Snapshot) o;
+
+        if (!decisions.equals(snapshot.decisions)) return false;
+        return events.equals(snapshot.events);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = decisions.hashCode();
+        result = 31 * result + events.hashCode();
+        return result;
+    }
+
+    @Nonnull
+    public List<Decision> getDecisions() {
+        return decisions;
+    }
+
+    public void setDecisions(@Nonnull List<Decision> decisions) {
+        this.decisions = decisions;
+    }
+
+    @Nonnull
+    public List<Event> getEvents() {
+        return events;
+    }
+
+    public void setEvents(@Nonnull List<Event> events) {
+        this.events = events;
+    }
+
+
+}

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/payload/batch/Visitor.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/payload/batch/Visitor.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2016-2017, Optimizely and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.optimizely.ab.event.internal.payload.batch;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Visitor {
+
+    @Nullable private List<Attribute> attributes = new ArrayList<Attribute>();
+    @Nullable private String sessionId;
+    @Nonnull private List<Snapshot> snapshots = new ArrayList<Snapshot>();
+    @Nonnull private String visitorId;
+
+    public Visitor(@Nonnull String visitorId) {
+        this.visitorId = visitorId;
+    }
+
+    public Visitor(@Nullable List<Attribute> attributes, @Nullable String sessionId, @Nonnull List<Snapshot> snapshots,
+                   @Nonnull String visitorId) {
+        this.attributes = attributes;
+        this.sessionId = sessionId;
+        this.snapshots = snapshots;
+        this.visitorId = visitorId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Visitor visitor = (Visitor) o;
+
+        if (attributes != null ? !attributes.equals(visitor.attributes) : visitor.attributes != null) return false;
+        if (sessionId != null ? !sessionId.equals(visitor.sessionId) : visitor.sessionId != null) return false;
+        if (!snapshots.equals(visitor.snapshots)) return false;
+        return visitorId.equals(visitor.visitorId);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = attributes != null ? attributes.hashCode() : 0;
+        result = 31 * result + (sessionId != null ? sessionId.hashCode() : 0);
+        result = 31 * result + snapshots.hashCode();
+        result = 31 * result + visitorId.hashCode();
+        return result;
+    }
+
+    @Nullable
+    public List<Attribute> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(@Nullable List<Attribute> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Nullable
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public void setSessionId(@Nullable String sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    @Nonnull
+    public List<Snapshot> getSnapshots() {
+        return snapshots;
+    }
+
+    public void setSnapshots(@Nonnull List<Snapshot> snapshots) {
+        this.snapshots = snapshots;
+    }
+
+    @Nonnull
+    public String getVisitorId() {
+        return visitorId;
+    }
+
+    public void setVisitorId(@Nonnull String visitorId) {
+        this.visitorId = visitorId;
+    }
+}

--- a/core-api/src/test/java/com/optimizely/ab/config/ProjectConfigTestUtils.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/ProjectConfigTestUtils.java
@@ -18,30 +18,17 @@ package com.optimizely.ab.config;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
-
-import com.optimizely.ab.config.audience.AndCondition;
-import com.optimizely.ab.config.audience.Audience;
-import com.optimizely.ab.config.audience.Condition;
-import com.optimizely.ab.config.audience.NotCondition;
-import com.optimizely.ab.config.audience.OrCondition;
-import com.optimizely.ab.config.audience.UserAttribute;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import com.optimizely.ab.config.audience.*;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.*;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 /**
  * Helper class that provides common functionality and resources for testing {@link ProjectConfig}.
@@ -520,6 +507,10 @@ public final class ProjectConfigTestUtils {
         return Resources.toString(Resources.getResource("config/no-audience-project-config-v3.json"), Charsets.UTF_8);
     }
 
+    public static String noAudienceProjectConfigJsonV4() throws IOException {
+        return Resources.toString(Resources.getResource("config/no-audience-project-config-v3.json"), Charsets.UTF_8);
+    }
+
     /**
      * @return the expected {@link ProjectConfig} for the json produced by {@link #validConfigJsonV1()} ()}
      */
@@ -560,6 +551,15 @@ public final class ProjectConfigTestUtils {
      */
     public static ProjectConfig noAudienceProjectConfigV3() {
         return NO_AUDIENCE_PROJECT_CONFIG_V3;
+    }
+
+    /**
+     * @see #noAudienceProjectConfigV3()
+     *
+     * // TODO ProjectConfigV4 only exists locally, it needs to be created on the backend.
+     */
+    public static ProjectConfig noAudienceProjectConfigV4() {
+        return VALID_PROJECT_CONFIG_V3;
     }
 
     /**

--- a/core-api/src/test/java/com/optimizely/ab/event/internal/EventBuilderV3Test.java
+++ b/core-api/src/test/java/com/optimizely/ab/event/internal/EventBuilderV3Test.java
@@ -1,0 +1,201 @@
+/**
+ *
+ *    Copyright 2016-2017, Optimizely and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.optimizely.ab.event.internal;
+
+import com.google.gson.Gson;
+import com.optimizely.ab.bucketing.Bucketer;
+import com.optimizely.ab.config.*;
+import com.optimizely.ab.config.Attribute;
+import com.optimizely.ab.event.LogEvent;
+import com.optimizely.ab.event.internal.payload.Event.ClientEngine;
+import com.optimizely.ab.event.internal.payload.batch.*;
+import com.optimizely.ab.internal.ProjectValidationUtils;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test for {@link EventBuilderV3}
+ */
+public class EventBuilderV3Test {
+
+    private Gson gson = new Gson();
+    private EventBuilderV3 builder = new EventBuilderV3();
+
+    /**
+     * Verify {@link Batch} event creation
+     */
+    @Test
+    public void createImpressionEvent() throws Exception {
+        ProjectConfig projectConfig = ProjectConfigTestUtils.noAudienceProjectConfigV4();
+        Experiment activatedExperiment = projectConfig.getExperiments().get(0);
+        Variation bucketedVariation = activatedExperiment.getVariations().get(0);
+        Attribute attribute = projectConfig.getAttributes().get(0);
+        String userId = "userId";
+        Map<String, String> attributeMap = Collections.singletonMap(attribute.getKey(), "value");
+        Decision expectedDecision = new Decision(
+                activatedExperiment.getLayerId(),
+                activatedExperiment.getId(),
+                false,
+                bucketedVariation.getId());
+
+        com.optimizely.ab.event.internal.payload.batch.Attribute batchAttr =
+                new com.optimizely.ab.event.internal.payload.batch.Attribute(
+                        attribute.getId(),
+                        attribute.getKey(),
+                        com.optimizely.ab.event.internal.payload.batch.Attribute.CUSTOM_ATTRIBUTE_FEATURE_TYPE,
+                        "value");
+
+        List<com.optimizely.ab.event.internal.payload.batch.Attribute> expectedAttributes = Collections.singletonList(batchAttr);
+
+        LogEvent impressionEvent = builder.createImpressionEvent(projectConfig, activatedExperiment, bucketedVariation,
+                userId, attributeMap);
+
+        // verify that request endpoint is correct
+        assertThat(impressionEvent.getEndpointUrl(), is(EventBuilderV3.BATCH_ENDPOINT));
+        assertThat(impressionEvent.getRequestMethod(), is(LogEvent.RequestMethod.POST));
+
+        // verify payload information
+
+        Batch impression = gson.fromJson(impressionEvent.getBody(), Batch.class);
+
+        assertNotNull(impression.getVisitors());
+        assertThat(impression.getVisitors(), hasSize(1));
+        Visitor visitor = impression.getVisitors().get(0);
+        assertNull(visitor.getSessionId());
+        assertThat(visitor.getAttributes(), is(expectedAttributes));
+
+        assertNotNull(visitor.getSnapshots());
+        assertThat(visitor.getSnapshots(), hasSize(1));
+        Snapshot snapshot = visitor.getSnapshots().get(0);
+
+        assertNotNull(snapshot.getEvents());
+        assertThat(snapshot.getEvents(), hasSize(1));
+        com.optimizely.ab.event.internal.payload.batch.Event event = snapshot.getEvents().get(0);
+        assertThat(event.getKey(), is(EventBuilderV3.KEY_CAMPAIGN_ACTIVATED));
+        assertThat(event.getEntityId(), is(activatedExperiment.getLayerId()));
+        assertThat((System.currentTimeMillis() - event.getTimestamp()), lessThan((2L * 1000)));
+
+        assertNotNull(snapshot.getDecisions());
+        assertThat(snapshot.getDecisions(), hasSize(1));
+        com.optimizely.ab.event.internal.payload.batch.Decision decision = snapshot.getDecisions().get(0);
+        assertThat(decision.getCampaignId(), is(activatedExperiment.getLayerId()));
+        assertThat(decision.getExperimentId(), is(expectedDecision.getExperimentId()));
+        assertThat(decision.getVariationId(), is((expectedDecision.getVariationId())));
+
+        assertThat(impression.getAccountId(), is(projectConfig.getAccountId()));
+        assertThat(impression.getAnonymizeIp(), is(projectConfig.getAnonymizeIP()));
+        assertThat(impression.getClientName(), is(ClientEngine.JAVA_SDK.getClientEngineValue()));
+        assertThat(impression.getClientVersion(), is(BuildVersionInfo.VERSION));
+        assertThat(impression.getProjectId(), is(projectConfig.getProjectId()));
+    }
+
+    /**
+     * Verify {@link Batch} conversion event creation
+     */
+    @Test
+    public void createConversionEvent() throws Exception {
+        ProjectConfig projectConfig = ProjectConfigTestUtils.noAudienceProjectConfigV4();
+        Attribute attribute = projectConfig.getAttributes().get(0);
+        EventType eventType = projectConfig.getEventTypes().get(0);
+        String visitorId = "visitorId";
+
+        Bucketer mockBucketAlgorithm = mock(Bucketer.class);
+
+        List<Experiment> allExperiments = projectConfig.getExperiments();
+        List<String> experimentIds = projectConfig.getExperimentIdsForGoal(eventType.getKey());
+
+        // Bucket to the first variation for all experiments. However, only a subset of the experiments will actually
+        // call the bucket function.
+        for (Experiment experiment : allExperiments) {
+            when(mockBucketAlgorithm.bucket(experiment, visitorId))
+                .thenReturn(experiment.getVariations().get(0));
+        }
+
+        Map<String, String> attributeMap = Collections.singletonMap(attribute.getKey(), "value");
+        Map<String, Object> eventTagMap = new HashMap<String, Object>();
+        eventTagMap.put("boolean_param", false);
+        eventTagMap.put("string_param", "123");
+        LogEvent conversionEvent = builder.createConversionEvent(projectConfig, mockBucketAlgorithm, visitorId,
+                                                                 eventType.getId(), eventType.getKey(), attributeMap, eventTagMap);
+
+        List<Decision> expectedDecisions = new ArrayList<Decision>();
+        for (Experiment experiment : allExperiments) {
+            if (experimentIds.contains(experiment.getId()) &&
+                    ProjectValidationUtils.validatePreconditions(projectConfig, experiment, visitorId, attributeMap)) {
+                verify(mockBucketAlgorithm).bucket(experiment, visitorId);
+                Decision decision = new Decision(experiment.getLayerId());
+                decision.setExperimentId(experiment.getId());
+                decision.setVariationId(experiment.getVariations().get(0).getId());
+                expectedDecisions.add(decision);
+            } else {
+                verify(mockBucketAlgorithm, never()).bucket(experiment, visitorId);
+            }
+        }
+
+        com.optimizely.ab.event.internal.payload.batch.Attribute batchAttr =
+                new com.optimizely.ab.event.internal.payload.batch.Attribute(
+                        attribute.getId(),
+                        attribute.getKey(),
+                        com.optimizely.ab.event.internal.payload.batch.Attribute.CUSTOM_ATTRIBUTE_FEATURE_TYPE,
+                        "value");
+
+        List<com.optimizely.ab.event.internal.payload.batch.Attribute> expectedAttributes = Collections.singletonList(batchAttr);
+
+        // verify that the request endpoint is correct
+        assertThat(conversionEvent.getEndpointUrl(), is(EventBuilderV3.BATCH_ENDPOINT));
+
+        Batch conversion = gson.fromJson(conversionEvent.getBody(), Batch.class);
+
+        assertThat(conversion.getProjectId(), is(projectConfig.getProjectId()));
+        assertThat(conversion.getClientName(), is(ClientEngine.JAVA_SDK.getClientEngineValue()));
+        assertThat(conversion.getClientVersion(), is(BuildVersionInfo.VERSION));
+        assertThat(conversion.getAnonymizeIp(), is(projectConfig.getAnonymizeIP()));
+
+        assertThat(conversion.getVisitors(), hasSize(1));
+        List<Visitor> visitors = conversion.getVisitors();
+        Visitor visitor = visitors.get(0);
+        assertThat(visitor.getVisitorId(), is(visitorId));
+        assertThat(visitor.getAttributes(), is(expectedAttributes));
+        assertThat(visitor.getSnapshots(), hasSize(1));
+
+        List<Snapshot> snapshots = Collections.singletonList(visitor.getSnapshots().get(0));
+        Snapshot snapshot = snapshots.get(0);
+        assertThat(snapshot.getDecisions(), hasSize(experimentIds.size()));
+        assertThat(snapshot.getEvents(), hasSize(1));
+
+        List<Decision> decisions = snapshot.getDecisions();
+        assertThat(decisions, is(expectedDecisions));
+
+        List<Event> events = snapshot.getEvents();
+        Event event = events.get(0);
+        // TODO I Don't think there is a way around this is Java 1.6
+        Map<String, Object> tags = (Map<String, Object>) event.getTags();
+        assertThat(tags, is(eventTagMap));
+        assertThat(event.getKey(), is(eventType.getKey()));
+        assertThat(event.getEntityId(), is(eventType.getId()));
+        assertThat((System.currentTimeMillis() - event.getTimestamp()), lessThan((2L * 1000)));
+    }
+
+
+}


### PR DESCRIPTION
I took a stab at implementing the new Batch api in Java X SDK.  It implemented very cleanly and there are no breaking API changes.  Right now the diff allows users to pass a custom EventBuilder.  I assume that eventually a ProjectConfig version will be bumped to a version in which batch would be enabled like the past API changes.

The Java SDK should create singular batches of conversion or impression events that are delivered to `EventHandler#dispatchEvent(LogEvent event)`.  The merging of these of singular batches is the responsibility of an EventHandler implementation.  They should be merged into one batch and sent as one request if possible.  I took a stab at this is in the Android PR.

This PR needs to more test cases added to match the coverage of the existing endpoints but it should relatively working.