### PR TITLE
Move serialization to LogEvent.getBody().

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -199,9 +199,13 @@ public class Optimizely {
                     userId,
                     filteredAttributes);
             logger.info("Activating user \"{}\" in experiment \"{}\".", userId, experiment.getKey());
-            logger.debug(
-                    "Dispatching impression event to URL {} with params {} and payload \"{}\".",
-                    impressionEvent.getEndpointUrl(), impressionEvent.getRequestParams(), impressionEvent.getBody());
+
+            if (logger.isDebugEnabled()) {
+                logger.debug(
+                        "Dispatching impression event to URL {} with params {} and payload \"{}\".",
+                        impressionEvent.getEndpointUrl(), impressionEvent.getRequestParams(), impressionEvent.getBody());
+            }
+
             try {
                 eventHandler.dispatchEvent(impressionEvent);
             } catch (Exception e) {
@@ -294,8 +298,12 @@ public class Optimizely {
         }
 
         logger.info("Tracking event \"{}\" for user \"{}\".", eventName, userId);
-        logger.debug("Dispatching conversion event to URL {} with params {} and payload \"{}\".",
-                conversionEvent.getEndpointUrl(), conversionEvent.getRequestParams(), conversionEvent.getBody());
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Dispatching conversion event to URL {} with params {} and payload \"{}\".",
+                    conversionEvent.getEndpointUrl(), conversionEvent.getRequestParams(), conversionEvent.getBody());
+        }
+
         try {
             eventHandler.dispatchEvent(conversionEvent);
         } catch (Exception e) {

--- a/core-api/src/main/java/com/optimizely/ab/event/LogEvent.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/LogEvent.java
@@ -16,6 +16,10 @@
  */
 package com.optimizely.ab.event;
 
+import com.optimizely.ab.event.internal.payload.EventBatch;
+import com.optimizely.ab.event.internal.serializer.DefaultJsonSerializer;
+import com.optimizely.ab.event.internal.serializer.Serializer;
+
 import java.util.Map;
 
 import javax.annotation.Nonnull;
@@ -30,16 +34,16 @@ public class LogEvent {
     private final RequestMethod requestMethod;
     private final String endpointUrl;
     private final Map<String, String> requestParams;
-    private final String body;
+    private final EventBatch eventBatch;
 
     public LogEvent(@Nonnull RequestMethod requestMethod,
                     @Nonnull String endpointUrl,
                     @Nonnull Map<String, String> requestParams,
-                    @Nonnull String body) {
+                    EventBatch eventBatch) {
         this.requestMethod = requestMethod;
         this.endpointUrl = endpointUrl;
         this.requestParams = requestParams;
-        this.body = body;
+        this.eventBatch = eventBatch;
     }
 
     //======== Getters ========//
@@ -57,7 +61,12 @@ public class LogEvent {
     }
 
     public String getBody() {
-        return body;
+        if (eventBatch == null) {
+            return "";
+        }
+
+        Serializer serializer = DefaultJsonSerializer.getInstance();
+        return serializer.serialize(eventBatch);
     }
 
     //======== Overriding method ========//
@@ -68,7 +77,7 @@ public class LogEvent {
                "requestMethod=" + requestMethod +
                ", endpointUrl='" + endpointUrl + '\'' +
                ", requestParams=" + requestParams +
-               ", body='" + body + '\'' +
+               ", body='" + getBody() + '\'' +
                '}';
     }
 

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/EventFactory.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/EventFactory.java
@@ -28,8 +28,6 @@ import com.optimizely.ab.event.internal.payload.EventBatch;
 import com.optimizely.ab.event.internal.payload.Event;
 import com.optimizely.ab.event.internal.payload.Snapshot;
 import com.optimizely.ab.event.internal.payload.Visitor;
-import com.optimizely.ab.event.internal.serializer.DefaultJsonSerializer;
-import com.optimizely.ab.event.internal.serializer.Serializer;
 import com.optimizely.ab.internal.EventTagUtils;
 import com.optimizely.ab.internal.ControlAttribute;
 import org.slf4j.Logger;
@@ -46,7 +44,6 @@ public class EventFactory {
     static final String EVENT_ENDPOINT = "https://logx.optimizely.com/v1/events";  // Should be part of the datafile
     static final String  ACTIVATE_EVENT_KEY = "campaign_activated";
 
-    private Serializer serializer;
     @VisibleForTesting
     public final String clientVersion;
     @VisibleForTesting
@@ -59,7 +56,6 @@ public class EventFactory {
     public EventFactory(EventBatch.ClientEngine clientEngine, String clientVersion) {
         this.clientEngine = clientEngine;
         this.clientVersion = clientVersion;
-        this.serializer = DefaultJsonSerializer.getInstance();
     }
 
     public LogEvent createImpressionEvent(@Nonnull ProjectConfig projectConfig,
@@ -104,8 +100,7 @@ public class EventFactory {
                 .setRevision(projectConfig.getRevision())
                 .build();
 
-        String payload = this.serializer.serialize(eventBatch);
-        return new LogEvent(LogEvent.RequestMethod.POST, EVENT_ENDPOINT, Collections.<String, String>emptyMap(), payload);
+        return new LogEvent(LogEvent.RequestMethod.POST, EVENT_ENDPOINT, Collections.<String, String>emptyMap(), eventBatch);
     }
 
     public LogEvent createConversionEvent(@Nonnull ProjectConfig projectConfig,
@@ -166,8 +161,7 @@ public class EventFactory {
                 .setRevision(projectConfig.getRevision())
                 .build();
 
-        String payload = this.serializer.serialize(eventBatch);
-        return new LogEvent(LogEvent.RequestMethod.POST, EVENT_ENDPOINT, Collections.<String, String>emptyMap(), payload);
+        return new LogEvent(LogEvent.RequestMethod.POST, EVENT_ENDPOINT, Collections.<String, String>emptyMap(), eventBatch);
     }
 
     private List<Attribute> buildAttributeList(ProjectConfig projectConfig, Map<String, String> attributes) {

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -36,12 +36,14 @@ import com.optimizely.ab.error.RaiseExceptionErrorHandler;
 import com.optimizely.ab.event.EventHandler;
 import com.optimizely.ab.event.LogEvent;
 import com.optimizely.ab.event.internal.EventFactory;
+import com.optimizely.ab.event.internal.payload.EventBatch;
 import com.optimizely.ab.internal.LogbackVerifier;
 import com.optimizely.ab.internal.ControlAttribute;
 import com.optimizely.ab.notification.ActivateNotificationListener;
 import com.optimizely.ab.notification.NotificationCenter;
 import com.optimizely.ab.notification.TrackNotificationListener;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -134,6 +136,8 @@ public class OptimizelyTest {
     private static final String testUserId = "userId";
     private static final String testBucketingId = "bucketingId";
     private static final String testBucketingIdKey = ControlAttribute.BUCKETING_ATTRIBUTE.toString();
+    private static final Map<String, String> testParams = Collections.singletonMap("test", "params");
+    private static final LogEvent logEventToDispatch = new LogEvent(RequestMethod.GET, "test_url", testParams, null);
 
     private int datafileVersion;
     private String validDatafile;
@@ -185,10 +189,7 @@ public class OptimizelyTest {
                 .withErrorHandler(mockErrorHandler)
                 .build();
 
-        Map<String, String> testParams = new HashMap<String, String>();
 
-        testParams.put("test", "params");
-        LogEvent logEventToDispatch = new LogEvent(RequestMethod.GET, "test_url", testParams, "");
         when(mockEventFactory.createImpressionEvent(validProjectConfig, activatedExperiment, bucketedVariation, testUserId,
                 testUserAttributes))
                 .thenReturn(logEventToDispatch);
@@ -305,10 +306,6 @@ public class OptimizelyTest {
         testUserAttributes.put(testBucketingIdKey,
                 testBucketingId);
 
-        Map<String, String> testParams = new HashMap<String, String>();
-        testParams.put("test", "params");
-
-        LogEvent logEventToDispatch = new LogEvent(RequestMethod.GET, "test_url", testParams, "");
         when(mockEventFactory.createImpressionEvent(eq(validProjectConfig), eq(activatedExperiment), eq(forcedVariation),
                 eq(testUserId), eq(testUserAttributes)))
                 .thenReturn(logEventToDispatch);
@@ -361,10 +358,6 @@ public class OptimizelyTest {
         testUserAttributes.put(testBucketingIdKey,
                 testBucketingId);
 
-        Map<String, String> testParams = new HashMap<String, String>();
-        testParams.put("test", "params");
-
-        LogEvent logEventToDispatch = new LogEvent(RequestMethod.GET, "test_url", testParams, "");
         when(mockEventFactory.createImpressionEvent(eq(validProjectConfig), eq(activatedExperiment), eq(forcedVariation),
                 eq(testUserId), eq(testUserAttributes)))
                 .thenReturn(logEventToDispatch);
@@ -413,10 +406,6 @@ public class OptimizelyTest {
             testUserAttributes.put("browser_type", "chrome");
         }
 
-        Map<String, String> testParams = new HashMap<String, String>();
-        testParams.put("test", "params");
-
-        LogEvent logEventToDispatch = new LogEvent(RequestMethod.GET, "test_url", testParams, "");
         when(mockEventFactory.createImpressionEvent(eq(validProjectConfig), eq(activatedExperiment), eq(forcedVariation),
                 eq(testUserId), eq(testUserAttributes)))
                 .thenReturn(logEventToDispatch);
@@ -463,9 +452,6 @@ public class OptimizelyTest {
 
         testUserAttributes.put(testBucketingIdKey, testBucketingId);
 
-        Map<String, String> testParams = new HashMap<String, String>();
-        testParams.put("test", "params");
-        LogEvent logEventToDispatch = new LogEvent(RequestMethod.GET, "test_url", testParams, "");
         when(mockEventFactory.createImpressionEvent(eq(validProjectConfig), eq(activatedExperiment), eq(bucketedVariation),
                 eq(testUserId), eq(testUserAttributes)))
                 .thenReturn(logEventToDispatch);
@@ -550,9 +536,6 @@ public class OptimizelyTest {
                 .withErrorHandler(mockErrorHandler)
                 .build();
 
-        Map<String, String> testParams = new HashMap<String, String>();
-        testParams.put("test", "params");
-        LogEvent logEventToDispatch = new LogEvent(RequestMethod.GET, "test_url", testParams, "");
         when(mockEventFactory.createImpressionEvent(eq(validProjectConfig), eq(activatedExperiment), eq(bucketedVariation),
                 eq(testUserId), anyMapOf(String.class, String.class)))
                 .thenReturn(logEventToDispatch);
@@ -618,9 +601,6 @@ public class OptimizelyTest {
         }
         testUserAttributes.put("unknownAttribute", "dimValue");
 
-        Map<String, String> testParams = new HashMap<String, String>();
-        testParams.put("test", "params");
-        LogEvent logEventToDispatch = new LogEvent(RequestMethod.GET, "test_url", testParams, "");
         when(mockEventFactory.createImpressionEvent(eq(validProjectConfig), eq(activatedExperiment), eq(bucketedVariation),
                 eq(testUserId), anyMapOf(String.class, String.class)))
                 .thenReturn(logEventToDispatch);
@@ -675,9 +655,6 @@ public class OptimizelyTest {
                 .withErrorHandler(mockErrorHandler)
                 .build();
 
-        Map<String, String> testParams = new HashMap<String, String>();
-        testParams.put("test", "params");
-        LogEvent logEventToDispatch = new LogEvent(RequestMethod.GET, "test_url", testParams, "");
         when(mockEventFactory.createImpressionEvent(eq(noAudienceProjectConfig), eq(activatedExperiment), eq(bucketedVariation),
                 eq(testUserId), eq(Collections.<String, String>emptyMap())))
                 .thenReturn(logEventToDispatch);
@@ -726,9 +703,6 @@ public class OptimizelyTest {
                 .withErrorHandler(mockErrorHandler)
                 .build();
 
-        Map<String, String> testParams = new HashMap<String, String>();
-        testParams.put("test", "params");
-        LogEvent logEventToDispatch = new LogEvent(RequestMethod.GET, "test_url", testParams, "");
         when(mockEventFactory.createImpressionEvent(eq(validProjectConfig), eq(activatedExperiment), eq(bucketedVariation),
                 eq(testUserId), anyMapOf(String.class, String.class)))
                 .thenReturn(logEventToDispatch);
@@ -1339,8 +1313,6 @@ public class OptimizelyTest {
                 .withErrorHandler(mockErrorHandler)
                 .build();
 
-        Map<String, String> testParams = new HashMap<String, String>();
-        testParams.put("test", "params");
         Map<String, String> attributes = ImmutableMap.of(attribute.getKey(), "attributeValue");
         Map<Experiment, Variation> experimentVariationMap = createExperimentVariationMap(
                 validProjectConfig,
@@ -1348,7 +1320,7 @@ public class OptimizelyTest {
                 eventType.getKey(),
                 genericUserId,
                 attributes);
-        LogEvent logEventToDispatch = new LogEvent(RequestMethod.GET, "test_url", testParams, "");
+
         when(mockEventFactory.createConversionEvent(
                 eq(validProjectConfig),
                 eq(experimentVariationMap),
@@ -1412,15 +1384,13 @@ public class OptimizelyTest {
                 .withErrorHandler(mockErrorHandler)
                 .build();
 
-        Map<String, String> testParams = new HashMap<String, String>();
-        testParams.put("test", "params");
         Map<Experiment, Variation> experimentVariationMap = createExperimentVariationMap(
                 validProjectConfig,
                 mockDecisionService,
                 eventType.getKey(),
                 genericUserId,
                 Collections.<String, String>emptyMap());
-        LogEvent logEventToDispatch = new LogEvent(RequestMethod.GET, "test_url", testParams, "");
+
         when(mockEventFactory.createConversionEvent(
                 eq(validProjectConfig),
                 eq(experimentVariationMap),
@@ -1484,15 +1454,13 @@ public class OptimizelyTest {
                 .withErrorHandler(mockErrorHandler)
                 .build();
 
-        Map<String, String> testParams = new HashMap<String, String>();
-        testParams.put("test", "params");
         Map<Experiment, Variation> experimentVariationMap = createExperimentVariationMap(
                 validProjectConfig,
                 mockDecisionService,
                 eventType.getKey(),
                 genericUserId,
                 Collections.<String, String>emptyMap());
-        LogEvent logEventToDispatch = new LogEvent(RequestMethod.GET, "test_url", testParams, "");
+
         when(mockEventFactory.createConversionEvent(
                 eq(validProjectConfig),
                 eq(experimentVariationMap),
@@ -1556,15 +1524,13 @@ public class OptimizelyTest {
                 .withErrorHandler(new RaiseExceptionErrorHandler())
                 .build();
 
-        Map<String, String> testParams = new HashMap<String, String>();
-        testParams.put("test", "params");
         Map<Experiment, Variation> experimentVariationMap = createExperimentVariationMap(
                 validProjectConfig,
                 mockDecisionService,
                 eventType.getKey(),
                 genericUserId,
                 Collections.<String, String>emptyMap());
-        LogEvent logEventToDispatch = new LogEvent(RequestMethod.GET, "test_url", testParams, "");
+
         when(mockEventFactory.createConversionEvent(
                 eq(validProjectConfig),
                 eq(experimentVariationMap),
@@ -1627,9 +1593,6 @@ public class OptimizelyTest {
                 .withErrorHandler(mockErrorHandler)
                 .build();
 
-        Map<String, String> testParams = new HashMap<String, String>();
-        testParams.put("test", "params");
-
         Map<String, Object> eventTags = new HashMap<String, Object>();
         eventTags.put("int_param", 123);
         eventTags.put("string_param", "123");
@@ -1642,7 +1605,6 @@ public class OptimizelyTest {
                 genericUserId,
                 Collections.<String, String>emptyMap());
 
-        LogEvent logEventToDispatch = new LogEvent(RequestMethod.GET, "test_url", testParams, "");
         when(mockEventFactory.createConversionEvent(
                 eq(validProjectConfig),
                 eq(experimentVariationMap),
@@ -1710,15 +1672,13 @@ public class OptimizelyTest {
                 .withErrorHandler(mockErrorHandler)
                 .build();
 
-        Map<String, String> testParams = new HashMap<String, String>();
-        testParams.put("test", "params");
         Map<Experiment, Variation> experimentVariationMap = createExperimentVariationMap(
                 validProjectConfig,
                 mockDecisionService,
                 eventType.getKey(),
                 genericUserId,
                 Collections.<String, String>emptyMap());
-        LogEvent logEventToDispatch = new LogEvent(RequestMethod.GET, "test_url", testParams, "");
+
         when(mockEventFactory.createConversionEvent(
                 eq(validProjectConfig),
                 eq(experimentVariationMap),
@@ -1775,15 +1735,13 @@ public class OptimizelyTest {
                 .withErrorHandler(mockErrorHandler)
                 .build();
 
-        Map<String, String> testParams = new HashMap<String, String>();
-        testParams.put("test", "params");
         Map<Experiment, Variation> experimentVariationMap = createExperimentVariationMap(
                 validProjectConfig,
                 mockDecisionService,
                 eventType.getKey(),
                 genericUserId,
                 Collections.<String, String>emptyMap());
-        LogEvent logEventToDispatch = new LogEvent(RequestMethod.GET, "test_url", testParams, "");
+
         when(mockEventFactory.createConversionEvent(
                 eq(validProjectConfig),
                 eq(experimentVariationMap),
@@ -1826,15 +1784,13 @@ public class OptimizelyTest {
                 .withErrorHandler(mockErrorHandler)
                 .build();
 
-        Map<String, String> testParams = new HashMap<String, String>();
-        testParams.put("test", "params");
         Map<Experiment, Variation> experimentVariationMap = createExperimentVariationMap(
                 validProjectConfig,
                 mockDecisionService,
                 eventType.getKey(),
                 genericUserId,
                 Collections.<String, String>emptyMap());
-        LogEvent logEventToDispatch = new LogEvent(RequestMethod.GET, "test_url", testParams, "");
+
         when(mockEventFactory.createConversionEvent(
                 eq(validProjectConfig),
                 eq(experimentVariationMap),
@@ -1983,8 +1939,6 @@ public class OptimizelyTest {
                 .withEventBuilder(mockEventFactory)
                 .build();
 
-        Map<String, String> testParams = new HashMap<String, String>();
-        testParams.put("test", "params");
         Map<Experiment, Variation> experimentVariationMap = createExperimentVariationMap(
                 noAudienceProjectConfig,
                 client.decisionService,
@@ -1995,7 +1949,6 @@ public class OptimizelyTest {
         // Create an Argument Captor to ensure we are creating a correct experiment variation map
         ArgumentCaptor<Map> experimentVariationMapCaptor = ArgumentCaptor.forClass(Map.class);
 
-        LogEvent conversionEvent = new LogEvent(RequestMethod.GET, "test_url", testParams, "");
         when(mockEventFactory.createConversionEvent(
                 eq(noAudienceProjectConfig),
                 experimentVariationMapCaptor.capture(),
@@ -2004,7 +1957,7 @@ public class OptimizelyTest {
                 eq(eventType.getKey()),
                 eq(Collections.<String, String>emptyMap()),
                 eq(Collections.<String, Object>emptyMap())
-        )).thenReturn(conversionEvent);
+        )).thenReturn(logEventToDispatch);
 
         List<Experiment> eventExperiments = noAudienceProjectConfig.getExperimentsForEventKey(eventType.getKey());
         for (Experiment experiment : eventExperiments) {
@@ -2020,7 +1973,7 @@ public class OptimizelyTest {
         // The event has 1 launched experiment and 1 running experiment.
         // It should send a track event with the running experiment
         client.track(eventType.getKey(), genericUserId, Collections.<String, String>emptyMap());
-        verify(client.eventHandler).dispatchEvent(eq(conversionEvent));
+        verify(client.eventHandler).dispatchEvent(eq(logEventToDispatch));
 
         // Check the argument captor got the correct arguments
         Map<Experiment, Variation> actualExperimentVariationMap = experimentVariationMapCaptor.getValue();
@@ -2384,9 +2337,6 @@ public class OptimizelyTest {
 
         int notificationId = optimizely.notificationCenter.addNotificationListener(NotificationCenter.NotificationType.Activate, activateNotification);
 
-        Map<String, String> testParams = new HashMap<String, String>();
-        testParams.put("test", "params");
-        LogEvent logEventToDispatch = new LogEvent(RequestMethod.GET, "test_url", testParams, "");
         when(mockEventFactory.createImpressionEvent(eq(validProjectConfig), eq(activatedExperiment), eq(bucketedVariation),
                 eq(testUserId), eq(testUserAttributes)))
                 .thenReturn(logEventToDispatch);
@@ -2425,9 +2375,6 @@ public class OptimizelyTest {
                 .withErrorHandler(mockErrorHandler)
                 .build();
 
-        Map<String, String> testParams = new HashMap<String, String>();
-        testParams.put("test", "params");
-        LogEvent logEventToDispatch = new LogEvent(RequestMethod.GET, "test_url", testParams, "");
         when(mockEventFactory.createImpressionEvent(eq(noAudienceProjectConfig), eq(activatedExperiment), eq(bucketedVariation),
                 eq(testUserId), eq(Collections.<String, String>emptyMap())))
                 .thenReturn(logEventToDispatch);
@@ -2505,9 +2452,6 @@ public class OptimizelyTest {
 
         Map<String, String> attributes = Collections.emptyMap();
 
-        Map<String, String> testParams = new HashMap<String, String>();
-        testParams.put("test", "params");
-        LogEvent logEventToDispatch = new LogEvent(RequestMethod.GET, "test_url", testParams, "");
         when(mockEventFactory.createImpressionEvent(validProjectConfig, activatedExperiment,
                 bucketedVariation, genericUserId, attributes))
                 .thenReturn(logEventToDispatch);
@@ -2576,9 +2520,6 @@ public class OptimizelyTest {
         Map<String, String> attributes = new HashMap<String, String>();
         attributes.put(ATTRIBUTE_HOUSE_KEY, AUDIENCE_GRYFFINDOR_VALUE);
 
-        Map<String, String> testParams = new HashMap<String, String>();
-        testParams.put("test", "params");
-        LogEvent logEventToDispatch = new LogEvent(RequestMethod.GET, "test_url", testParams, "");
         when(mockEventFactory.createImpressionEvent(validProjectConfig, activatedExperiment,
                 bucketedVariation, genericUserId, attributes))
                 .thenReturn(logEventToDispatch);
@@ -2661,9 +2602,6 @@ public class OptimizelyTest {
                 .withErrorHandler(mockErrorHandler)
                 .build();
 
-        Map<String, String> testParams = new HashMap<String, String>();
-        testParams.put("test", "params");
-        LogEvent logEventToDispatch = new LogEvent(RequestMethod.GET, "test_url", testParams, "");
         when(mockEventFactory.createImpressionEvent(validProjectConfig, activatedExperiment,
                 bucketedVariation, genericUserId, attributes))
                 .thenReturn(logEventToDispatch);
@@ -2756,8 +2694,6 @@ public class OptimizelyTest {
                 .withErrorHandler(mockErrorHandler)
                 .build();
 
-        Map<String, String> testParams = new HashMap<String, String>();
-        testParams.put("test", "params");
         final Map<String, String> attributes = ImmutableMap.of(attribute.getKey(), "attributeValue");
         Map<Experiment, Variation> experimentVariationMap = createExperimentVariationMap(
                 validProjectConfig,
@@ -2765,7 +2701,7 @@ public class OptimizelyTest {
                 eventType.getKey(),
                 genericUserId,
                 attributes);
-        LogEvent logEventToDispatch = new LogEvent(RequestMethod.GET, "test_url", testParams, "");
+
         when(mockEventFactory.createConversionEvent(
                 eq(validProjectConfig),
                 eq(experimentVariationMap),
@@ -2843,15 +2779,13 @@ public class OptimizelyTest {
                 .withErrorHandler(mockErrorHandler)
                 .build();
 
-        Map<String, String> testParams = new HashMap<String, String>();
-        testParams.put("test", "params");
         Map<Experiment, Variation> experimentVariationMap = createExperimentVariationMap(
                 validProjectConfig,
                 mockDecisionService,
                 eventType.getKey(),
                 genericUserId,
                 Collections.<String, String>emptyMap());
-        LogEvent logEventToDispatch = new LogEvent(RequestMethod.GET, "test_url", testParams, "");
+
         when(mockEventFactory.createConversionEvent(
                 eq(validProjectConfig),
                 eq(experimentVariationMap),

--- a/core-api/src/test/java/com/optimizely/ab/event/NoopEventHandlerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/event/NoopEventHandlerTest.java
@@ -39,7 +39,7 @@ public class NoopEventHandlerTest {
     public void dispatchEvent() throws Exception {
         NoopEventHandler noopEventHandler = new NoopEventHandler();
         noopEventHandler.dispatchEvent(
-            new LogEvent(RequestMethod.GET, "blah", Collections.<String, String>emptyMap(), ""));
+            new LogEvent(RequestMethod.GET, "blah", Collections.<String, String>emptyMap(), null));
         logbackVerifier.expectMessage(Level.DEBUG, "Called dispatchEvent with URL: blah and params: {}");
     }
 }


### PR DESCRIPTION
This PR moves the serialization from POJO to JSON into `LogEvent#getBody()`. This allows the serialization of the event to be offloaded to with the event handler when the HTTP request is built. This should be 100% backwards compatible with any existing `EventHandler` implementations. Initial benchmarks are much improved over the current master in tight loop simulations.

Stats after 100,000 calls to `activate(...)` in my simulation:

|Metric (us)|PR-199|2.0.0-beta2|2.0.0-SNAPSHOT|THIS PR|
|---|---|---|---|---|
|Min|21|2|3|1||
|Median|29|2|9|6||
|Mean|41|3.8|10.2|6.1||
|75th Pct|40|3|11|7||
|95th Pct|85|7|18|11||
|99th Pct|126|26|43|21||
|999th Pct|713|65|237|232||
|Max|11825|17732|34384|12845||

Note `2.0.0-beta2` was pre-batch endpoint, so isn't a valid comparison. Also performance runs can have some volatility, but the overall trends remain.

I've also wrapped some calls to `logger.debug` in `logger.isDebugEnabled()` to prevent unused log statement from triggering the serialization synchronously.