### PR TITLE
Better way to configure ExhaustiveTest JUnit category

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,18 +84,8 @@ subprojects {
     }
 
     test {
-        useJUnit {
-            excludeCategories 'com.optimizely.ab.categories.ExhaustiveTest'
-        }
-
         testLogging {
             showStandardStreams = false
-        }
-    }
-
-    task exhaustiveTest(type: Test) {
-        useJUnit {
-            includeCategories 'com.optimizely.ab.categories.ExhaustiveTest'
         }
     }
 

--- a/core-api/build.gradle
+++ b/core-api/build.gradle
@@ -12,6 +12,18 @@ dependencies {
     compileOnly group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion, optional
 }
 
+test {
+    useJUnit {
+        excludeCategories 'com.optimizely.ab.categories.ExhaustiveTest'
+    }
+}
+
+task exhaustiveTest(type: Test) {
+    useJUnit {
+        includeCategories 'com.optimizely.ab.categories.ExhaustiveTest'
+    }
+}
+
 task generateVersionFile {
     // add the build version information into a file that'll go into the distribution
     ext.buildVersion = new File(projectDir, "src/main/resources/optimizely-build-version")

--- a/core-httpclient-impl/build.gradle
+++ b/core-httpclient-impl/build.gradle
@@ -1,6 +1,5 @@
 dependencies {
     compile project(':core-api')
-    testCompile project(':core-api').sourceSets.test.output
 
     compileOnly group: 'com.google.code.gson', name: 'gson', version: gsonVersion
 


### PR DESCRIPTION
## Summary

The `com.optimizely.ab.categories.ExhaustiveTest` JUnit test category
marker is defined in the core-api subproject. It is also only used in the
core-api subproject.

Isolate the configuration to use this class to the core-api subproject
by moving out of the root `build.gradle`. This way, we can remove
core-api's testSources as a dependency of core-httpclient-impl's
testSources, as well as any additional subprojects that are added to
this repository.

Bringing this up because I noticed the following:
*   If you create a subproject (experimenting in a local branch), you won't 
    be able to run tests because a `ClassNotFound` exception gets thrown
    because root `build.gradle` prescribes this JUnit config to all `subprojects`
*  I noticed that core-httpclient-impl compiles every time you modify test in core-api. 
    That's because core-httpclient-impl depends on core-api's test sources.
    And it's not immediately obvious why. Working around the misplaced
    `test.useJUnit.excludeCategories` configuration seems to be the only explanation.

If we want to use `ExhaustiveTest` in both core-api and core-httpclient-impl,
or share any common testing logic, we should put it in its own source set that
is shared.