### PR TITLE
use precise distribution instead of trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: precise
 jdk:
   - openjdk7
   - oraclejdk7


### PR DESCRIPTION
travis-ci switch builds to trusty by default it seems
we want `dist: precise` in configs