### PR TITLE
Automate license headers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,11 @@ Refer to the [Google Java Style Guide](https://google.github.io/styleguide/javag
 
 ## License
 
-All contributions are under the CLA mentioned above. For this project, Optimizely uses the Apache 2.0 license, and so asks that by contributing your code, you agree to license your contribution under the terms of the [Apache License v2.0](http://www.apache.org/licenses/LICENSE-2.0). Your contributions should also include the following header:
+All contributions are under the CLA mentioned above.
+
+For this project, Optimizely uses the Apache 2.0 license, and so asks that by contributing your code, you agree to license your contribution under the terms of the [Apache License v2.0](http://www.apache.org/licenses/LICENSE-2.0).
+
+Your contributions should also include the following header:
 
 ```
 /****************************************************************************
@@ -48,6 +52,10 @@ All contributions are under the CLA mentioned above. For this project, Optimizel
  ```
 
 The YEAR above should be the year of the contribution. If work on the file has been done over multiple years, list each year in the section above. Example: Optimizely writes the file and releases it in 2014. No changes are made in 2015. Change made in 2016. YEAR should be “2014, 2016”.
+
+This project contains Gradle tasks that check the correct license header exists
+in each file. Contributors can use the `./gradlew licenseFormat` command to
+automatically insert missing license headers.
 
 ## Contact
 

--- a/build.gradle
+++ b/build.gradle
@@ -91,9 +91,6 @@ subprojects {
         }
     }
 
-    check.finalizedBy licenseMain
-    check.finalizedBy licenseTest
-
     jmh {
         duplicateClassesStrategy = 'warn'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -91,8 +91,8 @@ subprojects {
         }
     }
 
-    check.dependsOn licenseMain
-    check.dependsOn licenseTest
+    check.finalizedBy licenseMain
+    check.finalizedBy licenseTest
 
     jmh {
         duplicateClassesStrategy = 'warn'

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ plugins {
     id 'jacoco'
     id 'me.champeau.gradle.jmh' version '0.4.5'
     id 'nebula.optional-base' version '3.2.0'
+    id 'com.github.hierynomus.license' version '0.15.0'
 }
 
 allprojects {
@@ -49,6 +50,7 @@ subprojects {
     apply plugin: 'maven-publish'
     apply plugin: 'me.champeau.gradle.jmh'
     apply plugin: 'nebula.optional-base'
+    apply plugin: 'com.github.hierynomus.license'
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
@@ -88,6 +90,9 @@ subprojects {
             showStandardStreams = false
         }
     }
+
+    check.dependsOn licenseMain
+    check.dependsOn licenseTest
 
     jmh {
         duplicateClassesStrategy = 'warn'
@@ -146,6 +151,14 @@ subprojects {
                 }
             }
         }
+    }
+
+    license {
+        header = rootProject.file("resources/HEADER")
+        skipExistingHeaders = true
+        include "**/*.java"
+        ext.author = "Optimizely"
+        ext.year = Calendar.getInstance().get(Calendar.YEAR)
     }
 
     def bintrayName = 'core-api';

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/EmptyCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/EmptyCondition.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2019, Optimizely Inc. and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package com.optimizely.ab.config.audience;
 
 import com.optimizely.ab.config.ProjectConfig;

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/NullCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/NullCondition.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2019, Optimizely Inc. and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package com.optimizely.ab.config.audience;
 
 import com.optimizely.ab.config.ProjectConfig;

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/TypedAudienceJacksonDeserializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/TypedAudienceJacksonDeserializer.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2019, Optimizely Inc. and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package com.optimizely.ab.config.parser;
 
 import com.fasterxml.jackson.core.JsonParser;

--- a/core-api/src/test/java/com/optimizely/ab/internal/LogbackVerifier.java
+++ b/core-api/src/test/java/com/optimizely/ab/internal/LogbackVerifier.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2019, Optimizely Inc. and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package com.optimizely.ab.internal;
 
 import ch.qos.logback.classic.Level;

--- a/resources/HEADER
+++ b/resources/HEADER
@@ -1,4 +1,4 @@
-   Copyright ${year}, Optimizely and contributors
+   Copyright ${year}, Optimizely Inc. and contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/resources/HEADER
+++ b/resources/HEADER
@@ -1,0 +1,13 @@
+   Copyright ${year}, Optimizely and contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
Adds the [`com.github.hierynomus.license`][plugin] Gradle plugin that will verify
all source files have license header when the `check` task runs (i.e. tests).

The plugin will handle adding headers to files that are missing it (i.e.
check failures) by running the `licenseFormatMain` or `licenseFormatTest` task,
depending on which source set the file belongs to.

See [plugin][] documentation for more information.

[plugin]: https://github.com/hierynomus/license-gradle-plugin