### PR TITLE
Fixing how project config is updated. Also, fixing issue in Optimizely.close()

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -214,7 +214,7 @@ public class Optimizely implements AutoCloseable {
         }
         Map<String, ?> copiedAttributes = copyAttributes(attributes);
         // bucket the user to the given experiment and dispatch an impression event
-        Variation variation = getVariation(experiment, userId, copiedAttributes, projectConfig);
+        Variation variation = getVariation(projectConfig, experiment, userId, copiedAttributes);
         if (variation == null) {
             logger.info("Not activating user \"{}\" for experiment \"{}\".", userId, experiment.getKey());
             return null;
@@ -781,14 +781,14 @@ public class Optimizely implements AutoCloseable {
     public Variation getVariation(@Nonnull Experiment experiment,
                                   @Nonnull String userId,
                                   @Nonnull Map<String, ?> attributes) throws UnknownExperimentException {
-        return getVariation(experiment, userId, attributes, getProjectConfig());
+        return getVariation(getProjectConfig(), experiment, userId, attributes);
     }
 
     @Nullable
-    public Variation getVariation(@Nonnull Experiment experiment,
-                                  @Nonnull String userId,
-                                  @Nonnull Map<String, ?> attributes,
-                                  @Nonnull ProjectConfig projectConfig) throws UnknownExperimentException {
+    private Variation getVariation(@Nonnull ProjectConfig projectConfig,
+                                   @Nonnull Experiment experiment,
+                                   @Nonnull String userId,
+                                   @Nonnull Map<String, ?> attributes) throws UnknownExperimentException {
         Map<String, ?> copiedAttributes = copyAttributes(attributes);
         Variation variation = decisionService.getVariation(experiment, userId, copiedAttributes, projectConfig);
 
@@ -843,7 +843,7 @@ public class Optimizely implements AutoCloseable {
             return null;
         }
 
-        return getVariation(experiment, userId, attributes, projectConfig);
+        return getVariation(projectConfig, experiment, userId, attributes);
     }
 
     /**

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -145,14 +145,14 @@ public class OptimizelyTest {
     }
 
     @Test
-    public void testClose() throws IOException {
+    public void testClose() throws Exception {
         EventHandler mockCloseableEventHandler = mock(
             EventHandler.class,
-            withSettings().extraInterfaces(Closeable.class)
+            withSettings().extraInterfaces(AutoCloseable.class)
         );
         ProjectConfigManager mockCloseableProjectConfigManager = mock(
             ProjectConfigManager.class,
-            withSettings().extraInterfaces(Closeable.class)
+            withSettings().extraInterfaces(AutoCloseable.class)
         );
 
         Optimizely optimizely = Optimizely.builder()
@@ -162,19 +162,19 @@ public class OptimizelyTest {
 
         optimizely.close();
 
-        verify((Closeable) mockCloseableEventHandler).close();
-        verify((Closeable) mockCloseableProjectConfigManager).close();
+        verify((AutoCloseable) mockCloseableEventHandler).close();
+        verify((AutoCloseable) mockCloseableProjectConfigManager).close();
     }
 
     @Test
-    public void testCloseConfigManagerThrowsException() throws IOException {
+    public void testCloseConfigManagerThrowsException() throws Exception {
         EventHandler mockCloseableEventHandler = mock(
             EventHandler.class,
-            withSettings().extraInterfaces(Closeable.class)
+            withSettings().extraInterfaces(AutoCloseable.class)
         );
         ProjectConfigManager mockCloseableProjectConfigManager = mock(
             ProjectConfigManager.class,
-            withSettings().extraInterfaces(Closeable.class)
+            withSettings().extraInterfaces(AutoCloseable.class)
         );
 
         Optimizely optimizely = Optimizely.builder()
@@ -182,20 +182,20 @@ public class OptimizelyTest {
             .withConfigManager(mockCloseableProjectConfigManager)
             .build();
 
-        doThrow(new IOException()).when((Closeable) mockCloseableProjectConfigManager).close();
+        doThrow(new IOException()).when((AutoCloseable) mockCloseableProjectConfigManager).close();
         logbackVerifier.expectMessage(Level.WARN, "Unexpected exception on trying to close " + mockCloseableProjectConfigManager + ".");
         optimizely.close();
     }
 
     @Test
-    public void testCloseEventHandlerThrowsException() throws IOException {
+    public void testCloseEventHandlerThrowsException() throws Exception {
         EventHandler mockCloseableEventHandler = mock(
             EventHandler.class,
-            withSettings().extraInterfaces(Closeable.class)
+            withSettings().extraInterfaces(AutoCloseable.class)
         );
         ProjectConfigManager mockCloseableProjectConfigManager = mock(
             ProjectConfigManager.class,
-            withSettings().extraInterfaces(Closeable.class)
+            withSettings().extraInterfaces(AutoCloseable.class)
         );
 
         Optimizely optimizely = Optimizely.builder()
@@ -203,7 +203,7 @@ public class OptimizelyTest {
             .withConfigManager(mockCloseableProjectConfigManager)
             .build();
 
-        doThrow(new IOException()).when((Closeable) mockCloseableEventHandler).close();
+        doThrow(new IOException()).when((AutoCloseable) mockCloseableEventHandler).close();
         logbackVerifier.expectMessage(Level.WARN, "Unexpected exception on trying to close " + mockCloseableEventHandler + ".");
         optimizely.close();
     }
@@ -4852,6 +4852,7 @@ public class OptimizelyTest {
             .withConfig(validProjectConfig)
             .build());
         doReturn(false).when(spyOptimizely).isFeatureEnabled(
+            validProjectConfig,
             any(String.class),
             eq(genericUserId),
             eq(Collections.<String, String>emptyMap())

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -4852,7 +4852,6 @@ public class OptimizelyTest {
             .withConfig(validProjectConfig)
             .build());
         doReturn(false).when(spyOptimizely).isFeatureEnabled(
-            validProjectConfig,
             any(String.class),
             eq(genericUserId),
             eq(Collections.<String, String>emptyMap())

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -146,65 +146,86 @@ public class OptimizelyTest {
 
     @Test
     public void testClose() throws Exception {
-        EventHandler mockCloseableEventHandler = mock(
+        // Check for AutoCloseable
+        EventHandler mockAutoCloseableEventHandler = mock(
             EventHandler.class,
             withSettings().extraInterfaces(AutoCloseable.class)
         );
-        ProjectConfigManager mockCloseableProjectConfigManager = mock(
+        ProjectConfigManager mockAutoCloseableProjectConfigManager = mock(
             ProjectConfigManager.class,
             withSettings().extraInterfaces(AutoCloseable.class)
         );
 
         Optimizely optimizely = Optimizely.builder()
+            .withEventHandler(mockAutoCloseableEventHandler)
+            .withConfigManager(mockAutoCloseableProjectConfigManager)
+            .build();
+
+        optimizely.close();
+
+        verify((AutoCloseable) mockAutoCloseableEventHandler).close();
+        verify((AutoCloseable) mockAutoCloseableProjectConfigManager).close();
+
+        // Check for Closeable
+        EventHandler mockCloseableEventHandler = mock(
+            EventHandler.class,
+            withSettings().extraInterfaces(Closeable.class)
+        );
+        ProjectConfigManager mockCloseableProjectConfigManager = mock(
+            ProjectConfigManager.class,
+            withSettings().extraInterfaces(Closeable.class)
+        );
+
+        optimizely = Optimizely.builder()
             .withEventHandler(mockCloseableEventHandler)
             .withConfigManager(mockCloseableProjectConfigManager)
             .build();
 
         optimizely.close();
 
-        verify((AutoCloseable) mockCloseableEventHandler).close();
-        verify((AutoCloseable) mockCloseableProjectConfigManager).close();
+        verify((Closeable) mockCloseableEventHandler).close();
+        verify((Closeable) mockCloseableProjectConfigManager).close();
     }
 
     @Test
     public void testCloseConfigManagerThrowsException() throws Exception {
-        EventHandler mockCloseableEventHandler = mock(
+        EventHandler mockAutoCloseableEventHandler = mock(
             EventHandler.class,
             withSettings().extraInterfaces(AutoCloseable.class)
         );
-        ProjectConfigManager mockCloseableProjectConfigManager = mock(
+        ProjectConfigManager mockAutoCloseableProjectConfigManager = mock(
             ProjectConfigManager.class,
             withSettings().extraInterfaces(AutoCloseable.class)
         );
 
         Optimizely optimizely = Optimizely.builder()
-            .withEventHandler(mockCloseableEventHandler)
-            .withConfigManager(mockCloseableProjectConfigManager)
+            .withEventHandler(mockAutoCloseableEventHandler)
+            .withConfigManager(mockAutoCloseableProjectConfigManager)
             .build();
 
-        doThrow(new IOException()).when((AutoCloseable) mockCloseableProjectConfigManager).close();
-        logbackVerifier.expectMessage(Level.WARN, "Unexpected exception on trying to close " + mockCloseableProjectConfigManager + ".");
+        doThrow(new IOException()).when((AutoCloseable) mockAutoCloseableProjectConfigManager).close();
+        logbackVerifier.expectMessage(Level.WARN, "Unexpected exception on trying to close " + mockAutoCloseableProjectConfigManager + ".");
         optimizely.close();
     }
 
     @Test
     public void testCloseEventHandlerThrowsException() throws Exception {
-        EventHandler mockCloseableEventHandler = mock(
+        EventHandler mockAutoCloseableEventHandler = mock(
             EventHandler.class,
             withSettings().extraInterfaces(AutoCloseable.class)
         );
-        ProjectConfigManager mockCloseableProjectConfigManager = mock(
+        ProjectConfigManager mockAutoCloseableProjectConfigManager = mock(
             ProjectConfigManager.class,
             withSettings().extraInterfaces(AutoCloseable.class)
         );
 
         Optimizely optimizely = Optimizely.builder()
-            .withEventHandler(mockCloseableEventHandler)
-            .withConfigManager(mockCloseableProjectConfigManager)
+            .withEventHandler(mockAutoCloseableEventHandler)
+            .withConfigManager(mockAutoCloseableProjectConfigManager)
             .build();
 
-        doThrow(new IOException()).when((AutoCloseable) mockCloseableEventHandler).close();
-        logbackVerifier.expectMessage(Level.WARN, "Unexpected exception on trying to close " + mockCloseableEventHandler + ".");
+        doThrow(new IOException()).when((AutoCloseable) mockAutoCloseableEventHandler).close();
+        logbackVerifier.expectMessage(Level.WARN, "Unexpected exception on trying to close " + mockAutoCloseableEventHandler + ".");
         optimizely.close();
     }
 
@@ -2861,9 +2882,9 @@ public class OptimizelyTest {
 
     /**
      * Verify {@link Optimizely#getEnabledFeatures(String, Map)} calls into
-     * {@link Optimizely#isFeatureEnabled(String, String, Map)} for each featureFlag sending
+     * {@link DecisionService#getVariationForFeature} for each featureFlag sending
      * userId and emptyMap and Mocked {@link Optimizely#isFeatureEnabled(String, String, Map)}
-     * to return false so {@link Optimizely#getEnabledFeatures(String, Map)} will
+     * to return feature disabled so {@link Optimizely#getEnabledFeatures(String, Map)} will
      * return empty List of FeatureFlags and no notification listener will get called.
      */
     @Test
@@ -2873,13 +2894,16 @@ public class OptimizelyTest {
         isListenerCalled = false;
         Optimizely spyOptimizely = spy(Optimizely.builder(validDatafile, mockEventHandler)
             .withConfig(validProjectConfig)
+            .withDecisionService(mockDecisionService)
             .build());
-        doReturn(false).when(spyOptimizely).isFeatureEnabled(
-            any(String.class),
-            eq(genericUserId),
-            eq(Collections.<String, String>emptyMap())
-        );
 
+        FeatureDecision featureDecision = new FeatureDecision(null, null, FeatureDecision.DecisionSource.ROLLOUT);
+        doReturn(featureDecision).when(mockDecisionService).getVariationForFeature(
+            any(FeatureFlag.class),
+            anyString(),
+            anyMapOf(String.class, String.class),
+            any(ProjectConfig.class)
+        );
         int notificationId = spyOptimizely.addDecisionNotificationHandler( decisionNotification -> { });
 
         ArrayList<String> featureFlags = (ArrayList<String>) spyOptimizely.getEnabledFeatures(genericUserId,
@@ -4839,23 +4863,27 @@ public class OptimizelyTest {
 
     /**
      * Verify {@link Optimizely#getEnabledFeatures(String, Map)} calls into
-     * {@link Optimizely#isFeatureEnabled(String, String, Map)} for each featureFlag sending
-     * userId and emptyMap and Mocked {@link Optimizely#isFeatureEnabled(String, String, Map)}
-     * to return false so {@link Optimizely#getEnabledFeatures(String, Map)} will
+     * {@link DecisionService#getVariationForFeature} to return feature
+     * disabled so {@link Optimizely#getEnabledFeatures(String, Map)} will
      * return empty List of FeatureFlags.
      */
     @Test
-    public void getEnabledFeatureWithMockIsFeatureEnabledToReturnFalse() throws ConfigParseException {
+    public void getEnabledFeatureWithMockDecisionService() throws ConfigParseException {
         assumeTrue(datafileVersion >= Integer.parseInt(ProjectConfig.Version.V4.toString()));
 
         Optimizely spyOptimizely = spy(Optimizely.builder(validDatafile, mockEventHandler)
             .withConfig(validProjectConfig)
+            .withDecisionService(mockDecisionService)
             .build());
-        doReturn(false).when(spyOptimizely).isFeatureEnabled(
-            any(String.class),
-            eq(genericUserId),
-            eq(Collections.<String, String>emptyMap())
+
+        FeatureDecision featureDecision = new FeatureDecision(null, null, FeatureDecision.DecisionSource.ROLLOUT);
+        doReturn(featureDecision).when(mockDecisionService).getVariationForFeature(
+            any(FeatureFlag.class),
+            anyString(),
+            anyMapOf(String.class, String.class),
+            any(ProjectConfig.class)
         );
+
         ArrayList<String> featureFlags = (ArrayList<String>) spyOptimizely.getEnabledFeatures(genericUserId,
             Collections.<String, String>emptyMap());
         assertTrue(featureFlags.isEmpty());


### PR DESCRIPTION
## Summary
This change fixes:
- `Optimizely.close()` which currently checks that `eventHandler` and `projectConfigManager` are instances of `Closeable`. Changing that to check if they are instances of `AutoCloseable`.
- `ProjectConfig` is refetched every time in `getVariation`. Using the passing in config itself.
- `ProjectConfig` is fetched multiple times when `getEnabledFeatures` is called. Updating `isFeatureEnabled`.

## Test plan
- Unit tests. 
