### PR TITLE
refactor(init): build invalid instance if datafile cannot be parsed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 local.properties
 
 **/build
+bin
 out
 classes
 

--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -29,7 +29,6 @@ import com.optimizely.ab.config.LiveVariableUsageInstance;
 import com.optimizely.ab.config.ProjectConfig;
 import com.optimizely.ab.config.Variation;
 import com.optimizely.ab.config.parser.ConfigParseException;
-import com.optimizely.ab.config.parser.DefaultConfigParser;
 import com.optimizely.ab.error.ErrorHandler;
 import com.optimizely.ab.error.NoOpErrorHandler;
 import com.optimizely.ab.event.EventHandler;
@@ -80,22 +79,21 @@ public class Optimizely {
 
     private static final Logger logger = LoggerFactory.getLogger(Optimizely.class);
 
-    @VisibleForTesting final DecisionService decisionService;
+    @VisibleForTesting DecisionService decisionService;
     @VisibleForTesting final EventFactory eventFactory;
-    @VisibleForTesting final ProjectConfig projectConfig;
+    @VisibleForTesting ProjectConfig projectConfig;
     @VisibleForTesting final EventHandler eventHandler;
     @VisibleForTesting final ErrorHandler errorHandler;
+    public boolean isValid = false;
     public final NotificationCenter notificationCenter = new NotificationCenter();
 
     @Nullable private final UserProfileService userProfileService;
 
-    private Optimizely(@Nonnull ProjectConfig projectConfig,
-                       @Nonnull DecisionService decisionService,
-                       @Nonnull EventHandler eventHandler,
+    private Optimizely(@Nonnull EventHandler eventHandler,
                        @Nonnull EventFactory eventFactory,
                        @Nonnull ErrorHandler errorHandler,
+                       @Nullable DecisionService decisionService,
                        @Nullable UserProfileService userProfileService) {
-        this.projectConfig = projectConfig;
         this.decisionService = decisionService;
         this.eventHandler = eventHandler;
         this.eventFactory = eventFactory;
@@ -103,10 +101,33 @@ public class Optimizely {
         this.userProfileService = userProfileService;
     }
 
-    // Do work here that should be done once per Optimizely lifecycle
+    /**
+     * Initializes the SDK state. Can conceivably re-use this in the future with datafile sync where
+     * we can re-initialize the SDK instead of re-instantiating.
+     */
     @VisibleForTesting
-    void initialize() {
+    void initialize(@Nonnull String datafile, @Nullable ProjectConfig projectConfig) {
+        if (projectConfig == null) {
+            try {
+                projectConfig = new ProjectConfig.Builder()
+                        .withDatafile(datafile)
+                        .build();
+                isValid = true;
+                logger.info("Datafile is valid");
+            } catch (ConfigParseException ex) {
+                logger.error("Unable to parse the datafile", ex);
+                logger.info("Datafile is invalid");
+                errorHandler.handleError(new OptimizelyRuntimeException(ex));
+            }
+        } else {
+            isValid = true;
+        }
 
+        this.projectConfig = projectConfig;
+        if (decisionService == null) {
+            Bucketer bucketer = new Bucketer(projectConfig);
+            decisionService = new DecisionService(bucketer, errorHandler, projectConfig, userProfileService);
+        }
     }
 
     //======== activate calls ========//
@@ -121,6 +142,10 @@ public class Optimizely {
     Variation activate(@Nonnull String experimentKey,
                        @Nonnull String userId,
                        @Nonnull Map<String, ?> attributes) throws UnknownExperimentException {
+        if (!isValid) {
+            logger.error("Optimizely instance is not valid, failing activate call.");
+            return null;
+        }
 
         if (experimentKey == null) {
             logger.error("The experimentKey parameter must be nonnull.");
@@ -165,6 +190,10 @@ public class Optimizely {
                        @Nonnull Experiment experiment,
                        @Nonnull String userId,
                        @Nonnull Map<String, ?> attributes) {
+        if (!isValid) {
+            logger.error("Optimizely instance is not valid, failing activate call.");
+            return null;
+        }
 
         if (!validateUserId(userId)){
             logger.info("Not activating user \"{}\" for experiment \"{}\".", userId, experiment.getKey());
@@ -236,6 +265,10 @@ public class Optimizely {
                       @Nonnull String userId,
                       @Nonnull Map<String, ?> attributes,
                       @Nonnull Map<String, ?> eventTags) throws UnknownEventTypeException {
+        if (!isValid) {
+            logger.error("Optimizely instance is not valid, failing track call.");
+            return;
+        }
 
         if (!validateUserId(userId)) {
             logger.info("Not tracking event \"{}\".", eventName);
@@ -345,6 +378,11 @@ public class Optimizely {
     public @Nonnull Boolean isFeatureEnabled(@Nonnull String featureKey,
                                               @Nonnull String userId,
                                               @Nonnull Map<String, ?> attributes) {
+        if (!isValid) {
+            logger.error("Optimizely instance is not valid, failing isFeatureEnabled call.");
+            return false;
+        }
+
         if (featureKey == null) {
             logger.warn("The featureKey parameter must be nonnull.");
             return false;
@@ -411,6 +449,11 @@ public class Optimizely {
                                                        @Nonnull String variableKey,
                                                        @Nonnull String userId,
                                                        @Nonnull Map<String, ?> attributes) {
+        if (!isValid) {
+            logger.error("Optimizely instance is not valid, failing getFeatureVariableBoolean call.");
+            return null;
+        }
+
         String variableValue = getFeatureVariableValueForType(
                 featureKey,
                 variableKey,
@@ -451,6 +494,11 @@ public class Optimizely {
                                                      @Nonnull String variableKey,
                                                      @Nonnull String userId,
                                                      @Nonnull Map<String, ?> attributes) {
+        if (!isValid) {
+            logger.error("Optimizely instance is not valid, failing getFeatureVariableDouble call.");
+            return null;
+        }
+
         String variableValue = getFeatureVariableValueForType(
                 featureKey,
                 variableKey,
@@ -496,6 +544,11 @@ public class Optimizely {
                                                        @Nonnull String variableKey,
                                                        @Nonnull String userId,
                                                        @Nonnull Map<String, ?> attributes) {
+        if (!isValid) {
+            logger.error("Optimizely instance is not valid, failing getFeatureVariableInteger call.");
+            return null;
+        }
+
         String variableValue = getFeatureVariableValueForType(
                 featureKey,
                 variableKey,
@@ -541,6 +594,11 @@ public class Optimizely {
                                                      @Nonnull String variableKey,
                                                      @Nonnull String userId,
                                                      @Nonnull Map<String, ?> attributes) {
+        if (!isValid) {
+            logger.error("Optimizely instance is not valid, failing getFeatureVariableString call.");
+            return null;
+        }
+
         return getFeatureVariableValueForType(
                 featureKey,
                 variableKey,
@@ -617,6 +675,11 @@ public class Optimizely {
     public List<String> getEnabledFeatures(@Nonnull String userId, @Nonnull Map<String, ?> attributes) {
         List<String> enabledFeaturesList = new ArrayList<String>();
 
+        if (!isValid) {
+            logger.error("Optimizely instance is not valid, failing getEnabledFeatures call.");
+            return enabledFeaturesList;
+        }
+
         if (!validateUserId(userId)){
             return enabledFeaturesList;
         }
@@ -660,6 +723,11 @@ public class Optimizely {
     Variation getVariation(@Nonnull String experimentKey,
                            @Nonnull String userId,
                            @Nonnull Map<String, ?> attributes) {
+        if (!isValid) {
+            logger.error("Optimizely instance is not valid, failing getVariation call.");
+            return null;
+        }
+
         if (!validateUserId(userId)) {
             return null;
         }
@@ -697,7 +765,10 @@ public class Optimizely {
     public boolean setForcedVariation(@Nonnull String experimentKey,
                                       @Nonnull String userId,
                                       @Nullable String variationKey) {
-
+        if (!isValid) {
+            logger.error("Optimizely instance is not valid, failing setForcedVariation call.");
+            return false;
+        }
 
         return projectConfig.setForcedVariation(experimentKey, userId, variationKey);
     }
@@ -715,6 +786,11 @@ public class Optimizely {
      */
     public @Nullable Variation getForcedVariation(@Nonnull String experimentKey,
                                         @Nonnull String userId) {
+        if (!isValid) {
+            logger.error("Optimizely instance is not valid, failing getForcedVariation call.");
+            return null;
+        }
+
         return projectConfig.getForcedVariation(experimentKey, userId);
     }
 
@@ -869,17 +945,7 @@ public class Optimizely {
             return this;
         }
 
-        public Optimizely build() throws ConfigParseException {
-            if (projectConfig == null) {
-                projectConfig = new ProjectConfig.Builder()
-                        .withDatafile(datafile)
-                        .build();
-            }
-
-            if (bucketer == null) {
-                bucketer = new Bucketer(projectConfig);
-            }
-
+        public Optimizely build() {
             if (clientEngine == null) {
                 clientEngine = ClientEngine.JAVA_SDK;
             }
@@ -897,12 +963,13 @@ public class Optimizely {
                 errorHandler = new NoOpErrorHandler();
             }
 
-            if (decisionService == null) {
+            // Used for convenience while unit testing to override/mock bucketing. This interface is NOT public and should be refactored out.
+            if (bucketer != null && decisionService == null) {
                 decisionService = new DecisionService(bucketer, errorHandler, projectConfig, userProfileService);
             }
 
-            Optimizely optimizely = new Optimizely(projectConfig, decisionService, eventHandler, eventFactory, errorHandler, userProfileService);
-            optimizely.initialize();
+            Optimizely optimizely = new Optimizely(eventHandler, eventFactory, errorHandler, decisionService, userProfileService);
+            optimizely.initialize(datafile, projectConfig);
             return optimizely;
         }
     }

--- a/core-api/src/main/java/com/optimizely/ab/bucketing/DecisionService.java
+++ b/core-api/src/main/java/com/optimizely/ab/bucketing/DecisionService.java
@@ -62,7 +62,7 @@ public class DecisionService {
      */
     public DecisionService(@Nonnull Bucketer bucketer,
                            @Nonnull ErrorHandler errorHandler,
-                           @Nonnull ProjectConfig projectConfig,
+                           @Nullable ProjectConfig projectConfig,
                            @Nullable UserProfileService userProfileService) {
         this.bucketer = bucketer;
         this.errorHandler = errorHandler;

--- a/core-api/src/main/java/com/optimizely/ab/config/ProjectConfig.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/ProjectConfig.java
@@ -614,7 +614,7 @@ public class ProjectConfig {
         /**
          * @return a {@link ProjectConfig} instance given a JSON string datafile
          */
-        public ProjectConfig build() throws ConfigParseException{
+        public ProjectConfig build() throws ConfigParseException {
             if (datafile == null) {
                 throw new ConfigParseException("Unable to parse null datafile.");
             }

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyBuilderTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyBuilderTest.java
@@ -33,12 +33,10 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import static com.optimizely.ab.config.ProjectConfigTestUtils.validConfigJsonV2;
-import static com.optimizely.ab.config.ProjectConfigTestUtils.validConfigJsonV3;
-import static com.optimizely.ab.config.ProjectConfigTestUtils.validProjectConfigV2;
-import static com.optimizely.ab.config.ProjectConfigTestUtils.validProjectConfigV3;
+import static com.optimizely.ab.config.ProjectConfigTestUtils.*;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -154,20 +152,31 @@ public class OptimizelyBuilderTest {
 
     @SuppressFBWarnings(value="NP_NONNULL_PARAM_VIOLATION", justification="Testing nullness contract violation")
     @Test
-    public void builderThrowsConfigParseExceptionForNullDatafile() throws Exception {
-        thrown.expect(ConfigParseException.class);
-        Optimizely.builder(null, mockEventHandler).build();
+    public void nullDatafileResultsInInvalidOptimizelyInstance() throws Exception {
+        Optimizely optimizelyClient = Optimizely.builder(null, mockEventHandler).build();
+
+        assertFalse(optimizelyClient.isValid);
     }
 
     @Test
-    public void builderThrowsConfigParseExceptionForEmptyDatafile() throws Exception {
-        thrown.expect(ConfigParseException.class);
-        Optimizely.builder("", mockEventHandler).build();
+    public void emptyDatafileResultsInInvalidOptimizelyInstance() throws Exception {
+        Optimizely optimizelyClient = Optimizely.builder("", mockEventHandler).build();
+
+        assertFalse(optimizelyClient.isValid);
     }
 
     @Test
-    public void builderThrowsConfigParseExceptionForInvalidDatafile() throws Exception {
-        thrown.expect(ConfigParseException.class);
-        Optimizely.builder("{invalidDatafile}", mockEventHandler).build();
+    public void invalidDatafileResultsInInvalidOptimizelyInstance() throws Exception {
+        Optimizely optimizelyClient = Optimizely.builder("{invalidDatafile}", mockEventHandler).build();
+
+        assertFalse(optimizelyClient.isValid);
+    }
+
+    @Test
+    public void unsupportedDatafileResultsInInvalidOptimizelyInstance() throws Exception {
+        Optimizely optimizelyClient = Optimizely.builder(invalidProjectConfigV5(), mockEventHandler)
+                .build();
+
+        assertFalse(optimizelyClient.isValid);
     }
 }

--- a/core-api/src/test/resources/config/invalid-project-config-v5.json
+++ b/core-api/src/test/resources/config/invalid-project-config-v5.json
@@ -77,6 +77,43 @@
         "entityId": "281",
         "endOfRange": 10000
       }]
+    },
+    {
+      "id": "120",
+      "key": "no_variable_feature_test",
+      "status": "Running",
+      "layerId": "3",
+      "audienceIds": [],
+      "variations": [
+        {
+          "id": "282",
+          "key": "no_variable_feature_test_variation_1"
+        },
+        {
+          "id": "283",
+          "key": "no_variable_feature_test_variation_2"
+        }
+      ],
+      "forcedVariations": {},
+      "trafficAllocation": [
+        {
+          "entityId": "282",
+          "endOfRange": 5000
+        },
+        {
+          "entityId": "283",
+          "endOfRange": 10000
+        }
+      ]
+    }
+  ],
+  "featureFlags": [
+    {
+      "id": "4195505407",
+      "key": "no_variable_feature",
+      "rolloutId": "",
+      "experimentIds": [120],
+      "variables": []
     }
   ],
   "groups": [],


### PR DESCRIPTION
## Summary

Refactor the Java SDK to follow the rest of the Full Stack SDKs in not throwing or preventing SDK initialization when an invalid datafile is passed in. Instead we will return an `Optimizely` instance with the `isValid` property set to `false`.  When accessing any of the SDK APIs, we will first check if the instance is valid before proceeding. If not valid, we will return the sensible defaults for each API.

