### PR TITLE
chore: Enable Travis builds on release branches.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,6 @@ cache:
 branches:
   only:
   - master
-  - /^\d+\.\d+\.\d+(-SNAPSHOT|-alpha|-beta)?\d*$/ # trigger builds on tags which are semantically versioned to ship the SDK.
+  - /^\d+\.\d+\.(\d|[x])+(-SNAPSHOT|-alpha|-beta)?\d*$/ # trigger builds on tags which are semantically versioned to ship the SDK.
 after_success:
   - ./gradlew coveralls uploadArchives --console plain


### PR DESCRIPTION
This allows us to run Travis CI unit tests on release branches for minor versions: 2.1.x, 2.0.x, etc