### PR TITLE
Fix: Deserializers to parse single leaf node audience condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 Changes that have landed but are not yet released.
 * AudienceJacksonDeserializer: To handle and parse both single leaf node and arraylist of audience conditions.
+* AudienceGsonDeserializer: To handle and parse both single leaf node and arraylist of audience conditions.
+* JsonConfigParser: To handle and parse both single leaf node and arraylist of audience conditions.
+* JsonSimpleConfigParser: To handle and parse both single leaf node and arraylist of audience conditions.
 
 ## 2.1.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Optimizely Java X SDK Changelog
 
+## [Unreleased]
+Changes that have landed but are not yet released.
+* AudienceJacksonDeserializer: To handle and parse both single leaf node and arraylist of audience conditions.
+
 ## 2.1.4
 
 December 6th, 2018

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/AudienceGsonDeserializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/AudienceGsonDeserializer.java
@@ -55,7 +55,7 @@ public class AudienceGsonDeserializer implements JsonDeserializer<Audience> {
         JsonElement conditionsElement = parser.parse(jsonObject.get("conditions").getAsString());
         Object rawObject = gson.fromJson(conditionsElement, Object.class);
         Condition conditions;
-        if (rawObject instanceof ArrayList) {
+        if (rawObject instanceof List) {
             conditions = parseConditions((List<Object>) rawObject);
         } else {
             conditions = parseConditions(rawObject);
@@ -95,7 +95,7 @@ public class AudienceGsonDeserializer implements JsonDeserializer<Audience> {
     private Condition parseConditions(Object rawObject) {
         List<Condition> conditions = new ArrayList<Condition>();
 
-        Map<String, String> conditionMap = (LinkedTreeMap<String, String>) rawObject;
+        Map<String, String> conditionMap = (Map<String, String>) rawObject;
         conditions.add(new UserAttribute(conditionMap.get("name"), conditionMap.get("type"),
                 conditionMap.get("value")));
 

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/AudienceJacksonDeserializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/AudienceJacksonDeserializer.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2016-2017, Optimizely and contributors
+ *    Copyright 2016-2017, 2019, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -44,7 +44,6 @@ public class AudienceJacksonDeserializer extends JsonDeserializer<Audience> {
         String id = node.get("id").textValue();
         String name = node.get("name").textValue();
 
-
         Object rawObject = mapper.readValue(node.get("conditions").textValue(), Object.class);
         Condition conditions;
         if (rawObject instanceof ArrayList) {
@@ -57,17 +56,17 @@ public class AudienceJacksonDeserializer extends JsonDeserializer<Audience> {
 
     private Condition parseConditions(List<Object> rawObjectList) {
         List<Condition> conditions = new ArrayList<Condition>();
-        String operand = (String)rawObjectList.get(0);
+        String operand = (String) rawObjectList.get(0);
 
         for (int i = 1; i < rawObjectList.size(); i++) {
             Object obj = rawObjectList.get(i);
             if (obj instanceof List) {
-                List<Object> objectList = (List<Object>)rawObjectList.get(i);
+                List<Object> objectList = (List<Object>) rawObjectList.get(i);
                 conditions.add(parseConditions(objectList));
             } else {
-                HashMap<String, String> conditionMap = (HashMap<String, String>)rawObjectList.get(i);
+                HashMap<String, String> conditionMap = (HashMap<String, String>) rawObjectList.get(i);
                 conditions.add(new UserAttribute(conditionMap.get("name"), conditionMap.get("type"),
-                               conditionMap.get("value")));
+                        conditionMap.get("value")));
             }
         }
 
@@ -86,7 +85,7 @@ public class AudienceJacksonDeserializer extends JsonDeserializer<Audience> {
     private Condition parseConditions(Object rawObject) {
         List<Condition> conditions = new ArrayList<Condition>();
 
-        HashMap<String, String> conditionMap = (HashMap<String, String>)rawObject;
+        HashMap<String, String> conditionMap = (HashMap<String, String>) rawObject;
         conditions.add(new UserAttribute(conditionMap.get("name"), conditionMap.get("type"),
                 conditionMap.get("value")));
 

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/AudienceJacksonDeserializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/AudienceJacksonDeserializer.java
@@ -43,9 +43,15 @@ public class AudienceJacksonDeserializer extends JsonDeserializer<Audience> {
 
         String id = node.get("id").textValue();
         String name = node.get("name").textValue();
-        List<Object> rawObjectList = (List<Object>)mapper.readValue(node.get("conditions").textValue(), List.class);
-        Condition conditions = parseConditions(rawObjectList);
 
+
+        Object rawObject = mapper.readValue(node.get("conditions").textValue(), Object.class);
+        Condition conditions;
+        if (rawObject instanceof ArrayList) {
+           conditions = parseConditions((List<Object>) rawObject);
+        } else {
+            conditions = parseConditions(rawObject);
+        }
         return new Audience(id, name, conditions);
     }
 
@@ -73,6 +79,18 @@ public class AudienceJacksonDeserializer extends JsonDeserializer<Audience> {
         } else {
             condition = new NotCondition(conditions.get(0));
         }
+
+        return condition;
+    }
+
+    private Condition parseConditions(Object rawObject) {
+        List<Condition> conditions = new ArrayList<Condition>();
+
+        HashMap<String, String> conditionMap = (HashMap<String, String>)rawObject;
+        conditions.add(new UserAttribute(conditionMap.get("name"), conditionMap.get("type"),
+                conditionMap.get("value")));
+
+        Condition condition = new OrCondition(conditions);
 
         return condition;
     }

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/AudienceJacksonDeserializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/AudienceJacksonDeserializer.java
@@ -31,8 +31,8 @@ import com.optimizely.ab.config.audience.OrCondition;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class AudienceJacksonDeserializer extends JsonDeserializer<Audience> {
 
@@ -46,7 +46,7 @@ public class AudienceJacksonDeserializer extends JsonDeserializer<Audience> {
 
         Object rawObject = mapper.readValue(node.get("conditions").textValue(), Object.class);
         Condition conditions;
-        if (rawObject instanceof ArrayList) {
+        if (rawObject instanceof List) {
            conditions = parseConditions((List<Object>) rawObject);
         } else {
             conditions = parseConditions(rawObject);
@@ -64,7 +64,7 @@ public class AudienceJacksonDeserializer extends JsonDeserializer<Audience> {
                 List<Object> objectList = (List<Object>) rawObjectList.get(i);
                 conditions.add(parseConditions(objectList));
             } else {
-                HashMap<String, String> conditionMap = (HashMap<String, String>) rawObjectList.get(i);
+                Map<String, String> conditionMap = (Map<String, String>) rawObjectList.get(i);
                 conditions.add(new UserAttribute(conditionMap.get("name"), conditionMap.get("type"),
                         conditionMap.get("value")));
             }
@@ -85,7 +85,7 @@ public class AudienceJacksonDeserializer extends JsonDeserializer<Audience> {
     private Condition parseConditions(Object rawObject) {
         List<Condition> conditions = new ArrayList<Condition>();
 
-        HashMap<String, String> conditionMap = (HashMap<String, String>) rawObject;
+        Map<String, String> conditionMap = (Map<String, String>) rawObject;
         conditions.add(new UserAttribute(conditionMap.get("name"), conditionMap.get("type"),
                 conditionMap.get("value")));
 

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/JsonConfigParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/JsonConfigParser.java
@@ -38,6 +38,7 @@ import com.optimizely.ab.config.audience.OrCondition;
 import com.optimizely.ab.config.audience.UserAttribute;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.json.JSONTokener;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -271,11 +272,12 @@ final class JsonConfigParser implements ConfigParser {
             String key = audienceObject.getString("name");
             String conditionString = audienceObject.getString("conditions");
             Condition conditions;
-            if (conditionString.startsWith("[")) {
-                JSONArray conditionJsonArray = new JSONArray(conditionString);
+            Object conditionJsonTokener = new JSONTokener(conditionString).nextValue();
+            if (conditionJsonTokener instanceof JSONArray) {
+                JSONArray conditionJsonArray = (JSONArray) conditionJsonTokener;
                 conditions = parseConditions(conditionJsonArray);
             } else {
-                JSONObject conditionJsonObject = new JSONObject(conditionString);
+                JSONObject conditionJsonObject = (JSONObject) conditionJsonTokener;
                 conditions = parseConditions(conditionJsonObject);
             }
             audiences.add(new Audience(id, key, conditions));
@@ -293,8 +295,8 @@ final class JsonConfigParser implements ConfigParser {
             value = conditionMap.getString("value");
         }
         conditions.add(new UserAttribute(
-                (String) conditionMap.get("name"),
-                (String) conditionMap.get("type"),
+                conditionMap.getString("name"),
+                conditionMap.getString("type"),
                 value
         ));
 
@@ -318,8 +320,8 @@ final class JsonConfigParser implements ConfigParser {
                     value = conditionMap.getString("value");
                 }
                 conditions.add(new UserAttribute(
-                        (String)conditionMap.get("name"),
-                        (String)conditionMap.get("type"),
+                        conditionMap.getString("name"),
+                        conditionMap.getString("type"),
                                value
                 ));
             }

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/JsonSimpleConfigParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/JsonSimpleConfigParser.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2016-2018, Optimizely and contributors
+ *    Copyright 2016-2019, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -274,17 +274,33 @@ final class JsonSimpleConfigParser implements ConfigParser {
         List<Audience> audiences = new ArrayList<Audience>(audienceJson.size());
 
         for (Object obj : audienceJson) {
-            JSONObject audienceObject = (JSONObject)obj;
-            String id = (String)audienceObject.get("id");
-            String key = (String)audienceObject.get("name");
-            String conditionString = (String)audienceObject.get("conditions");
+            JSONObject audienceObject = (JSONObject) obj;
+            String id = (String) audienceObject.get("id");
+            String key = (String) audienceObject.get("name");
+            String conditionString = (String) audienceObject.get("conditions");
 
-            JSONArray conditionJson = (JSONArray)parser.parse(conditionString);
-            Condition conditions = parseConditions(conditionJson);
+            Object conditionJson = parser.parse(conditionString);
+            Condition conditions;
+            if (conditionJson instanceof JSONArray) {
+                conditions = parseConditions((JSONArray) conditionJson);
+            } else {
+                conditions = parseConditions((JSONObject) conditionJson);
+            }
             audiences.add(new Audience(id, key, conditions));
         }
 
         return audiences;
+    }
+
+    private Condition parseConditions(JSONObject conditionJson) {
+        List<Condition> conditions = new ArrayList<Condition>();
+
+        conditions.add(new UserAttribute((String) conditionJson.get("name"), (String) conditionJson.get("type"),
+                (String) conditionJson.get("value")));
+
+        Condition condition = new OrCondition(conditions);
+
+        return condition;
     }
 
     private Condition parseConditions(JSONArray conditionJson) {

--- a/core-api/src/test/java/com/optimizely/ab/config/ValidProjectConfigV4.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/ValidProjectConfigV4.java
@@ -114,10 +114,10 @@ public class ValidProjectConfigV4 {
             ))
     );
 
-    private static final String     UNTYPED_SINGLE_CONDITION_LEAF_ID = "10413101795";
-    private static final String     UNTYPED_SINGLE_CONDITION_LEAF_KEY = "untyped_single_condition_leaf_root";
-    public  static final String     UNTYPED_SINGLE_CONDITION_LEAF_VALUE = "leaf_root";
-    private static final Audience   UNTYPED_SINGLE_CONDITION_LEAF = new Audience(
+    private static final String UNTYPED_SINGLE_CONDITION_LEAF_ID = "10413101795";
+    private static final String UNTYPED_SINGLE_CONDITION_LEAF_KEY = "untyped_single_condition_leaf_root";
+    public static final String UNTYPED_SINGLE_CONDITION_LEAF_VALUE = "leaf_root";
+    private static final Audience UNTYPED_SINGLE_CONDITION_LEAF = new Audience(
             UNTYPED_SINGLE_CONDITION_LEAF_ID,
             UNTYPED_SINGLE_CONDITION_LEAF_KEY,
             new OrCondition(Collections.singletonList((Condition) new UserAttribute("string_attribute",

--- a/core-api/src/test/java/com/optimizely/ab/config/ValidProjectConfigV4.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/ValidProjectConfigV4.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2017-2018, Optimizely and contributors
+ *    Copyright 2017-2019, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -112,6 +112,17 @@ public class ValidProjectConfigV4 {
                             ))
                     ))
             ))
+    );
+
+    private static final String     UNTYPED_SINGLE_CONDITION_LEAF_ID = "10413101795";
+    private static final String     UNTYPED_SINGLE_CONDITION_LEAF_KEY = "untyped_single_condition_leaf_root";
+    public  static final String     UNTYPED_SINGLE_CONDITION_LEAF_VALUE = "leaf_root";
+    private static final Audience   UNTYPED_SINGLE_CONDITION_LEAF = new Audience(
+            UNTYPED_SINGLE_CONDITION_LEAF_ID,
+            UNTYPED_SINGLE_CONDITION_LEAF_KEY,
+            new OrCondition(Collections.singletonList((Condition) new UserAttribute("string_attribute",
+                    CUSTOM_DIMENSION_TYPE,
+                    UNTYPED_SINGLE_CONDITION_LEAF_VALUE)))
     );
 
     // features
@@ -1040,6 +1051,7 @@ public class ValidProjectConfigV4 {
         audiences.add(AUDIENCE_SLYTHERIN);
         audiences.add(AUDIENCE_ENGLISH_CITIZENS);
         audiences.add(AUDIENCE_WITH_MISSING_VALUE);
+        audiences.add(UNTYPED_SINGLE_CONDITION_LEAF);
 
         // list events
         List<EventType> events = new ArrayList<EventType>();

--- a/core-api/src/test/resources/config/valid-project-config-v4.json
+++ b/core-api/src/test/resources/config/valid-project-config-v4.json
@@ -25,6 +25,11 @@
       "id": "2196265320",
       "name": "audience_with_missing_value",
       "conditions": "[\"and\", [\"or\", [\"or\", {\"name\": \"nationality\", \"type\": \"custom_dimension\", \"value\": \"English\"}, {\"name\": \"nationality\", \"type\": \"custom_dimension\"}]]]"
+    },
+    {
+      "id": "10413101795",
+      "conditions": "{\"type\": \"custom_dimension\", \"name\": \"string_attribute\", \"match\": \"exact\", \"value\": \"leaf_root\"}",
+      "name": "untyped_single_condition_leaf_root"
     }
   ],
   "attributes": [


### PR DESCRIPTION
## Summary
-  AudienceJacksonDeserializer was throwing exception on parsing single leaf node audience condition due to which datafile was not getting parsed.

## NOTE:
This is to support java sdk 2.1.x branch with latest datafile

## Ticket
- [OASIS-4568](https://optimizely.atlassian.net/browse/OASIS-4568)