### PR TITLE
fix: created a new matcher for numbers

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/config/audience/match/ExactNumberMatch.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/match/ExactNumberMatch.java
@@ -1,0 +1,26 @@
+package com.optimizely.ab.config.audience.match;
+
+import javax.annotation.Nullable;
+
+// Because json number is a double in most java json parsers.  at this
+// point we allow comparision of Integer and Double.  The instance class is Double and
+// Integer which would fail in our normal exact match.  So, we are special casing for now.  We have already filtered
+// out other Number types.
+public class ExactNumberMatch extends AttributeMatch<Number> {
+    Number value;
+
+    protected ExactNumberMatch(Number value) {
+        this.value = value;
+    }
+
+    public @Nullable
+    Boolean eval(Object attributeValue) {
+        try {
+            return value.doubleValue() == convert(attributeValue).doubleValue();
+        } catch (Exception e) {
+            MatchType.logger.error("Exact number match failed ", e);
+        }
+
+        return null;
+    }
+}

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/match/ExactNumberMatch.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/match/ExactNumberMatch.java
@@ -1,3 +1,19 @@
+/**
+ *
+ *    Copyright 2018, Optimizely and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package com.optimizely.ab.config.audience.match;
 
 import javax.annotation.Nullable;

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/match/MatchType.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/match/MatchType.java
@@ -39,7 +39,7 @@ public class MatchType {
                     return new MatchType(matchType, new ExactMatch<String>((String) conditionValue));
                 }
                 else if (conditionValue instanceof Integer || conditionValue instanceof Double) {
-                    return new MatchType(matchType, new ExactMatch<Number>((Number) conditionValue));
+                    return new MatchType(matchType, new ExactNumberMatch((Number) conditionValue));
                 }
                 else if (conditionValue instanceof Boolean) {
                     return new MatchType(matchType, new ExactMatch<Boolean>((Boolean) conditionValue));

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -280,6 +280,100 @@ public class OptimizelyTest {
     }
 
     /**
+     * Verify that activating using typed audiences works for numeric match exact using double and integer.
+     */
+    @Test
+    public void activateEndToEndWithTypedAudienceIntExactDouble() throws Exception {
+        Experiment activatedExperiment;
+        Map<String, Object> testUserAttributes = new HashMap<String, Object>();
+        String bucketingKey = testBucketingIdKey;
+        String userId = testUserId;
+        String bucketingId = testBucketingId;
+        if(datafileVersion >= 4) {
+            activatedExperiment = validProjectConfig.getExperimentKeyMapping().get(EXPERIMENT_TYPEDAUDIENCE_EXPERIMENT_KEY);
+            testUserAttributes.put(ATTRIBUTE_INTEGER_KEY, 1.0); // should be equal 1.
+        }
+        else {
+            return; // only test on v4 datafiles.
+        }
+        testUserAttributes.put(bucketingKey, bucketingId);
+        Variation bucketedVariation = activatedExperiment.getVariations().get(0);
+        EventFactory mockEventFactory = mock(EventFactory.class);
+
+        Optimizely optimizely = Optimizely.builder(validDatafile, mockEventHandler)
+            .withBucketing(mockBucketer)
+            .withEventBuilder(mockEventFactory)
+            .withConfig(validProjectConfig)
+            .withErrorHandler(mockErrorHandler)
+            .build();
+
+
+        when(mockEventFactory.createImpressionEvent(validProjectConfig, activatedExperiment, bucketedVariation, testUserId,
+            testUserAttributes))
+            .thenReturn(logEventToDispatch);
+
+        when(mockBucketer.bucket(activatedExperiment, bucketingId))
+            .thenReturn(bucketedVariation);
+
+        // activate the experiment
+        Variation actualVariation = optimizely.activate(activatedExperiment.getKey(), userId, testUserAttributes);
+
+        // verify that the bucketing algorithm was called correctly
+        verify(mockBucketer).bucket(activatedExperiment, bucketingId);
+        assertThat(actualVariation, is(bucketedVariation));
+
+        // verify that dispatchEvent was called with the correct LogEvent object
+        verify(mockEventHandler).dispatchEvent(logEventToDispatch);
+    }
+
+    /**
+     * Verify that activating using typed audiences works for numeric match exact using double and integer.
+     */
+    @Test
+    public void activateEndToEndWithTypedAudienceIntExact() throws Exception {
+        Experiment activatedExperiment;
+        Map<String, Object> testUserAttributes = new HashMap<String, Object>();
+        String bucketingKey = testBucketingIdKey;
+        String userId = testUserId;
+        String bucketingId = testBucketingId;
+        if(datafileVersion >= 4) {
+            activatedExperiment = validProjectConfig.getExperimentKeyMapping().get(EXPERIMENT_TYPEDAUDIENCE_EXPERIMENT_KEY);
+            testUserAttributes.put(ATTRIBUTE_INTEGER_KEY, 1); // should be equal 1.
+        }
+        else {
+            return; // only test on v4 datafiles.
+        }
+        testUserAttributes.put(bucketingKey, bucketingId);
+        Variation bucketedVariation = activatedExperiment.getVariations().get(0);
+        EventFactory mockEventFactory = mock(EventFactory.class);
+
+        Optimizely optimizely = Optimizely.builder(validDatafile, mockEventHandler)
+            .withBucketing(mockBucketer)
+            .withEventBuilder(mockEventFactory)
+            .withConfig(validProjectConfig)
+            .withErrorHandler(mockErrorHandler)
+            .build();
+
+
+        when(mockEventFactory.createImpressionEvent(validProjectConfig, activatedExperiment, bucketedVariation, testUserId,
+            testUserAttributes))
+            .thenReturn(logEventToDispatch);
+
+        when(mockBucketer.bucket(activatedExperiment, bucketingId))
+            .thenReturn(bucketedVariation);
+
+        // activate the experiment
+        Variation actualVariation = optimizely.activate(activatedExperiment.getKey(), userId, testUserAttributes);
+
+        // verify that the bucketing algorithm was called correctly
+        verify(mockBucketer).bucket(activatedExperiment, bucketingId);
+        assertThat(actualVariation, is(bucketedVariation));
+
+        // verify that dispatchEvent was called with the correct LogEvent object
+        verify(mockEventHandler).dispatchEvent(logEventToDispatch);
+    }
+
+    /**
      * Verify that the {@link Optimizely#activate(Experiment, String, Map)} call correctly builds an endpoint url and
      * request params and passes them through {@link EventHandler#dispatchEvent(LogEvent)}.
      */

