### PR TITLE
Making Optimizely Autocloseable

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -122,17 +122,24 @@ public class Optimizely implements AutoCloseable {
    * are Closeable {@link Closeable} and calls close on them.
    *
    * <b>NOTE:</b> There is a chance that this could be long running if the implementations of close are long running.
-   *
-   * @throws IOException
    */
   @Override
-    public void close() throws IOException {
+    public void close() {
         if (eventHandler instanceof Closeable) {
-            ((Closeable) eventHandler).close();
+            try {
+                ((Closeable) eventHandler).close();
+            } catch (Exception e) {
+                logger.warn("Unexpected exception on trying to close event handler.");
+            }
+
         }
 
         if (projectConfigManager instanceof Closeable) {
-            ((Closeable) projectConfigManager).close();
+            try {
+                ((Closeable) projectConfigManager).close();
+            } catch (Exception e) {
+                logger.warn("Unexpected exception on trying to close config manager.");
+            }
         }
     }
 

--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -38,7 +38,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import java.io.Closeable;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -117,30 +116,31 @@ public class Optimizely implements AutoCloseable {
         return getProjectConfig() != null;
     }
 
-  /**
-   * Checks if eventHandler {@link EventHandler} and projectConfigManager {@link ProjectConfigManager}
-   * are Closeable {@link Closeable} and calls close on them.
-   *
-   * <b>NOTE:</b> There is a chance that this could be long running if the implementations of close are long running.
-   */
-  @Override
+    /**
+     * Helper method which checks if Object is an instance of Closeable and calls close() on it.
+     */
+    private void tryClose(Object obj) {
+        if (!(obj instanceof Closeable)) {
+            return;
+        }
+
+        try {
+            ((Closeable) obj).close();
+        } catch (Exception e) {
+            logger.warn("Unexpected exception on trying to close {}.", obj);
+        }
+    }
+
+    /**
+     * Checks if eventHandler {@link EventHandler} and projectConfigManager {@link ProjectConfigManager}
+     * are Closeable {@link Closeable} and calls close on them.
+     *
+     * <b>NOTE:</b> There is a chance that this could be long running if the implementations of close are long running.
+     */
+    @Override
     public void close() {
-        if (eventHandler instanceof Closeable) {
-            try {
-                ((Closeable) eventHandler).close();
-            } catch (Exception e) {
-                logger.warn("Unexpected exception on trying to close event handler.");
-            }
-
-        }
-
-        if (projectConfigManager instanceof Closeable) {
-            try {
-                ((Closeable) projectConfigManager).close();
-            } catch (Exception e) {
-                logger.warn("Unexpected exception on trying to close config manager.");
-            }
-        }
+        tryClose(eventHandler);
+        tryClose(projectConfigManager);
     }
 
     //======== activate calls ========//

--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -117,14 +117,22 @@ public class Optimizely implements AutoCloseable {
         return getProjectConfig() != null;
     }
 
-    @Override
+  /**
+   * Checks if eventHandler {@link EventHandler} and projectConfigManager {@link ProjectConfigManager}
+   * are Closeable {@link Closeable} and calls the close on them.
+   *
+   * <b>NOTE:</b> There is a chance that this could be long running if the implementations of close are long running.
+   *
+   * @throws IOException
+   */
+  @Override
     public void close() throws IOException {
-        if (this.eventHandler instanceof Closeable) {
-            ((Closeable) this.eventHandler).close();
+        if (eventHandler instanceof Closeable) {
+            ((Closeable) eventHandler).close();
         }
 
-        if (this.projectConfigManager instanceof Closeable) {
-            ((Closeable) this.projectConfigManager).close();
+        if (projectConfigManager instanceof Closeable) {
+            ((Closeable) projectConfigManager).close();
         }
     }
 

--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -119,7 +119,7 @@ public class Optimizely implements AutoCloseable {
 
   /**
    * Checks if eventHandler {@link EventHandler} and projectConfigManager {@link ProjectConfigManager}
-   * are Closeable {@link Closeable} and calls the close on them.
+   * are Closeable {@link Closeable} and calls close on them.
    *
    * <b>NOTE:</b> There is a chance that this could be long running if the implementations of close are long running.
    *

--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -37,6 +37,8 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -69,7 +71,7 @@ import java.util.Map;
  * to be logged, and for the "control" variation to be returned.
  */
 @ThreadSafe
-public class Optimizely {
+public class Optimizely implements AutoCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(Optimizely.class);
 
@@ -113,6 +115,17 @@ public class Optimizely {
      */
     public boolean isValid() {
         return getProjectConfig() != null;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (this.eventHandler instanceof Closeable) {
+            ((Closeable) this.eventHandler).close();
+        }
+
+        if (this.projectConfigManager instanceof Closeable) {
+            ((Closeable) this.projectConfigManager).close();
+        }
     }
 
     //======== activate calls ========//

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -54,9 +54,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static com.optimizely.ab.config.DatafileProjectConfigTestUtils.*;
 import static com.optimizely.ab.config.ValidProjectConfigV4.*;
@@ -64,8 +61,6 @@ import static com.optimizely.ab.event.LogEvent.RequestMethod;
 import static com.optimizely.ab.notification.DecisionNotification.ExperimentDecisionNotificationBuilder.EXPERIMENT_KEY;
 import static com.optimizely.ab.notification.DecisionNotification.ExperimentDecisionNotificationBuilder.VARIATION_KEY;
 import static com.optimizely.ab.notification.DecisionNotification.FeatureVariableDecisionNotificationBuilder.*;
-import static com.optimizely.ab.notification.DecisionNotification.ExperimentDecisionNotificationBuilder.EXPERIMENT_KEY;
-import static com.optimizely.ab.notification.DecisionNotification.ExperimentDecisionNotificationBuilder.VARIATION_KEY;
 import static java.util.Arrays.asList;
 import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.CoreMatchers.is;
@@ -114,10 +109,6 @@ public class OptimizelyTest {
     @Rule
     public LogbackVerifier logbackVerifier = new LogbackVerifier();
 
-    @Mock(extraInterfaces = Closeable.class)
-    EventHandler mockCloseableEventHandler;
-    @Mock(extraInterfaces = Closeable.class)
-    ProjectConfigManager mockCloseableProjectConfigManager;
     @Mock
     EventHandler mockEventHandler;
     @Mock
@@ -151,18 +142,6 @@ public class OptimizelyTest {
         //assertEquals(validProjectConfig.getVersion(), noAudienceProjectConfig.getVersion());
 
         this.datafileVersion = Integer.parseInt(validProjectConfig.getVersion());
-    }
-
-    @Test
-    public void testClose() throws IOException {
-        Optimizely optimizely = Optimizely.builder()
-            .withEventHandler(mockCloseableEventHandler)
-            .withConfigManager(mockCloseableProjectConfigManager)
-            .build();
-
-        optimizely.close();
-        verify(mockCloseableEventHandler).close();
-        verify(mockCloseableProjectConfigManager).close();
     }
 
     //======== activate tests ========//

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -45,7 +45,6 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import javax.annotation.Nonnull;
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -166,6 +166,22 @@ public class OptimizelyTest {
         verify((Closeable) mockCloseableProjectConfigManager).close();
     }
 
+    @Test(expected = IOException.class)
+    public void testCloseExceptionThrown() throws IOException {
+        ProjectConfigManager mockCloseableProjectConfigManager = mock(
+            ProjectConfigManager.class,
+            withSettings().extraInterfaces(Closeable.class)
+        );
+
+        doThrow(new IOException()).when((Closeable) mockCloseableProjectConfigManager).close();
+
+        Optimizely optimizely = Optimizely.builder()
+            .withEventHandler(mockEventHandler)
+            .withConfigManager(mockCloseableProjectConfigManager)
+            .build();
+
+        optimizely.close();
+    }
     //======== activate tests ========//
 
     /**

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -183,7 +183,7 @@ public class OptimizelyTest {
             .build();
 
         doThrow(new IOException()).when((Closeable) mockCloseableProjectConfigManager).close();
-        logbackVerifier.expectMessage(Level.WARN, "Unexpected exception on trying to close config manager.");
+        logbackVerifier.expectMessage(Level.WARN, "Unexpected exception on trying to close " + mockCloseableProjectConfigManager + ".");
         optimizely.close();
     }
 
@@ -204,7 +204,7 @@ public class OptimizelyTest {
             .build();
 
         doThrow(new IOException()).when((Closeable) mockCloseableEventHandler).close();
-        logbackVerifier.expectMessage(Level.WARN, "Unexpected exception on trying to close event handler.");
+        logbackVerifier.expectMessage(Level.WARN, "Unexpected exception on trying to close " + mockCloseableEventHandler + ".");
         optimizely.close();
     }
 

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -166,22 +166,48 @@ public class OptimizelyTest {
         verify((Closeable) mockCloseableProjectConfigManager).close();
     }
 
-    @Test(expected = IOException.class)
-    public void testCloseExceptionThrown() throws IOException {
+    @Test
+    public void testCloseConfigManagerThrowsException() throws IOException {
+        EventHandler mockCloseableEventHandler = mock(
+            EventHandler.class,
+            withSettings().extraInterfaces(Closeable.class)
+        );
         ProjectConfigManager mockCloseableProjectConfigManager = mock(
             ProjectConfigManager.class,
             withSettings().extraInterfaces(Closeable.class)
         );
 
-        doThrow(new IOException()).when((Closeable) mockCloseableProjectConfigManager).close();
-
         Optimizely optimizely = Optimizely.builder()
-            .withEventHandler(mockEventHandler)
+            .withEventHandler(mockCloseableEventHandler)
             .withConfigManager(mockCloseableProjectConfigManager)
             .build();
 
+        doThrow(new IOException()).when((Closeable) mockCloseableProjectConfigManager).close();
+        logbackVerifier.expectMessage(Level.WARN, "Unexpected exception on trying to close config manager.");
         optimizely.close();
     }
+
+    @Test
+    public void testCloseEventHandlerThrowsException() throws IOException {
+        EventHandler mockCloseableEventHandler = mock(
+            EventHandler.class,
+            withSettings().extraInterfaces(Closeable.class)
+        );
+        ProjectConfigManager mockCloseableProjectConfigManager = mock(
+            ProjectConfigManager.class,
+            withSettings().extraInterfaces(Closeable.class)
+        );
+
+        Optimizely optimizely = Optimizely.builder()
+            .withEventHandler(mockCloseableEventHandler)
+            .withConfigManager(mockCloseableProjectConfigManager)
+            .build();
+
+        doThrow(new IOException()).when((Closeable) mockCloseableEventHandler).close();
+        logbackVerifier.expectMessage(Level.WARN, "Unexpected exception on trying to close event handler.");
+        optimizely.close();
+    }
+
     //======== activate tests ========//
 
     /**

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -45,6 +45,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import javax.annotation.Nonnull;
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -141,6 +142,28 @@ public class OptimizelyTest {
         //assertEquals(validProjectConfig.getVersion(), noAudienceProjectConfig.getVersion());
 
         this.datafileVersion = Integer.parseInt(validProjectConfig.getVersion());
+    }
+
+    @Test
+    public void testClose() throws IOException {
+        EventHandler mockCloseableEventHandler = mock(
+            EventHandler.class,
+            withSettings().extraInterfaces(Closeable.class)
+        );
+        ProjectConfigManager mockCloseableProjectConfigManager = mock(
+            ProjectConfigManager.class,
+            withSettings().extraInterfaces(Closeable.class)
+        );
+
+        Optimizely optimizely = Optimizely.builder()
+            .withEventHandler(mockCloseableEventHandler)
+            .withConfigManager(mockCloseableProjectConfigManager)
+            .build();
+
+        optimizely.close();
+
+        verify((Closeable) mockCloseableEventHandler).close();
+        verify((Closeable) mockCloseableProjectConfigManager).close();
     }
 
     //======== activate tests ========//

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -45,6 +45,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import javax.annotation.Nonnull;
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -113,6 +114,10 @@ public class OptimizelyTest {
     @Rule
     public LogbackVerifier logbackVerifier = new LogbackVerifier();
 
+    @Mock(extraInterfaces = Closeable.class)
+    EventHandler mockCloseableEventHandler;
+    @Mock(extraInterfaces = Closeable.class)
+    ProjectConfigManager mockCloseableProjectConfigManager;
     @Mock
     EventHandler mockEventHandler;
     @Mock
@@ -146,6 +151,18 @@ public class OptimizelyTest {
         //assertEquals(validProjectConfig.getVersion(), noAudienceProjectConfig.getVersion());
 
         this.datafileVersion = Integer.parseInt(validProjectConfig.getVersion());
+    }
+
+    @Test
+    public void testClose() throws IOException {
+        Optimizely optimizely = Optimizely.builder()
+            .withEventHandler(mockCloseableEventHandler)
+            .withConfigManager(mockCloseableProjectConfigManager)
+            .build();
+
+        optimizely.close();
+        verify(mockCloseableEventHandler).close();
+        verify(mockCloseableProjectConfigManager).close();
     }
 
     //======== activate tests ========//


### PR DESCRIPTION
Making Optimizely `Autocloseable` and calling close on `EventHandler` and `ProjectConfigManager` if they are `Closeable` themselves.