### PR TITLE
Source Clear Improvements

### DIFF
--- a/core-api/build.gradle
+++ b/core-api/build.gradle
@@ -2,8 +2,8 @@ dependencies {
     compile group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: jacksonVersion
 
-    compile group: 'com.google.code.findbugs', name: 'annotations', version: findbugsVersion
-    compile group: 'com.google.code.findbugs', name: 'jsr305', version: findbugsVersion
+    compile group: 'com.google.code.findbugs', name: 'annotations', version: findbugsAnnotationVersion
+    compile group: 'com.google.code.findbugs', name: 'jsr305', version: findbugsJsrVersion
 
     // an assortment of json parsers
     compileOnly group: 'com.google.code.gson', name: 'gson', version: gsonVersion, optional

--- a/core-httpclient-impl/gradle.properties
+++ b/core-httpclient-impl/gradle.properties
@@ -1,1 +1,1 @@
-httpClientVersion = 5.0-alpha3 
+httpClientVersion = 4.5.6

--- a/core-httpclient-impl/gradle.properties
+++ b/core-httpclient-impl/gradle.properties
@@ -1,1 +1,1 @@
-httpClientVersion = 4.5.2
+httpClientVersion = 4.5.6

--- a/core-httpclient-impl/gradle.properties
+++ b/core-httpclient-impl/gradle.properties
@@ -1,1 +1,1 @@
-httpClientVersion = 4.5.6
+httpClientVersion = 5.0-alpha3 

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ logbackVersion = 1.1.5
 slf4jVersion = 1.8.0-beta2
 
 # Style Packages
-findbugsVersion = 3.0.2
+findbugsVersion = 3.0.1
 
 # Test Packages
 junitVersion = 4.12

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,14 +13,14 @@ org.gradle.parallel = true
 gsonVersion = 2.6.1
 guavaVersion = 19.0
 hamcrestVersion = 1.3
-jacksonVersion = 2.7.1
+jacksonVersion = 2.9.6
 jsonVersion = 20160212
 jsonSimpleVersion = 1.1.1
 logbackVersion = 1.1.5
-slf4jVersion = 1.7.16
+slf4jVersion = 1.8.0-beta2
 
 # Style Packages
-findbugsVersion = 3.0.1
+findbugsVersion = 3.0.2
 
 # Test Packages
 junitVersion = 4.12

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,10 +17,11 @@ jacksonVersion = 2.9.6
 jsonVersion = 20160212
 jsonSimpleVersion = 1.1.1
 logbackVersion = 1.1.5
-slf4jVersion = 1.8.0-beta2
+slf4jVersion = 1.7.25
 
 # Style Packages
-findbugsVersion = 3.0.1
+findbugsAnnotationVersion = 3.0.1
+findbugsJsrVersion = 3.0.2
 
 # Test Packages
 junitVersion = 4.12


### PR DESCRIPTION
## Summary/Background
Results from Source Clear were 1 vulnerability and several suggested library updates. The following changes were made largely with the suggestions Source Clear made. All the information below is also in our Source Clear account.

### Vulnerability
`Apache httpclient 4.5.2` had a security vulnerability, in which Source Clear suggests a package update. Looking through the Source Clear Vulnerability Database, `4.5.6` does not have any vulnerabilities and is the most recent package. (There were also 5.0 beta versions that were breaking our code.)

### Libraries
There were several libraries that were outdated, in which some libraries were dependent on other libraries. The only library upgrade suggestion that I did not follow was `SLF4J 1.8.0-beta2`, and I upgraded it to `1.7.25` instead. `1.8.0-beta2` broke the code, so I elected to upgrade it to the most current 1.7.x version. We were also using `findBugsVersion` on two different libraries `annotations` and `jsr305`. One required an update, so I chose to specify the versions for the two libraries. 

### Testing
Build with `./gradlew build` had no errors. Ran and passed `./gradlew test`, and `./gradlew check`.