### PR TITLE
Add openjdk7 to test matrix. Remove oraclejdk8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: java
 dist: trusty
 jdk:
+  - openjdk7
   - openjdk8
-  - oraclejdk8
   - oraclejdk9
 install: true
 addons:


### PR DESCRIPTION
# Summary

Build and test against jdk7 since that's what is configured for target
and source compatibility.

Swap `oraclejdk8` with `openjdk7` because its a not essential to have
both `oraclejdk8` and `openjdk8` and to keep the test matrix minimal.
Happy to undo this change or move it to a separate PR.