### PR TITLE
Catch errors thrown while sending notifications.

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/notification/NotificationCenter.java
+++ b/core-api/src/main/java/com/optimizely/ab/notification/NotificationCenter.java
@@ -90,9 +90,9 @@ public class NotificationCenter {
     public NotificationCenter() {
         AtomicInteger counter = new AtomicInteger();
         Map<Class, NotificationManager> validManagers = new HashMap<>();
-        validManagers.put(ActivateNotification.class, new NotificationManager<ActivateNotification>(counter));
-        validManagers.put(TrackNotification.class, new NotificationManager<TrackNotification>(counter));
-        validManagers.put(DecisionNotification.class, new NotificationManager<DecisionNotification>(counter));
+        validManagers.put(ActivateNotification.class, new NotificationManager<>(ActivateNotification.class, counter));
+        validManagers.put(TrackNotification.class, new NotificationManager<>(TrackNotification.class, counter));
+        validManagers.put(DecisionNotification.class, new NotificationManager<>(DecisionNotification.class, counter));
 
         notifierMap = Collections.unmodifiableMap(validManagers);
     }

--- a/core-api/src/main/java/com/optimizely/ab/notification/NotificationManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/notification/NotificationManager.java
@@ -35,8 +35,10 @@ public class NotificationManager<T> {
 
     private final Map<Integer, NotificationHandler<T>> handlers = new LinkedHashMap<>();
     private final AtomicInteger counter;
+    private final Class<T> clazz;
 
-    NotificationManager(AtomicInteger counter) {
+    NotificationManager(Class<T> clazz, AtomicInteger counter) {
+        this.clazz = clazz;
         this.counter = counter;
     }
 
@@ -56,9 +58,13 @@ public class NotificationManager<T> {
         return notificationId;
     }
 
-    public void send(T message) {
-        for (NotificationHandler<T> handler: handlers.values()) {
-            handler.handle(message);
+    void send(T message) {
+        for (Map.Entry<Integer, NotificationHandler<T>> handler: handlers.entrySet()) {
+            try {
+                handler.getValue().handle(message);
+            } catch (Exception e) {
+                logger.warn("Catching exception sending notification for class: {}, handler: {}", clazz, handler.getKey());
+            }
         }
     }
 

--- a/core-api/src/test/java/com/optimizely/ab/notification/NotificationManagerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/notification/NotificationManagerTest.java
@@ -32,14 +32,14 @@ public class NotificationManagerTest {
     @Before
     public void setUp() {
         counter = new AtomicInteger();
-        notificationManager = new NotificationManager<>(counter);
+        notificationManager = new NotificationManager<>(TestNotification.class, counter);
     }
 
     @Test
     public void testAddListener() {
-        assertEquals(1, notificationManager.addHandler(new TestNotificationHandler()));
-        assertEquals(2, notificationManager.addHandler(new TestNotificationHandler()));
-        assertEquals(3, notificationManager.addHandler(new TestNotificationHandler()));
+        assertEquals(1, notificationManager.addHandler(new TestNotificationHandler<>()));
+        assertEquals(2, notificationManager.addHandler(new TestNotificationHandler<>()));
+        assertEquals(3, notificationManager.addHandler(new TestNotificationHandler<>()));
     }
 
     @Test
@@ -56,6 +56,18 @@ public class NotificationManagerTest {
         assertEquals("message1", messages.get(0).getMessage());
         assertEquals("message2", messages.get(1).getMessage());
         assertEquals("message3", messages.get(2).getMessage());
+    }
 
+    @Test
+    public void testSendWithError() {
+        TestNotificationHandler<TestNotification> handler = new TestNotificationHandler<>();
+        assertEquals(1, notificationManager.addHandler(message -> {throw new RuntimeException("handle me");}));
+        assertEquals(2, notificationManager.addHandler(handler));
+
+        notificationManager.send(new TestNotification("message1"));
+
+        List<TestNotification> messages = handler.getMessages();
+        assertEquals(1, messages.size());
+        assertEquals("message1", messages.get(0).getMessage());
     }
 }


### PR DESCRIPTION
## Summary
- Catch all exceptions thrown from NotificationHandlers.

This fixes a regression in #288 refactor when a `NotificationHandler` throws an error.