### PR TITLE
ignore experiment status when bucketing rollout rule experiments

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/bucketing/DecisionService.java
+++ b/core-api/src/main/java/com/optimizely/ab/bucketing/DecisionService.java
@@ -210,11 +210,7 @@ public class DecisionService {
         for (int i = 0; i < rolloutRulesLength - 1; i++) {
             Experiment rolloutRule= rollout.getExperiments().get(i);
             Audience audience = projectConfig.getAudienceIdMapping().get(rolloutRule.getAudienceIds().get(0));
-            if (!rolloutRule.isActive()) {
-                logger.debug("Did not attempt to bucket user into rollout rule for audience \"" +
-                        audience.getName() + "\" since the rule is not active.");
-            }
-            else if (ExperimentUtils.isUserInExperiment(projectConfig, rolloutRule, filteredAttributes)) {
+            if (ExperimentUtils.isUserInExperiment(projectConfig, rolloutRule, filteredAttributes)) {
                 logger.debug("Attempting to bucket user \"" + userId +
                         "\" into rollout rule for audience \"" + audience.getName() +
                         "\".");


### PR DESCRIPTION
we do not need to check experiment status since the datafile will not have inactive experiments