### PR TITLE
(fix): added unit tests for leaf node parsing

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/config/parser/AudienceJacksonDeserializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/AudienceJacksonDeserializer.java
@@ -48,7 +48,7 @@ public class AudienceJacksonDeserializer extends JsonDeserializer<Audience> {
         JsonNode conditionsJson = node.get("conditions");
         conditionsJson = objectMapper.readTree(conditionsJson.textValue());
 
-        Condition conditions = ConditionJacksonDeserializer.<UserAttribute>parseConditions(UserAttribute.class, objectMapper, conditionsJson);
+        Condition conditions = ConditionJacksonDeserializer.<UserAttribute>parseCondition(UserAttribute.class, objectMapper, conditionsJson);
 
         return new Audience(id, name, conditions);
     }

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/ConditionJacksonDeserializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/ConditionJacksonDeserializer.java
@@ -30,6 +30,7 @@ import com.optimizely.ab.config.audience.EmptyCondition;
 import com.optimizely.ab.config.audience.NullCondition;
 import com.optimizely.ab.config.audience.OrCondition;
 import com.optimizely.ab.config.audience.UserAttribute;
+import com.optimizely.ab.internal.ConditionUtils;
 import com.optimizely.ab.internal.InvalidAudienceCondition;
 
 import java.io.IOException;
@@ -50,7 +51,7 @@ public class ConditionJacksonDeserializer extends JsonDeserializer<Condition> {
     @Override
     public Condition deserialize(JsonParser parser, DeserializationContext context) throws IOException {
         JsonNode node = parser.getCodec().readTree(parser);
-        Condition conditions = ConditionJacksonDeserializer.<AudienceIdCondition>parseConditions(AudienceIdCondition.class, objectMapper, node);
+        Condition conditions = ConditionJacksonDeserializer.<AudienceIdCondition>parseCondition(AudienceIdCondition.class, objectMapper, node);
 
         return conditions;
     }
@@ -69,10 +70,35 @@ public class ConditionJacksonDeserializer extends JsonDeserializer<Condition> {
         }
         return null;
     }