--- a/core-api/src/test/java/com/optimizely/ab/config/ValidProjectConfigV4.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/ValidProjectConfigV4.java
@@ -91,6 +91,18 @@ public class ValidProjectConfigV4 {
                                     CUSTOM_ATTRIBUTE_TYPE, "gt",
                                     AUDIENCE_INT_VALUE)))))))
     );
+
+    private static final String     AUDIENCE_INT_EXACT_ID = "3468206646";
+    private static final String     AUDIENCE_INT_EXACT_KEY = "INTEXACT";
+    private static final Audience   TYPED_AUDIENCE_EXACT_INT = new Audience(
+        AUDIENCE_INT_EXACT_ID,
+        AUDIENCE_INT_EXACT_KEY,
+        new AndCondition(Collections.<Condition>singletonList(
+            new OrCondition(Collections.<Condition>singletonList(
+                new OrCondition(Collections.singletonList((Condition) new UserAttribute(ATTRIBUTE_INTEGER_KEY,
+                    CUSTOM_ATTRIBUTE_TYPE, "exact",
+                    AUDIENCE_INT_VALUE)))))))
+    );
     private static final String     AUDIENCE_DOUBLE_ID = "3468206645";
     private static final String     AUDIENCE_DOUBLE_KEY = "DOUBLE";
     public  static final Double     AUDIENCE_DOUBLE_VALUE = 100.0;
@@ -461,6 +473,7 @@ public class ValidProjectConfigV4 {
             ProjectConfigTestUtils.createListOfObjects(
                     AUDIENCE_BOOL_ID,
                     AUDIENCE_INT_ID,
+                    AUDIENCE_INT_EXACT_ID,
                     AUDIENCE_DOUBLE_ID
             ),
             ProjectConfigTestUtils.createListOfObjects(
@@ -1173,6 +1186,7 @@ public class ValidProjectConfigV4 {
 
         List<Audience> typedAudiences = new ArrayList<Audience>();
         typedAudiences.add(TYPED_AUDIENCE_BOOL);
+        typedAudiences.add(TYPED_AUDIENCE_EXACT_INT);
         typedAudiences.add(TYPED_AUDIENCE_INT);
         typedAudiences.add(TYPED_AUDIENCE_DOUBLE);
         typedAudiences.add(TYPED_AUDIENCE_GRYFFINDOR);

--- a/core-api/src/test/java/com/optimizely/ab/config/audience/AudienceConditionEvaluationTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/audience/AudienceConditionEvaluationTest.java
@@ -208,6 +208,10 @@ public class AudienceConditionEvaluationTest {
         assertNull(testInstanceInteger.evaluate(testTypedUserAttributes));
         assertNull(testInstanceDouble.evaluate(testTypedUserAttributes));
         assertNull(testInstanceNull.evaluate(testTypedUserAttributes));
+        Map<String,Object> attr = new HashMap<>();
+        attr.put("browser_type", "true");
+        assertNull(testInstanceString.evaluate(attr));
+
     }
 
     /**

--- a/core-api/src/test/resources/config/valid-project-config-v4.json
+++ b/core-api/src/test/resources/config/valid-project-config-v4.json
@@ -34,6 +34,11 @@
       "conditions": ["and", ["or", ["or", {"name": "booleanKey", "type": "custom_attribute", "match":"exact", "value":true}]]]
     },
     {
+      "id": "3468206646",
+      "name": "INTEXACT",
+      "conditions": ["and", ["or", ["or", {"name": "integerKey", "type": "custom_attribute", "match":"exact", "value":1.0}]]]
+    },
+    {
       "id": "3468206644",
       "name": "INT",
       "conditions": ["and", ["or", ["or", {"name": "integerKey", "type": "custom_attribute", "match":"gt", "value":1.0}]]]
@@ -182,7 +187,7 @@
           "endOfRange": 10000
         }
       ],
-      "audienceIds": ["3468206643", "3468206644", "3468206645"],
+      "audienceIds": ["3468206643", "3468206644", "3468206646", "3468206645"],
       "forcedVariations": {}
     },
     {


### PR DESCRIPTION
fix(core):Add a new match type for numbers exact match

The object.equals method will use Double.equals and fail if the Number is an Integer.  So, added an explicit ExactNumberMatch to compare actual values.

This fix was relatively small and does not have a large impact.  But, added tests to make sure that "exact" match works for both double and integer.