### PR TITLE
Merge master onto 2.0.x for beta2 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ cache:
 branches:
   only:
   - master
-  - /^\d+\.\d+\.\d+(-SNAPSHOT|-alpha|-beta)?$/ # trigger builds on tags which are semantically versioned to ship the SDK.
+  - /^\d+\.\d+\.\d+(-SNAPSHOT|-alpha|-beta)?\d*$/ # trigger builds on tags which are semantically versioned to ship the SDK.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Optimizely Java X SDK Changelog
+
+## 2.0.0 Beta 2
+October 5, 2017
+
+This release is a second beta release supporting feature flags and rollouts. It includes all the same new features and breaking changes as the last beta release.
+
+### Bug Fixes
+Fall back to default feature variable value when there is no variable usage in the variation a user is bucketed into. For more information see [PR #149](https://github.com/optimizely/java-sdk/pull/149).
+
 ## 2.0.0 Beta
 September 29, 2017
 

--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -556,7 +556,12 @@ public class Optimizely {
         if (variation != null) {
             LiveVariableUsageInstance liveVariableUsageInstance =
                     variation.getVariableIdToLiveVariableUsageInstanceMap().get(variable.getId());
-            variableValue = liveVariableUsageInstance.getValue();
+            if (liveVariableUsageInstance != null) {
+                variableValue = liveVariableUsageInstance.getValue();
+            }
+            else {
+                variableValue = variable.getDefaultValue();
+            }
         }
         else {
             logger.info("User \"" + userId +

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -80,9 +80,11 @@ import static com.optimizely.ab.config.ValidProjectConfigV4.EXPERIMENT_MULTIVARI
 import static com.optimizely.ab.config.ValidProjectConfigV4.EXPERIMENT_PAUSED_EXPERIMENT_KEY;
 import static com.optimizely.ab.config.ValidProjectConfigV4.FEATURE_FLAG_MULTI_VARIATE_FEATURE;
 import static com.optimizely.ab.config.ValidProjectConfigV4.FEATURE_FLAG_SINGLE_VARIABLE_DOUBLE;
+import static com.optimizely.ab.config.ValidProjectConfigV4.FEATURE_FLAG_SINGLE_VARIABLE_INTEGER;
 import static com.optimizely.ab.config.ValidProjectConfigV4.FEATURE_MULTI_VARIATE_FEATURE_KEY;
 import static com.optimizely.ab.config.ValidProjectConfigV4.FEATURE_SINGLE_VARIABLE_BOOLEAN_KEY;
 import static com.optimizely.ab.config.ValidProjectConfigV4.FEATURE_SINGLE_VARIABLE_DOUBLE_KEY;
+import static com.optimizely.ab.config.ValidProjectConfigV4.FEATURE_SINGLE_VARIABLE_INTEGER_KEY;
 import static com.optimizely.ab.config.ValidProjectConfigV4.MULTIVARIATE_EXPERIMENT_FORCED_VARIATION_USER_ID_GRED;
 import static com.optimizely.ab.config.ValidProjectConfigV4.PAUSED_EXPERIMENT_FORCED_VARIATION_USER_ID_CONTROL;
 import static com.optimizely.ab.config.ValidProjectConfigV4.VARIABLE_BOOLEAN_VARIABLE_DEFAULT_VALUE;
@@ -90,6 +92,7 @@ import static com.optimizely.ab.config.ValidProjectConfigV4.VARIABLE_BOOLEAN_VAR
 import static com.optimizely.ab.config.ValidProjectConfigV4.VARIABLE_DOUBLE_DEFAULT_VALUE;
 import static com.optimizely.ab.config.ValidProjectConfigV4.VARIABLE_DOUBLE_VARIABLE_KEY;
 import static com.optimizely.ab.config.ValidProjectConfigV4.VARIABLE_FIRST_LETTER_KEY;
+import static com.optimizely.ab.config.ValidProjectConfigV4.VARIABLE_INTEGER_VARIABLE_KEY;
 import static com.optimizely.ab.config.ValidProjectConfigV4.VARIATION_MULTIVARIATE_EXPERIMENT_GRED;
 import static com.optimizely.ab.config.ValidProjectConfigV4.VARIATION_MULTIVARIATE_EXPERIMENT_GRED_KEY;
 import static com.optimizely.ab.event.LogEvent.RequestMethod;
@@ -2626,6 +2629,36 @@ public class OptimizelyTest {
                 genericUserId,
                 Collections.singletonMap(ATTRIBUTE_HOUSE_KEY, AUDIENCE_GRYFFINDOR_VALUE),
                 LiveVariable.VariableType.STRING
+        );
+
+        assertEquals(expectedValue, value);
+    }
+
+    /**
+     * Verify {@link Optimizely#getFeatureVariableValueForType(String, String, String, Map, LiveVariable.VariableType)}
+     * returns the default value for the feature variable
+     * when there is no variable usage present for the variation the user is bucketed into.
+     * @throws ConfigParseException
+     */
+    @Test
+    public void getFeatureVariableValueReturnsDefaultValueWhenNoVariationUsageIsPresent() throws ConfigParseException {
+        assumeTrue(datafileVersion >= Integer.parseInt(ProjectConfig.Version.V4.toString()));
+
+        String validFeatureKey = FEATURE_SINGLE_VARIABLE_INTEGER_KEY;
+        String validVariableKey = VARIABLE_INTEGER_VARIABLE_KEY;
+        LiveVariable variable = FEATURE_FLAG_SINGLE_VARIABLE_INTEGER.getVariableKeyToLiveVariableMap().get(validVariableKey);
+        String expectedValue = variable.getDefaultValue();
+
+        Optimizely optimizely = Optimizely.builder(validDatafile, mockEventHandler)
+                .withConfig(validProjectConfig)
+                .build();
+
+        String value = optimizely.getFeatureVariableValueForType(
+                validFeatureKey,
+                validVariableKey,
+                genericUserId,
+                Collections.<String, String>emptyMap(),
+                LiveVariable.VariableType.INTEGER
         );
 
         assertEquals(expectedValue, value);

--- a/core-api/src/test/java/com/optimizely/ab/config/ValidProjectConfigV4.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/ValidProjectConfigV4.java
@@ -107,9 +107,9 @@ public class ValidProjectConfigV4 {
             LiveVariable.VariableType.DOUBLE
     );
     private static final String         FEATURE_SINGLE_VARIABLE_INTEGER_ID = "3281420120";
-    private static final String         FEATURE_SINGLE_VARIABLE_INTEGER_KEY = "integer_single_variable_feature";
+    public  static final String         FEATURE_SINGLE_VARIABLE_INTEGER_KEY = "integer_single_variable_feature";
     private static final String         VARIABLE_INTEGER_VARIABLE_ID = "593964691";
-    private static final String         VARIABLE_INTEGER_VARIABLE_KEY = "integer_variable";
+    public  static final String         VARIABLE_INTEGER_VARIABLE_KEY = "integer_variable";
     private static final String         VARIABLE_INTEGER_DEFAULT_VALUE = "7";
     private static final LiveVariable   VARIABLE_INTEGER_VARIABLE = new LiveVariable(
             VARIABLE_INTEGER_VARIABLE_ID,
@@ -117,15 +117,6 @@ public class ValidProjectConfigV4 {
             VARIABLE_INTEGER_DEFAULT_VALUE,
             null,
             LiveVariable.VariableType.INTEGER
-    );
-    private static final FeatureFlag FEATURE_FLAG_SINGLE_VARIABLE_INTEGER = new FeatureFlag(
-            FEATURE_SINGLE_VARIABLE_INTEGER_ID,
-            FEATURE_SINGLE_VARIABLE_INTEGER_KEY,
-            "",
-            Collections.<String>emptyList(),
-            Collections.singletonList(
-                    VARIABLE_INTEGER_VARIABLE
-            )
     );
     private static final String         FEATURE_SINGLE_VARIABLE_BOOLEAN_ID = "2591051011";
     public  static final String         FEATURE_SINGLE_VARIABLE_BOOLEAN_KEY = "boolean_single_variable_feature";
@@ -206,6 +197,38 @@ public class ValidProjectConfigV4 {
                     VARIABLE_STRING_VARIABLE
             )
     );
+    private static final String     ROLLOUT_3_ID = "2048875663";
+    private static final String     ROLLOUT_3_EVERYONE_ELSE_EXPERIMENT_ID = "3794675122";
+    private static final String     ROLLOUT_3_EVERYONE_ELSE_RULE_ENABLED_VARIATION_ID = "589640735";
+    private static final Variation  ROLLOUT_3_EVERYONE_ELSE_RULE_ENABLED_VARIATION = new Variation(
+            ROLLOUT_3_EVERYONE_ELSE_RULE_ENABLED_VARIATION_ID,
+            ROLLOUT_3_EVERYONE_ELSE_RULE_ENABLED_VARIATION_ID,
+            Collections.<LiveVariableUsageInstance>emptyList()
+    );
+    private static final Experiment ROLLOUT_3_EVERYONE_ELSE_RULE = new Experiment(
+            ROLLOUT_3_EVERYONE_ELSE_EXPERIMENT_ID,
+            ROLLOUT_3_EVERYONE_ELSE_EXPERIMENT_ID,
+            Experiment.ExperimentStatus.RUNNING.toString(),
+            ROLLOUT_3_ID,
+            Collections.<String>emptyList(),
+            Collections.singletonList(
+                    ROLLOUT_3_EVERYONE_ELSE_RULE_ENABLED_VARIATION
+            ),
+            Collections.<String, String>emptyMap(),
+            Collections.singletonList(
+                    new TrafficAllocation(
+                            ROLLOUT_3_EVERYONE_ELSE_RULE_ENABLED_VARIATION_ID,
+                            10000
+                    )
+            )
+    );
+    public  static final Rollout    ROLLOUT_3 = new Rollout(
+            ROLLOUT_3_ID,
+            Collections.singletonList(
+                    ROLLOUT_3_EVERYONE_ELSE_RULE
+            )
+    );
+
     private static final String         FEATURE_MULTI_VARIATE_FEATURE_ID = "3263342226";
     public  static final String         FEATURE_MULTI_VARIATE_FEATURE_KEY = "multi_variate_feature";
     private static final String         VARIABLE_FIRST_LETTER_ID = "675244127";
@@ -917,7 +940,15 @@ public class ValidProjectConfigV4 {
                     VARIABLE_DOUBLE_VARIABLE
             )
     );
-
+    public  static final FeatureFlag FEATURE_FLAG_SINGLE_VARIABLE_INTEGER = new FeatureFlag(
+            FEATURE_SINGLE_VARIABLE_INTEGER_ID,
+            FEATURE_SINGLE_VARIABLE_INTEGER_KEY,
+            ROLLOUT_3_ID,
+            Collections.<String>emptyList(),
+            Collections.singletonList(
+                    VARIABLE_INTEGER_VARIABLE
+            )
+    );
 
     public static ProjectConfig generateValidProjectConfigV4() {
 
@@ -964,6 +995,7 @@ public class ValidProjectConfigV4 {
         List<Rollout> rollouts = new ArrayList<Rollout>();
         rollouts.add(ROLLOUT_1);
         rollouts.add(ROLLOUT_2);
+        rollouts.add(ROLLOUT_3);
 
         return new ProjectConfig(
                 ACCOUNT_ID,

--- a/core-api/src/test/resources/config/valid-project-config-v4.json
+++ b/core-api/src/test/resources/config/valid-project-config-v4.json
@@ -449,7 +449,7 @@
     {
       "id": "3281420120",
       "key": "integer_single_variable_feature",
-      "rolloutId": "",
+      "rolloutId": "2048875663",
       "experimentIds": [],
       "variables": [
         {
@@ -675,6 +675,32 @@
             {
               "entityId": "3137445031",
               "endOfRange": 5000
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "2048875663",
+      "experiments": [
+        {
+          "id": "3794675122",
+          "key": "3794675122",
+          "status": "Running",
+          "layerId": "2048875663",
+          "audienceIds": [],
+          "forcedVariations": {},
+          "variations": [
+            {
+              "id": "589640735",
+              "key": "589640735",
+              "variables": []
+            }
+          ],
+          "trafficAllocation": [
+            {
+              "entityId": "589640735",
+              "endOfRange": 10000
             }
           ]
         }


### PR DESCRIPTION
* if no live variable usage exists for the variable in the variation, return the default value
* add rollout with variation that does not change variable value in rollout rule. This means no live variable usage will be in datafile. need to fallback on default value
* add test to make sure we fall back on default value when variable usage not found in datafile