+
+    protected static <T> Condition parseCondition(Class<T> clazz, ObjectMapper objectMapper,JsonNode conditionNode)
+        throws JsonProcessingException, InvalidAudienceCondition {
+        System.out.println("Inside parse condition");
+        System.out.println(conditionNode.getClass().getCanonicalName());
+        System.out.println(conditionNode.toString());
+        if (conditionNode.isArray()) {
+            return ConditionJacksonDeserializer.<T>parseConditions(clazz, objectMapper, conditionNode);
+        } else if (conditionNode.isTextual()) {
+            if (clazz != AudienceIdCondition.class) {
+                throw new InvalidAudienceCondition(String.format("Expected AudienceIdCondition got %s", clazz.getCanonicalName()));
+
+            }
+            return objectMapper.treeToValue(conditionNode, AudienceIdCondition.class);
+        }
+        else if (conditionNode.isObject()) {
+            if (clazz != UserAttribute.class) {
+                throw new InvalidAudienceCondition(String.format("Expected UserAttributes got %s", clazz.getCanonicalName()));
+
+            }
+            return objectMapper.treeToValue(conditionNode, UserAttribute.class);
+        }
+
+        return null;
+    }
     protected static <T> Condition parseConditions(Class<T> clazz, ObjectMapper objectMapper, JsonNode conditionNode)
         throws JsonProcessingException, InvalidAudienceCondition {
 
-        if (conditionNode.size() == 0) {
+        if (conditionNode.isArray() && conditionNode.size() == 0) {
             return new EmptyCondition();
         }
 
@@ -89,22 +115,7 @@ public class ConditionJacksonDeserializer extends JsonDeserializer<Condition> {
 
         for (int i = startingParsingIndex; i < conditionNode.size(); i++) {
             JsonNode subNode = conditionNode.get(i);
-            if (subNode.isArray()) {
-                conditions.add(ConditionJacksonDeserializer.<T>parseConditions(clazz, objectMapper, subNode));
-            } else if (subNode.isTextual()) {
-                if (clazz != AudienceIdCondition.class) {
-                    throw new InvalidAudienceCondition(String.format("Expected AudienceIdCondition got %s", clazz.getCanonicalName()));
-
-                }
-                conditions.add(objectMapper.treeToValue(subNode, AudienceIdCondition.class));
-            }
-            else if (subNode.isObject()) {
-                if (clazz != UserAttribute.class) {
-                    throw new InvalidAudienceCondition(String.format("Expected UserAttributes got %s", clazz.getCanonicalName()));
-
-                }
-                conditions.add(objectMapper.treeToValue(subNode, UserAttribute.class));
-            }
+            conditions.add(ConditionJacksonDeserializer.<T>parseCondition(clazz, objectMapper, subNode));
         }
 
         Condition condition;

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/ConditionJacksonDeserializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/ConditionJacksonDeserializer.java
@@ -73,9 +73,7 @@ public class ConditionJacksonDeserializer extends JsonDeserializer<Condition> {
 
     protected static <T> Condition parseCondition(Class<T> clazz, ObjectMapper objectMapper,JsonNode conditionNode)
         throws JsonProcessingException, InvalidAudienceCondition {
-        System.out.println("Inside parse condition");
-        System.out.println(conditionNode.getClass().getCanonicalName());
-        System.out.println(conditionNode.toString());
+
         if (conditionNode.isArray()) {
             return ConditionJacksonDeserializer.<T>parseConditions(clazz, objectMapper, conditionNode);
         } else if (conditionNode.isTextual()) {

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/GsonHelpers.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/GsonHelpers.java
@@ -113,12 +113,12 @@ final class GsonHelpers {
             List<Object> rawObjectList = gson.fromJson(conditionsElement, List.class);
             return ConditionUtils.<AudienceIdCondition>parseConditions(AudienceIdCondition.class, rawObjectList);
         }
-        else if (conditionsElement.isJsonObject()) {
+        else {
+            System.out.println("we have a object XXX");
             Object jsonObject = gson.fromJson(conditionsElement,Object.class);
             return ConditionUtils.<AudienceIdCondition>parseConditions(AudienceIdCondition.class, jsonObject);
         }
 
-        return null;
     }
 
     static Experiment parseExperiment(JsonObject experimentJson, String groupId, JsonDeserializationContext context) {

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/GsonHelpers.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/GsonHelpers.java
@@ -114,7 +114,6 @@ final class GsonHelpers {
             return ConditionUtils.<AudienceIdCondition>parseConditions(AudienceIdCondition.class, rawObjectList);
         }
         else {
-            System.out.println("we have a object XXX");
             Object jsonObject = gson.fromJson(conditionsElement,Object.class);
             return ConditionUtils.<AudienceIdCondition>parseConditions(AudienceIdCondition.class, jsonObject);
         }

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/TypedAudienceJacksonDeserializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/TypedAudienceJacksonDeserializer.java
@@ -33,7 +33,7 @@ public class TypedAudienceJacksonDeserializer extends JsonDeserializer<TypedAudi
 
         JsonNode conditionsJson = node.get("conditions");
 
-        Condition conditions = ConditionJacksonDeserializer.<UserAttribute>parseConditions(UserAttribute.class, objectMapper, conditionsJson);
+        Condition conditions = ConditionJacksonDeserializer.<UserAttribute>parseCondition(UserAttribute.class, objectMapper, conditionsJson);
 
         return new TypedAudience(id, name, conditions);
     }

--- a/core-api/src/main/java/com/optimizely/ab/internal/ConditionUtils.java
+++ b/core-api/src/main/java/com/optimizely/ab/internal/ConditionUtils.java
@@ -34,6 +34,7 @@ import java.util.Map;
 public class ConditionUtils {
 
     static public <T> Condition parseConditions(Class<T> clazz, Object object) throws InvalidAudienceCondition {
+
         if (object instanceof List) {
             List<Object> objectList = (List<Object>)object;
             return ConditionUtils.<T>parseConditions(clazz, objectList);

--- a/core-api/src/test/java/com/optimizely/ab/config/ValidProjectConfigV4.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/ValidProjectConfigV4.java
@@ -216,6 +216,10 @@ public class ValidProjectConfigV4 {
             new AudienceIdCondition(AUDIENCE_DOUBLE_ID)));
 
     // audienceConditions
+    private static final Condition AUDIENCE_COMBINATION_LEAF_CONDITION =
+            new AudienceIdCondition(AUDIENCE_BOOL_ID);
+
+    // audienceConditions
     private static final Condition AUDIENCE_COMBINATION =
             new OrCondition(Arrays.<Condition>asList(
                 new AudienceIdCondition(AUDIENCE_BOOL_ID),
@@ -555,6 +559,47 @@ public class ValidProjectConfigV4 {
                             10000
                     )
             )
+    );
+    private static final String     LAYER_TYPEDAUDIENCE_LEAF_EXPERIMENT_ID = "1630555629";
+    private static final String     EXPERIMENT_TYPEDAUDIENCE_LEAF_EXPERIMENT_ID = "1323241599";
+    public  static final String     EXPERIMENT_TYPEDAUDIENCE_LEAF_EXPERIMENT_KEY = "typed_audience_experiment_leaf_condition";
+    private static final String     VARIATION_TYPEDAUDIENCE_LEAF_EXPERIMENT_VARIATION_A_ID = "1423767505";
+    private static final String     VARIATION_TYPEDAUDIENCE_LEAF_EXPERIMENT_VARIATION_A_KEY = "A";
+    private static final Variation  VARIATION_TYPEDAUDIENCE_LEAF_EXPERIMENT_VARIATION_A = new Variation(
+        VARIATION_TYPEDAUDIENCE_LEAF_EXPERIMENT_VARIATION_A_ID,
+        VARIATION_TYPEDAUDIENCE_LEAF_EXPERIMENT_VARIATION_A_KEY,
+        Collections.<LiveVariableUsageInstance>emptyList()
+    );
+    private static final String     VARIATION_TYPEDAUDIENCE_LEAF_EXPERIMENT_VARIATION_B_ID = "3433458317";
+    private static final String     VARIATION_TYPEDAUDIENCE_LEAF_EXPERIMENT_VARIATION_B_KEY = "B";
+    private static final Variation  VARIATION_TYPEDAUDIENCE_LEAF_EXPERIMENT_VARIATION_B = new Variation(
+        VARIATION_TYPEDAUDIENCE_LEAF_EXPERIMENT_VARIATION_B_ID,
+        VARIATION_TYPEDAUDIENCE_LEAF_EXPERIMENT_VARIATION_B_KEY,
+        Collections.<LiveVariableUsageInstance>emptyList()
+    );
+
+    private static final Experiment EXPERIMENT_TYPEDAUDIENCE_LEAF_EXPERIMENT = new Experiment(
+        EXPERIMENT_TYPEDAUDIENCE_LEAF_EXPERIMENT_ID,
+        EXPERIMENT_TYPEDAUDIENCE_LEAF_EXPERIMENT_KEY,
+        Experiment.ExperimentStatus.RUNNING.toString(),
+        LAYER_TYPEDAUDIENCE_LEAF_EXPERIMENT_ID,
+        Collections.<String>emptyList(),
+        AUDIENCE_COMBINATION_LEAF_CONDITION,
+        ProjectConfigTestUtils.createListOfObjects(
+            VARIATION_TYPEDAUDIENCE_LEAF_EXPERIMENT_VARIATION_A,
+            VARIATION_TYPEDAUDIENCE_LEAF_EXPERIMENT_VARIATION_B
+        ),
+        Collections.EMPTY_MAP,
+        ProjectConfigTestUtils.createListOfObjects(
+            new TrafficAllocation(
+                VARIATION_TYPEDAUDIENCE_LEAF_EXPERIMENT_VARIATION_A_ID,
+                5000
+            ),
+            new TrafficAllocation(
+                VARIATION_TYPEDAUDIENCE_LEAF_EXPERIMENT_VARIATION_B_ID,
+                10000
+            )
+        )
     );
     private static final String     LAYER_FIRST_GROUPED_EXPERIMENT_ID = "3301900159";
     private static final String     EXPERIMENT_FIRST_GROUPED_EXPERIMENT_ID = "2738374745";
@@ -1282,6 +1327,7 @@ public class ValidProjectConfigV4 {
         experiments.add(EXPERIMENT_BASIC_EXPERIMENT);
         experiments.add(EXPERIMENT_TYPEDAUDIENCE_EXPERIMENT);
         experiments.add(EXPERIMENT_TYPEDAUDIENCE_WITH_AND_EXPERIMENT);
+        experiments.add(EXPERIMENT_TYPEDAUDIENCE_LEAF_EXPERIMENT);
         experiments.add(EXPERIMENT_MULTIVARIATE_EXPERIMENT);
         experiments.add(EXPERIMENT_DOUBLE_FEATURE_EXPERIMENT);
         experiments.add(EXPERIMENT_PAUSED_EXPERIMENT);

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/GsonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/GsonConfigParserTest.java
@@ -95,6 +95,23 @@ public class GsonConfigParserTest {
     }
 
     @Test
+    public void parseAudienceLeaf() throws Exception {
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("id", "123");
+        jsonObject.addProperty("name","blah");
+        jsonObject.addProperty("conditions",
+            "{\"name\": \"doubleKey\", \"type\": \"custom_attribute\", \"match\":\"lt\", \"value\":100.0}");
+
+        AudienceGsonDeserializer deserializer = new AudienceGsonDeserializer();
+        Type audienceType = new TypeToken<List<Audience>>() {}.getType();
+
+        Audience audience = deserializer.deserialize(jsonObject, audienceType, null);
+
+        assertNotNull(audience);
+        assertNotNull(audience.getConditions());
+    }
+
+    @Test
     public void parseInvalidAudience() throws Exception {
         thrown.expect(InvalidAudienceCondition.class);
         JsonObject jsonObject = new JsonObject();

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/GsonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/GsonConfigParserTest.java
@@ -16,6 +16,7 @@
  */
 package com.optimizely.ab.config.parser;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -121,6 +122,21 @@ public class GsonConfigParserTest {
         conditions.add("3");
 
         jsonObject.add("audienceConditions", conditions);
+        Condition condition = GsonHelpers.parseAudienceConditions(jsonObject);
+
+        assertNotNull(condition);
+    }
+
+    @Test
+    public void parseAudienceCondition() throws Exception {
+        JsonObject jsonObject = new JsonObject();
+
+        Gson gson = new Gson();
+
+
+        JsonElement leaf = gson.toJsonTree("1");
+
+        jsonObject.add("audienceConditions", leaf);
         Condition condition = GsonHelpers.parseAudienceConditions(jsonObject);
 
         assertNotNull(condition);

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/GsonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/GsonConfigParserTest.java
@@ -24,6 +24,7 @@ import com.google.gson.reflect.TypeToken;
 import com.optimizely.ab.config.ProjectConfig;
 import com.optimizely.ab.config.audience.Audience;
 import com.optimizely.ab.config.audience.Condition;
+import com.optimizely.ab.config.audience.TypedAudience;
 import com.optimizely.ab.internal.InvalidAudienceCondition;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.Rule;
@@ -83,7 +84,7 @@ public class GsonConfigParserTest {
         jsonObject.addProperty("id", "123");
         jsonObject.addProperty("name","blah");
         jsonObject.addProperty("conditions",
-            "[\"and\", [\"or\", [\"or\", {\"name\": \"doubleKey\", \"type\": \"custom_attribute\", \"match\":\"lt\", \"value\":100.0}]]]");
+            "[\"and\", [\"or\", [\"or\", {\"name\": \"doubleKey\", \"type\": \"custom_attribute\", \"match\":\"exact\", \"value\":100.0}]]]");
 
         AudienceGsonDeserializer deserializer = new AudienceGsonDeserializer();
         Type audienceType = new TypeToken<List<Audience>>() {}.getType();
@@ -100,10 +101,33 @@ public class GsonConfigParserTest {
         jsonObject.addProperty("id", "123");
         jsonObject.addProperty("name","blah");
         jsonObject.addProperty("conditions",
-            "{\"name\": \"doubleKey\", \"type\": \"custom_attribute\", \"match\":\"lt\", \"value\":100.0}");
+            "{\"name\": \"doubleKey\", \"type\": \"custom_attribute\", \"match\":\"exact\", \"value\":100.0}");
 
         AudienceGsonDeserializer deserializer = new AudienceGsonDeserializer();
         Type audienceType = new TypeToken<List<Audience>>() {}.getType();
+
+        Audience audience = deserializer.deserialize(jsonObject, audienceType, null);
+
+        assertNotNull(audience);
+        assertNotNull(audience.getConditions());
+    }
+
+    @Test
+    public void parseTypedAudienceLeaf() throws Exception {
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("id", "123");
+        jsonObject.addProperty("name","blah");
+
+        JsonObject userAttribute = new JsonObject();
+        userAttribute.addProperty("name","doubleKey");
+        userAttribute.addProperty("type", "custom_attribute");
+        userAttribute.addProperty("match", "lt");
+        userAttribute.addProperty("value", 100.0);
+
+        jsonObject.add("conditions", userAttribute);
+
+        AudienceGsonDeserializer deserializer = new AudienceGsonDeserializer();
+        Type audienceType = new TypeToken<List<TypedAudience>>() {}.getType();
 
         Audience audience = deserializer.deserialize(jsonObject, audienceType, null);
 

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/JacksonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/JacksonConfigParserTest.java
@@ -92,6 +92,26 @@ public class JacksonConfigParserTest {
     }
 
     @Test
+    public void parseAudienceLeaf() throws Exception {
+        String audienceString =
+            "{" +
+                "\"id\": \"3468206645\"," +
+                "\"name\": \"DOUBLE\"," +
+                "\"conditions\": \"{\\\"name\\\": \\\"doubleKey\\\", \\\"type\\\": \\\"custom_attribute\\\", \\\"match\\\":\\\"lt\\\", \\\"value\\\":100.0}\"" +
+            "},";
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        SimpleModule module = new SimpleModule();
+        module.addDeserializer(Audience.class, new AudienceJacksonDeserializer(objectMapper));
+        module.addDeserializer(Condition.class, new ConditionJacksonDeserializer(objectMapper));
+        objectMapper.registerModule(module);
+
+        Audience audience = objectMapper.readValue(audienceString, Audience.class);
+        assertNotNull(audience);
+        assertNotNull(audience.getConditions());
+    }
+
+    @Test
     public void parseInvalidAudience() throws Exception {
         thrown.expect(InvalidAudienceCondition.class);
         String audienceString =

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/JacksonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/JacksonConfigParserTest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.optimizely.ab.config.ProjectConfig;
 import com.optimizely.ab.config.audience.Audience;
 import com.optimizely.ab.config.audience.Condition;
+import com.optimizely.ab.config.audience.TypedAudience;
 import com.optimizely.ab.internal.InvalidAudienceCondition;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.Rule;
@@ -107,6 +108,26 @@ public class JacksonConfigParserTest {
         objectMapper.registerModule(module);
 
         Audience audience = objectMapper.readValue(audienceString, Audience.class);
+        assertNotNull(audience);
+        assertNotNull(audience.getConditions());
+    }
+
+    @Test
+    public void parseTypedAudienceLeaf() throws Exception {
+        String audienceString =
+            "{" +
+                "\"id\": \"3468206645\"," +
+                "\"name\": \"DOUBLE\"," +
+                "\"conditions\": {\"name\": \"doubleKey\", \"type\": \"custom_attribute\", \"match\":\"lt\", \"value\":100.0}" +
+                "},";
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        SimpleModule module = new SimpleModule();
+        module.addDeserializer(TypedAudience.class, new TypedAudienceJacksonDeserializer(objectMapper));
+        module.addDeserializer(Condition.class, new ConditionJacksonDeserializer(objectMapper));
+        objectMapper.registerModule(module);
+
+        Audience audience = objectMapper.readValue(audienceString, TypedAudience.class);
         assertNotNull(audience);
         assertNotNull(audience.getConditions());
     }

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/JacksonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/JacksonConfigParserTest.java
@@ -114,6 +114,20 @@ public class JacksonConfigParserTest {
     }
 
     @Test
+    public void parseAudienceCondition() throws Exception {
+        String conditionString = "\"123\"";
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        SimpleModule module = new SimpleModule();
+        module.addDeserializer(Audience.class, new AudienceJacksonDeserializer(objectMapper));
+        module.addDeserializer(Condition.class, new ConditionJacksonDeserializer(objectMapper));
+        objectMapper.registerModule(module);
+
+        Condition condition = objectMapper.readValue(conditionString, Condition.class);
+        assertNotNull(condition);
+    }
+
+    @Test
     public void parseAudienceConditions() throws Exception {
         String conditionString =
             "[\"and\", \"12\", \"123\"]";

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/JsonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/JsonConfigParserTest.java
@@ -101,6 +101,14 @@ public class JsonConfigParserTest {
     }
 
     @Test
+    public void parseAudienceCondition() throws Exception {
+        String conditions = "1";
+
+        Condition condition = ConditionUtils.parseConditions(AudienceIdCondition.class, conditions);
+        assertNotNull(condition);
+    }
+
+    @Test
     public void parseAudienceConditions() throws Exception {
         JSONArray conditions = new JSONArray();
         conditions.put("and");

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/JsonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/JsonConfigParserTest.java
@@ -97,7 +97,7 @@ public class JsonConfigParserTest {
         jsonObject.append("conditions",
             "{\"name\": \"doubleKey\", \"type\": \"custom_attribute\", \"match\":\"lt\", \"value\":100.0}");
 
-        Condition<UserAttribute> condition = ConditionUtils.parseConditions(UserAttribute.class, new JSONArray("[\"and\", [\"or\", [\"or\", {\"name\": \"doubleKey\", \"type\": \"custom_attribute\", \"match\":\"lt\", \"value\":100.0}]]]"));
+        Condition<UserAttribute> condition = ConditionUtils.parseConditions(UserAttribute.class, new JSONObject("{\"name\": \"doubleKey\", \"type\": \"custom_attribute\", \"match\":\"lt\", \"value\":100.0}"));
 
         assertNotNull(condition);
     }

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/JsonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/JsonConfigParserTest.java
@@ -89,6 +89,20 @@ public class JsonConfigParserTest {
     }
 
     @Test
+    public void parseAudienceLeaf() throws Exception {
+        JSONObject jsonObject = new JSONObject();
+
+        jsonObject.append("id", "123");
+        jsonObject.append("name","blah");
+        jsonObject.append("conditions",
+            "{\"name\": \"doubleKey\", \"type\": \"custom_attribute\", \"match\":\"lt\", \"value\":100.0}");
+
+        Condition<UserAttribute> condition = ConditionUtils.parseConditions(UserAttribute.class, new JSONArray("[\"and\", [\"or\", [\"or\", {\"name\": \"doubleKey\", \"type\": \"custom_attribute\", \"match\":\"lt\", \"value\":100.0}]]]"));
+
+        assertNotNull(condition);
+    }
+
+    @Test
     public void parseInvalidAudience() throws Exception {
         thrown.expect(InvalidAudienceCondition.class);
         JSONObject jsonObject = new JSONObject();

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/JsonSimpleConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/JsonSimpleConfigParserTest.java
@@ -113,6 +113,14 @@ public class JsonSimpleConfigParserTest {
     }
 
     @Test
+    public void parseAudienceCondition() throws Exception {
+        String conditions = "1";
+
+        Condition condition = ConditionUtils.parseConditions(AudienceIdCondition.class, conditions);
+        assertNotNull(condition);
+    }
+
+    @Test
     public void parseInvalidAudienceConditions() throws Exception {
         thrown.expect(InvalidAudienceCondition.class);
 

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/JsonSimpleConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/JsonSimpleConfigParserTest.java
@@ -89,6 +89,20 @@ public class JsonSimpleConfigParserTest {
     }
 
     @Test
+    public void parseAudienceLeaf() throws Exception {
+        JSONObject jsonObject = new JSONObject();
+
+        jsonObject.append("id", "123");
+        jsonObject.append("name","blah");
+        jsonObject.append("conditions",
+            "{\"name\": \"doubleKey\", \"type\": \"custom_attribute\", \"match\":\"lt\", \"value\":100.0}");
+
+        Condition<UserAttribute> condition = ConditionUtils.parseConditions(UserAttribute.class, new JSONArray("[\"and\", [\"or\", [\"or\", {\"name\": \"doubleKey\", \"type\": \"custom_attribute\", \"match\":\"lt\", \"value\":100.0}]]]"));
+
+        assertNotNull(condition);
+    }
+
+    @Test
     public void parseInvalidAudience() throws Exception {
         thrown.expect(InvalidAudienceCondition.class);
         JSONObject jsonObject = new JSONObject();

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/JsonSimpleConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/JsonSimpleConfigParserTest.java
@@ -97,7 +97,7 @@ public class JsonSimpleConfigParserTest {
         jsonObject.append("conditions",
             "{\"name\": \"doubleKey\", \"type\": \"custom_attribute\", \"match\":\"lt\", \"value\":100.0}");
 
-        Condition<UserAttribute> condition = ConditionUtils.parseConditions(UserAttribute.class, new JSONArray("[\"and\", [\"or\", [\"or\", {\"name\": \"doubleKey\", \"type\": \"custom_attribute\", \"match\":\"lt\", \"value\":100.0}]]]"));
+        Condition<UserAttribute> condition = ConditionUtils.parseConditions(UserAttribute.class, new JSONObject("{\"name\": \"doubleKey\", \"type\": \"custom_attribute\", \"match\":\"lt\", \"value\":100.0}"));
 
         assertNotNull(condition);
     }

--- a/core-api/src/test/resources/config/valid-project-config-v4.json
+++ b/core-api/src/test/resources/config/valid-project-config-v4.json
@@ -223,6 +223,37 @@
       "forcedVariations": {}
     },
     {
+      "id": "1323241599",
+      "key": "typed_audience_experiment_leaf_condition",
+      "layerId": "1630555629",
+      "status": "Running",
+      "variations": [
+        {
+          "id": "1423767505",
+          "key": "A",
+          "variables": []
+        },
+        {
+          "id": "3433458317",
+          "key": "B",
+          "variables": []
+        }
+      ],
+      "trafficAllocation": [
+        {
+          "entityId": "1423767505",
+          "endOfRange": 5000
+        },
+        {
+          "entityId": "3433458317",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions" : "3468206643",
+      "forcedVariations": {}
+    },
+    {
       "id": "3262035800",
       "key": "multivariate_experiment",
       "layerId": "3262035800",


### PR DESCRIPTION
## Summary
- After adding some compatibility tests, we discovered there were some errors in single leaf processing.  Fixed those and added tests.

## Test plan
Added unit tests in all json parsers for single leaf parsing.  
Added a single leaf node in the datafile and have all parsers parse it the same.

## Issues
- Java SDK was failing compatibility tests.