### PR TITLE
(fix) have the buffer reader call wrapped in a try catch in case of exception

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/event/internal/BuildVersionInfo.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/BuildVersionInfo.java
@@ -37,18 +37,22 @@ public final class BuildVersionInfo {
 
     public final static String VERSION = readVersionNumber();
     private static String readVersionNumber() {
-        BufferedReader bufferedReader =
-            new BufferedReader(
-                new InputStreamReader(BuildVersionInfo.class.getResourceAsStream("/optimizely-build-version"),
-                                      Charset.forName("UTF-8")));
+        BufferedReader bufferedReader = null;
         try {
+            bufferedReader =
+                new BufferedReader(
+                    new InputStreamReader(BuildVersionInfo.class.getResourceAsStream("/optimizely-build-version"),
+                        Charset.forName("UTF-8")));
+
             return bufferedReader.readLine();
         } catch (Exception e) {
             logger.error("unable to read version number");
             return "unknown";
         } finally {
             try {
-                bufferedReader.close();
+                if (bufferedReader != null) {
+                    bufferedReader.close();
+                }
             } catch (Exception e) {
                 logger.error("unable to close reader cleanly");
             }


### PR DESCRIPTION
## Summary
- A customer found an exception when BuilderVersion is being read.  It  seems to be an class initialization issue.  So, we are wrapping it in a try catch and logging the error before returning version unknown.

The "why", or other context.

## Test plan
No additional tests were written.

## Issues
- customer found issue