### PR TITLE
prime the serializer in a helper thread to cache reflection calls mak…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Optimizely Java X SDK Changelog
 
+## 2.1.1
+
+June 19th, 2018
+
+This is a patch release of the Optimizely SDK for 2.1.0 which is a major release.
+
+### Bug Fixes
+* Send impression event for Feature Test with Feature disabled ([#193](https://github.com/optimizely/java-sdk/pull/193))
+
+## 2.0.2
+
+June 19th, 2018
+
+This is a patch release of the Optimizely SDK for 2.0.0 which is a major release.
+
+### Bug Fixes
+* Send impression event for Feature Test with Feature disabled ([#193](https://github.com/optimizely/java-sdk/pull/193))
+
 ## 2.1.0
 
 June 15th, 2018

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/EventBuilder.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/EventBuilder.java
@@ -116,6 +116,9 @@ public class EventBuilder {
                                     @Nonnull String userId,
                                     @Nonnull Map<String, String> attributes) {
         try {
+            // guard 
+            if (primedEvent == null) return null;
+
             EventBatch eventBatch = primedEvent.get();
             primedEvent = null;
             Decision decision = new Decision(activatedExperiment.getLayerId(), activatedExperiment.getId(),


### PR DESCRIPTION
…ing subsequent calls to create and serialize EventBatch must faster.

This reduces activate calls on Android from 100 ms to 15 ms.