### PR TITLE
fix(nullfilter): filters out attributes with null values

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/event/internal/EventFactory.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/EventFactory.java
@@ -171,7 +171,7 @@ public class EventFactory {
             // Filter down to the types of values we're allowed to track.
             // Don't allow Longs, BigIntegers, or BigDecimals - they /can/ theoretically be serialized as JSON numbers
             // but may take on values that can't be faithfully parsed by the backend.
-            // https://github.com/optimizely/avro-schemas/blob/baeba19a7bd227aae67026474aec239110c5801d/event_batch/src/main/avro/EventBatch.avsc#L22
+            // https://developers.optimizely.com/x/events/api/#Attribute
             if (entry.getValue() == null ||
                     !((entry.getValue() instanceof String) ||
                     (entry.getValue() instanceof Integer) ||

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/EventFactory.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/EventFactory.java
@@ -168,12 +168,13 @@ public class EventFactory {
         List<Attribute> attributesList = new ArrayList<Attribute>();
 
         for (Map.Entry<String, ?> entry : attributes.entrySet()) {
-            //Ignore null value attribute
+            // Filters down to the types of values that are allowed.
+            // Don't allow Longs, BigIntegers, or BigDecimals - they /can/ theoretically be serialized as JSON numbers
             if (entry.getValue() == null ||
-                    (!(entry.getValue() instanceof String) &&
-                    !(entry.getValue() instanceof Integer) &&
-                    !(entry.getValue() instanceof Double) &&
-                    !(entry.getValue() instanceof Boolean))) {
+                    !((entry.getValue() instanceof String) ||
+                    (entry.getValue() instanceof Integer) ||
+                    (entry.getValue() instanceof Double) ||
+                    (entry.getValue() instanceof Boolean))) {
                 continue;
             }
 

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/EventFactory.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/EventFactory.java
@@ -169,7 +169,11 @@ public class EventFactory {
 
         for (Map.Entry<String, ?> entry : attributes.entrySet()) {
             //Ignore null value attribute
-            if (entry.getValue() == null) {
+            if (entry.getValue() == null ||
+                    (!(entry.getValue() instanceof String) &&
+                    !(entry.getValue() instanceof Integer) &&
+                    !(entry.getValue() instanceof Double) &&
+                    !(entry.getValue() instanceof Boolean))) {
                 continue;
             }
 

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/EventFactory.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/EventFactory.java
@@ -168,8 +168,10 @@ public class EventFactory {
         List<Attribute> attributesList = new ArrayList<Attribute>();
 
         for (Map.Entry<String, ?> entry : attributes.entrySet()) {
-            // Filters down to the types of values that are allowed.
+            // Filter down to the types of values we're allowed to track.
             // Don't allow Longs, BigIntegers, or BigDecimals - they /can/ theoretically be serialized as JSON numbers
+            // but may take on values that can't be faithfully parsed by the backend.
+            // https://github.com/optimizely/avro-schemas/blob/baeba19a7bd227aae67026474aec239110c5801d/event_batch/src/main/avro/EventBatch.avsc#L22
             if (entry.getValue() == null ||
                     !((entry.getValue() instanceof String) ||
                     (entry.getValue() instanceof Integer) ||

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/EventFactory.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/EventFactory.java
@@ -168,6 +168,11 @@ public class EventFactory {
         List<Attribute> attributesList = new ArrayList<Attribute>();
 
         for (Map.Entry<String, ?> entry : attributes.entrySet()) {
+            //Ignore null value attribute
+            if (entry.getValue() == null) {
+                continue;
+            }
+
             String attributeId = projectConfig.getAttributeId(projectConfig, entry.getKey());
             if(attributeId == null) {
                 continue;


### PR DESCRIPTION
This will ignore attributes with null values on creation of impression or conversion event. 