### PR TITLE
Implement Event Batching Take2

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -1099,10 +1099,8 @@ public class Optimizely implements AutoCloseable {
 
             // For backwards compatibility
             if (eventProcessor == null) {
-                eventProcessor = new ForwardingEventProcessor();
+                eventProcessor = new ForwardingEventProcessor(eventHandler);
             }
-
-            eventProcessor.addHandler(eventHandler::dispatchEvent);
 
             if (projectConfig == null && datafile != null && !datafile.isEmpty()) {
                 try {

--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -139,6 +139,7 @@ public class Optimizely implements AutoCloseable {
      */
     @Override
     public void close() {
+        tryClose(eventProcessor);
         tryClose(eventHandler);
         tryClose(projectConfigManager);
     }
@@ -1099,8 +1100,9 @@ public class Optimizely implements AutoCloseable {
             // For backwards compatibility
             if (eventProcessor == null) {
                 eventProcessor = new ForwardingEventProcessor();
-                eventProcessor.addHandler(eventHandler::dispatchEvent);
             }
+
+            eventProcessor.addHandler(eventHandler::dispatchEvent);
 
             if (projectConfig == null && datafile != null && !datafile.isEmpty()) {
                 try {

--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -24,9 +24,7 @@ import com.optimizely.ab.config.*;
 import com.optimizely.ab.config.parser.ConfigParseException;
 import com.optimizely.ab.error.ErrorHandler;
 import com.optimizely.ab.error.NoOpErrorHandler;
-import com.optimizely.ab.event.EventHandler;
-import com.optimizely.ab.event.LogEvent;
-import com.optimizely.ab.event.NoopEventHandler;
+import com.optimizely.ab.event.*;
 import com.optimizely.ab.event.internal.*;
 import com.optimizely.ab.event.internal.payload.EventBatch;
 import com.optimizely.ab.notification.*;
@@ -78,6 +76,8 @@ public class Optimizely implements AutoCloseable {
     @VisibleForTesting
     final EventHandler eventHandler;
     @VisibleForTesting
+    final EventProcessor eventProcessor;
+    @VisibleForTesting
     final ErrorHandler errorHandler;
 
     private final ProjectConfigManager projectConfigManager;
@@ -89,6 +89,7 @@ public class Optimizely implements AutoCloseable {
     private final UserProfileService userProfileService;
 
     private Optimizely(@Nonnull EventHandler eventHandler,
+                       @Nonnull EventProcessor eventProcessor,
                        @Nonnull ErrorHandler errorHandler,
                        @Nonnull DecisionService decisionService,
                        @Nullable UserProfileService userProfileService,
@@ -96,6 +97,7 @@ public class Optimizely implements AutoCloseable {
                        @Nonnull NotificationCenter notificationCenter
     ) {
         this.eventHandler = eventHandler;
+        this.eventProcessor = eventProcessor;
         this.errorHandler = errorHandler;
         this.decisionService = decisionService;
         this.userProfileService = userProfileService;
@@ -230,7 +232,6 @@ public class Optimizely implements AutoCloseable {
             return;
         }
 
-        logger.info("Activating user \"{}\" in experiment \"{}\".", userId, experiment.getKey());
         UserEvent userEvent = UserEventFactory.createImpressionEvent(
             projectConfig,
             experiment,
@@ -238,20 +239,18 @@ public class Optimizely implements AutoCloseable {
             userId,
             filteredAttributes);
 
-        LogEvent impressionEvent = EventFactory.createLogEvent(userEvent);
-
-        try {
-            eventHandler.dispatchEvent(impressionEvent);
-        } catch (Exception e) {
-            logger.error("Unexpected exception in event dispatcher", e);
-        }
+        eventProcessor.process(userEvent);
+        logger.info("Activating user \"{}\" in experiment \"{}\".", userId, experiment.getKey());
 
         // Kept For backwards compatibility.
         // This notification is deprecated and the new DecisionNotifications
         // are sent via their respective method calls.
-        ActivateNotification activateNotification = new ActivateNotification(
-            experiment, userId, filteredAttributes, variation, impressionEvent);
-        notificationCenter.send(activateNotification);
+        if (notificationCenter.getNotificationManager(ActivateNotification.class).size() > 0) {
+            LogEvent impressionEvent = EventFactory.createLogEvent(userEvent);
+            ActivateNotification activateNotification = new ActivateNotification(
+                experiment, userId, filteredAttributes, variation, impressionEvent);
+            notificationCenter.send(activateNotification);
+        }
     }
 
     //======== track calls ========//
@@ -309,20 +308,17 @@ public class Optimizely implements AutoCloseable {
             copiedAttributes,
             eventTags);
 
-        // create the conversion event request parameters, then dispatch
-        LogEvent conversionEvent = EventFactory.createLogEvent(userEvent);
+        eventProcessor.process(userEvent);
         logger.info("Tracking event \"{}\" for user \"{}\".", eventName, userId);
 
-        try {
-            eventHandler.dispatchEvent(conversionEvent);
-        } catch (Exception e) {
-            logger.error("Unexpected exception in event dispatcher", e);
+        if (notificationCenter.getNotificationManager(TrackNotification.class).size() > 0) {
+            // create the conversion event request parameters, then dispatch
+            LogEvent conversionEvent = EventFactory.createLogEvent(userEvent);
+            TrackNotification notification = new TrackNotification(eventName, userId,
+                copiedAttributes, eventTags, conversionEvent);
+
+            notificationCenter.send(notification);
         }
-
-        TrackNotification notification = new TrackNotification(eventName, userId,
-            copiedAttributes, eventTags, conversionEvent);
-
-        notificationCenter.send(notification);
     }
 
     //======== FeatureFlag APIs ========//
@@ -1000,6 +996,7 @@ public class Optimizely implements AutoCloseable {
         private DecisionService decisionService;
         private ErrorHandler errorHandler;
         private EventHandler eventHandler;
+        private EventProcessor eventProcessor;
         private ProjectConfig projectConfig;
         private ProjectConfigManager projectConfigManager;
         private UserProfileService userProfileService;
@@ -1024,6 +1021,11 @@ public class Optimizely implements AutoCloseable {
 
         public Builder withEventHandler(EventHandler eventHandler) {
             this.eventHandler = eventHandler;
+            return this;
+        }
+
+        public Builder withEventProcessor(EventProcessor eventProcessor) {
+            this.eventProcessor = eventProcessor;
             return this;
         }
 
@@ -1094,6 +1096,12 @@ public class Optimizely implements AutoCloseable {
                 decisionService = new DecisionService(bucketer, errorHandler, userProfileService);
             }
 
+            // For backwards compatibility
+            if (eventProcessor == null) {
+                eventProcessor = new ForwardingEventProcessor();
+                eventProcessor.addHandler(eventHandler::dispatchEvent);
+            }
+
             if (projectConfig == null && datafile != null && !datafile.isEmpty()) {
                 try {
                     projectConfig = new DatafileProjectConfig.Builder().withDatafile(datafile).build();
@@ -1117,7 +1125,7 @@ public class Optimizely implements AutoCloseable {
                 notificationCenter = new NotificationCenter();
             }
 
-            return new Optimizely(eventHandler, errorHandler, decisionService, userProfileService, projectConfigManager, notificationCenter);
+            return new Optimizely(eventHandler, eventProcessor, errorHandler, decisionService, userProfileService, projectConfigManager, notificationCenter);
         }
     }
 }

--- a/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java
@@ -117,6 +117,8 @@ public class BatchEventProcessor implements EventProcessor, AutoCloseable {
     }
 
     public void process(UserEvent userEvent) {
+        logger.debug("Received userEvent: {}", userEvent);
+
 
         if (executor.isShutdown()) {
             logger.warn("Executor shutdown, not accepting tasks.");
@@ -143,7 +145,7 @@ public class BatchEventProcessor implements EventProcessor, AutoCloseable {
 
                     Object item = eventQueue.poll(50, TimeUnit.MILLISECONDS);
                     if (item == null) {
-                        logger.info("Empty item, sleeping for 500ms.");
+                        logger.info("Empty item, sleeping for 50ms.");
                         Thread.sleep(50);
                         continue;
                     }

--- a/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java
@@ -199,27 +199,27 @@ public class BatchEventProcessor implements EventProcessor, AutoCloseable {
         private Long flushInterval = null;
         private ExecutorService executor = null;
 
-        public Builder setEventHandler(EventHandler eventHandler) {
+        public Builder withEventHandler(EventHandler eventHandler) {
             this.eventHandler = eventHandler;
             return this;
         }
 
-        public Builder setEventQueue(BlockingQueue<Object> eventQueue) {
+        public Builder withEventQueue(BlockingQueue<Object> eventQueue) {
             this.eventQueue = eventQueue;
             return this;
         }
 
-        public Builder setBatchSize(Integer batchSize) {
+        public Builder withBatchSize(Integer batchSize) {
             this.batchSize = batchSize;
             return this;
         }
 
-        public Builder setFlushInterval(Long flushInterval) {
+        public Builder withFlushInterval(Long flushInterval) {
             this.flushInterval = flushInterval;
             return this;
         }
 
-        public Builder setExecutor(ExecutorService executor) {
+        public Builder withExecutor(ExecutorService executor) {
             this.executor = executor;
             return this;
         }

--- a/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java
@@ -1,0 +1,202 @@
+/**
+ *
+ *    Copyright 2019, Optimizely and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.optimizely.ab.event;
+
+import com.optimizely.ab.event.internal.EventFactory;
+import com.optimizely.ab.event.internal.UserEvent;
+import com.optimizely.ab.event.internal.payload.EventBatch;
+import com.optimizely.ab.internal.PropertyUtils;
+import com.optimizely.ab.notification.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.*;
+
+/**
+ * BatchEventProcessor is a batched implementation of the {@link EventProcessor}
+ *
+ * Events passed to the BatchEventProcessor are immediately added to a BlockingQueue.
+ *
+ * The BatchEventProcessor maintains a single consumer thread that pulls events off of
+ * the BlockingQueue and buffers them for either a configured batch size or for a
+ * maximum duration before they resulting LogEvent is sent to the NotificationManager.
+ */
+public class BatchEventProcessor implements EventProcessor, AutoCloseable {
+
+    private static final Logger logger = LoggerFactory.getLogger(BatchEventProcessor.class);
+
+    public static final String CONFIG_BATCH_SIZE     = "event.processor.batch.size";
+    public static final String CONFIG_BATCH_DURATION = "event.processor.batch.duration.ms";
+
+    public static final int  DEFAULT_BATCH_SIZE     = 50;
+    public static final long DEFAULT_BATCH_DURATION = TimeUnit.MINUTES.toMillis(1);
+
+    private static final Object SHUTDOWN_SIGNAL = new Object();
+
+    private final NotificationManager<LogEvent> notificationManager = new NotificationManager<>();
+    private final BlockingQueue<Object> eventQueue;
+
+    private final int batchSize;
+    private final long batchDuration;
+    private final ExecutorService executor;
+
+    private Future<?> future;
+    private boolean isStarted = false;
+
+    // TODO use a builder.
+    public BatchEventProcessor() {
+        this(new ArrayBlockingQueue<>(1000));
+    }
+
+    public BatchEventProcessor(BlockingQueue<Object> eventQueue) {
+        this(eventQueue, null, null, Executors.newSingleThreadExecutor());
+    }
+
+    public BatchEventProcessor(BlockingQueue<Object> eventQueue, Integer batchSize, Integer batchDuration, ExecutorService executor) {
+        this.eventQueue = eventQueue;
+        this.batchSize = batchSize == null ? PropertyUtils.getInteger(CONFIG_BATCH_SIZE, DEFAULT_BATCH_SIZE) : batchSize;
+        this.batchDuration = batchDuration == null ? PropertyUtils.getLong(CONFIG_BATCH_DURATION, DEFAULT_BATCH_DURATION) : batchDuration;
+
+        if (executor == null) {
+            final ThreadFactory threadFactory = Executors.defaultThreadFactory();
+            this.executor = Executors.newSingleThreadExecutor(runnable -> {
+                Thread thread = threadFactory.newThread(runnable);
+                thread.setDaemon(true);
+                return thread;
+            });
+        } else {
+            this.executor = executor;
+        }
+
+        start();
+    }
+
+    public synchronized void start() {
+        if (isStarted) {
+            logger.info("Executor already started.");
+            return;
+        }
+
+        isStarted = true;
+        EventConsumer runnable = new EventConsumer();
+        future = executor.submit(runnable);
+    }
+
+    @Override
+    public void close() throws Exception {
+        logger.info("Start close");
+        eventQueue.put(SHUTDOWN_SIGNAL);
+        try {
+            future.get(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            logger.warn("Interrupted while awaiting termination.");
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    public int addHandler(NotificationHandler<LogEvent> handler) {
+        logger.debug("Adding notification handler: {}", handler);
+        return notificationManager.addHandler(handler);
+    }
+
+    public void process(UserEvent userEvent) {
+
+        if (executor.isShutdown()) {
+            logger.warn("Executor shutdown, not accepting tasks.");
+            return;
+        }
+
+        if (!eventQueue.offer(userEvent)) {
+            logger.warn("Payload not accepted by the queue. Current size: {}", eventQueue.size());
+        }
+    }
+
+    public class EventConsumer implements Runnable {
+        private LinkedList<UserEvent> currentBatch = new LinkedList<>();
+        private long deadline = System.currentTimeMillis() + batchDuration;
+
+        @Override
+        public void run() {
+            try {
+                while (true) {
+                    if (System.currentTimeMillis() > deadline) {
+                        logger.debug("Deadline exceeded flushing current batch.");
+                        flush();
+                    }
+
+                    Object item = eventQueue.poll(50, TimeUnit.MILLISECONDS);
+                    if (item == null) {
+                        logger.info("Empty item, sleeping for 500ms.");
+                        Thread.sleep(50);
+                        continue;
+                    }
+
+                    if (item == SHUTDOWN_SIGNAL) {
+                        logger.info("Received shutdown signal.");
+                        break;
+                    }
+
+                    addToBatch((UserEvent) item);
+                }
+            } catch (InterruptedException e) {
+                logger.info("Interrupted while processing buffer.");
+            } catch (Exception e) {
+                logger.error("Uncaught exception processing buffer.", e);
+            } finally {
+                logger.info("Exiting processing loop. Attempting to flush pending events.");
+                flush();
+            }
+        }
+
+        private void addToBatch(UserEvent userEvent) {
+            if (!currentBatch.isEmpty()) {
+                String currentRevision = currentBatch.peekLast().getUserContext().getProjectConfig().getRevision();
+
+                // Separate batches based on config revision.
+                if (!currentRevision.equals(userEvent.getUserContext().getProjectConfig().getRevision())) {
+                    flush();
+                    currentBatch = new LinkedList<>();
+                    return;
+                }
+            }
+
+            // Reset the deadline if starting a new batch.
+            if (currentBatch.isEmpty()) {
+                deadline = System.currentTimeMillis() + batchDuration;
+            }
+
+            currentBatch.add(userEvent);
+            if (currentBatch.size() >= batchSize) {
+                flush();
+            }
+        }
+
+        private void flush() {
+            if (currentBatch.isEmpty()) {
+                return;
+            }
+
+            LogEvent logEvent = EventFactory.createLogEvent(currentBatch);
+
+            notificationManager.send(logEvent);
+            currentBatch = new LinkedList<>();
+        }
+    }
+}

--- a/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java
@@ -18,15 +18,12 @@ package com.optimizely.ab.event;
 
 import com.optimizely.ab.event.internal.EventFactory;
 import com.optimizely.ab.event.internal.UserEvent;
-import com.optimizely.ab.event.internal.payload.EventBatch;
 import com.optimizely.ab.internal.PropertyUtils;
 import com.optimizely.ab.notification.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.concurrent.*;
 
 /**
@@ -175,7 +172,6 @@ public class BatchEventProcessor implements EventProcessor, AutoCloseable {
                 if (!currentRevision.equals(userEvent.getUserContext().getProjectConfig().getRevision())) {
                     flush();
                     currentBatch = new LinkedList<>();
-                    return;
                 }
             }
 

--- a/core-api/src/main/java/com/optimizely/ab/event/EventHandler.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/EventHandler.java
@@ -20,6 +20,5 @@ package com.optimizely.ab.event;
  * Implementations are responsible for dispatching event's to the Optimizely event end-point.
  */
 public interface EventHandler {
-
     void dispatchEvent(LogEvent logEvent) throws Exception;
 }

--- a/core-api/src/main/java/com/optimizely/ab/event/EventProcessor.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/EventProcessor.java
@@ -14,15 +14,17 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-package com.optimizely.ab.notification;
+package com.optimizely.ab.event;
+
+import com.optimizely.ab.event.internal.UserEvent;
+import com.optimizely.ab.event.internal.payload.EventBatch;
+import com.optimizely.ab.notification.NotificationHandler;
 
 /**
- * NotificationHandler is a generic interface Optimizely notification listeners.
- * This interface replaces {@link NotificationListener} which didn't provide adequate type safety.
- *
- * While this class adds generic handler implementations to be created, the domain of supported
- * implementations is maintained by the {@link NotificationCenter}
+ * EventProcessor interface is used to provide an intermediary processing stage within
+ * event production.
  */
-public interface NotificationHandler<T> {
-    void handle(T message) throws Exception;
+public interface EventProcessor {
+    void process(UserEvent userEvent);
+    int addHandler(NotificationHandler<LogEvent> handler);
 }

--- a/core-api/src/main/java/com/optimizely/ab/event/EventProcessor.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/EventProcessor.java
@@ -22,9 +22,9 @@ import com.optimizely.ab.notification.NotificationHandler;
 
 /**
  * EventProcessor interface is used to provide an intermediary processing stage within
- * event production.
+ * event production. It's assumed that the EventProcessor dispatches events via a provided
+ * {@link EventHandler}.
  */
 public interface EventProcessor {
     void process(UserEvent userEvent);
-    int addHandler(NotificationHandler<LogEvent> handler);
 }

--- a/core-api/src/main/java/com/optimizely/ab/event/ForwardingEventProcessor.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/ForwardingEventProcessor.java
@@ -1,0 +1,48 @@
+/**
+ *
+ *    Copyright 2019, Optimizely and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.optimizely.ab.event;
+
+import com.optimizely.ab.event.internal.EventFactory;
+import com.optimizely.ab.event.internal.UserEvent;
+import com.optimizely.ab.event.internal.payload.EventBatch;
+import com.optimizely.ab.notification.NotificationHandler;
+import com.optimizely.ab.notification.NotificationManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+
+/**
+ * ForwardingEventProcessor is a basic transformation stage for converting
+ * the event batch into a LogEvent to be dispatched.
+ */
+public class ForwardingEventProcessor implements EventProcessor {
+
+    private static final Logger logger = LoggerFactory.getLogger(ForwardingEventProcessor.class);
+
+    private final NotificationManager<LogEvent> notificationManager = new NotificationManager<>();
+
+    @Override
+    public void process(UserEvent userEvent) {
+        logger.debug("Not processing event");
+        notificationManager.send(EventFactory.createLogEvent(userEvent));
+    }
+
+    public int addHandler(NotificationHandler<LogEvent> handler) {
+        return notificationManager.addHandler(handler);
+    }
+}

--- a/core-api/src/main/java/com/optimizely/ab/event/ForwardingEventProcessor.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/ForwardingEventProcessor.java
@@ -18,13 +18,10 @@ package com.optimizely.ab.event;
 
 import com.optimizely.ab.event.internal.EventFactory;
 import com.optimizely.ab.event.internal.UserEvent;
-import com.optimizely.ab.event.internal.payload.EventBatch;
 import com.optimizely.ab.notification.NotificationHandler;
 import com.optimizely.ab.notification.NotificationManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Collections;
 
 /**
  * ForwardingEventProcessor is a basic transformation stage for converting
@@ -38,7 +35,6 @@ public class ForwardingEventProcessor implements EventProcessor {
 
     @Override
     public void process(UserEvent userEvent) {
-        logger.debug("Not processing event");
         notificationManager.send(EventFactory.createLogEvent(userEvent));
     }
 

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/ConversionEvent.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/ConversionEvent.java
@@ -17,6 +17,7 @@
 package com.optimizely.ab.event.internal;
 
 import java.util.Map;
+import java.util.StringJoiner;
 
 /**
  * ConversionEvent encapsulates information specific to conversion events.
@@ -107,5 +108,17 @@ public class ConversionEvent extends BaseEvent implements UserEvent {
         public ConversionEvent build() {
             return new ConversionEvent(userContext, eventId, eventKey, revenue, value, tags);
         }
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", ConversionEvent.class.getSimpleName() + "[", "]")
+            .add("userContext=" + userContext)
+            .add("eventId='" + eventId + "'")
+            .add("eventKey='" + eventKey + "'")
+            .add("revenue=" + revenue)
+            .add("value=" + value)
+            .add("tags=" + tags)
+            .toString();
     }
 }

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/ImpressionEvent.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/ImpressionEvent.java
@@ -16,6 +16,8 @@
  */
 package com.optimizely.ab.event.internal;
 
+import java.util.StringJoiner;
+
 /**
  * ImpressionEvent encapsulates information specific to conversion events.
  */
@@ -108,5 +110,17 @@ public class ImpressionEvent extends BaseEvent implements UserEvent {
         public ImpressionEvent build() {
             return new ImpressionEvent(userContext, layerId, experimentId, experimentKey, variationKey, variationId);
         }
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", ImpressionEvent.class.getSimpleName() + "[", "]")
+            .add("userContext=" + userContext)
+            .add("layerId='" + layerId + "'")
+            .add("experimentId='" + experimentId + "'")
+            .add("experimentKey='" + experimentKey + "'")
+            .add("variationKey='" + variationKey + "'")
+            .add("variationId='" + variationId + "'")
+            .toString();
     }
 }

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/UserContext.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/UserContext.java
@@ -19,6 +19,7 @@ package com.optimizely.ab.event.internal;
 import com.optimizely.ab.config.ProjectConfig;
 
 import java.util.Map;
+import java.util.StringJoiner;
 
 /**
  * UserContext stores the user id, attributes and a reference to the current {@link ProjectConfig}.
@@ -70,5 +71,14 @@ public class UserContext {
         public UserContext build() {
             return new UserContext(projectConfig, userId, attributes);
         }
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", UserContext.class.getSimpleName() + "[", "]")
+            .add("projectConfig=" + projectConfig.getRevision())
+            .add("userId='" + userId + "'")
+            .add("attributes=" + attributes)
+            .toString();
     }
 }

--- a/core-api/src/main/java/com/optimizely/ab/notification/NotificationCenter.java
+++ b/core-api/src/main/java/com/optimizely/ab/notification/NotificationCenter.java
@@ -90,10 +90,10 @@ public class NotificationCenter {
     public NotificationCenter() {
         AtomicInteger counter = new AtomicInteger();
         Map<Class, NotificationManager> validManagers = new HashMap<>();
-        validManagers.put(ActivateNotification.class, new NotificationManager<>(ActivateNotification.class, counter));
-        validManagers.put(TrackNotification.class, new NotificationManager<>(TrackNotification.class, counter));
-        validManagers.put(DecisionNotification.class, new NotificationManager<>(DecisionNotification.class, counter));
-        validManagers.put(UpdateConfigNotification.class, new NotificationManager<>(UpdateConfigNotification.class, counter));
+        validManagers.put(ActivateNotification.class, new NotificationManager<ActivateNotification>(counter));
+        validManagers.put(TrackNotification.class, new NotificationManager<TrackNotification>(counter));
+        validManagers.put(DecisionNotification.class, new NotificationManager<DecisionNotification>(counter));
+        validManagers.put(UpdateConfigNotification.class, new NotificationManager<UpdateConfigNotification>(counter));
 
         notifierMap = Collections.unmodifiableMap(validManagers);
     }

--- a/core-api/src/main/java/com/optimizely/ab/notification/NotificationManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/notification/NotificationManager.java
@@ -78,4 +78,8 @@ public class NotificationManager<T> {
         NotificationHandler<T> handler = handlers.remove(notificationID);
         return handler != null;
     }
+
+    public int size() {
+        return handlers.size();
+    }
 }

--- a/core-api/src/main/java/com/optimizely/ab/notification/NotificationManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/notification/NotificationManager.java
@@ -35,14 +35,12 @@ public class NotificationManager<T> {
 
     private final Map<Integer, NotificationHandler<T>> handlers = new LinkedHashMap<>();
     private final AtomicInteger counter;
-    private final Class<T> clazz;
 
-    public NotificationManager(Class<T> clazz) {
-        this(clazz, new AtomicInteger());
+    public NotificationManager() {
+        this(new AtomicInteger());
     }
 
-    public NotificationManager(Class<T> clazz, AtomicInteger counter) {
-        this.clazz = clazz;
+    public NotificationManager(AtomicInteger counter) {
         this.counter = counter;
     }
 
@@ -62,12 +60,12 @@ public class NotificationManager<T> {
         return notificationId;
     }
 
-    void send(T message) {
+    public void send(final T message) {
         for (Map.Entry<Integer, NotificationHandler<T>> handler: handlers.entrySet()) {
             try {
                 handler.getValue().handle(message);
             } catch (Exception e) {
-                logger.warn("Catching exception sending notification for class: {}, handler: {}", clazz, handler.getKey());
+                logger.warn("Catching exception sending notification for class: {}, handler: {}", message.getClass(), handler.getKey());
             }
         }
     }

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyRule.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyRule.java
@@ -1,0 +1,98 @@
+/**
+ *    Copyright 2019, Optimizely Inc. and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.optimizely.ab;
+
+import com.optimizely.ab.bucketing.Bucketer;
+import com.optimizely.ab.bucketing.DecisionService;
+import com.optimizely.ab.config.ProjectConfig;
+import com.optimizely.ab.config.ProjectConfigManager;
+import com.optimizely.ab.error.ErrorHandler;
+import com.optimizely.ab.event.EventHandler;
+import com.optimizely.ab.event.EventProcessor;
+import org.junit.rules.ExternalResource;
+
+/**
+ * Factory class for building and maintaining an Optimizely instance. The methods mirror the
+ * {@link Optimizely.Builder} methods so test can can use either class interchangeably.
+ *
+ * The main motivation of this class is to ensure that the built Optimizely resource get's
+ * explicitly closed at the end of each test run.
+ */
+public class OptimizelyRule extends ExternalResource {
+
+    private Optimizely.Builder builder;
+    private Optimizely optimizely;
+
+//    public OptimizelyRule withEventProcessor(EventProcessor eventProcessor) {
+//        builder.withEventProcessor(eventProcessor);
+//        return this;
+//    }
+
+    public OptimizelyRule withDecisionService(DecisionService decisionService) {
+        builder.withDecisionService(decisionService);
+        return this;
+    }
+
+    public OptimizelyRule withDatafile(String datafile) {
+        builder.withDatafile(datafile);
+        return this;
+    }
+
+    public OptimizelyRule withErrorHandler(ErrorHandler errorHandler) {
+        builder.withErrorHandler(errorHandler);
+        return this;
+    }
+
+    public OptimizelyRule withBucketing(Bucketer bucketer) {
+        builder.withBucketing(bucketer);
+        return this;
+    }
+
+    public OptimizelyRule withEventHandler(EventHandler eventHandler) {
+        builder.withEventHandler(eventHandler);
+        return this;
+    }
+
+    public OptimizelyRule withConfig(ProjectConfig projectConfig) {
+        builder.withConfig(projectConfig);
+        return this;
+    }
+
+    public OptimizelyRule withConfigManager(ProjectConfigManager projectConfigManager) {
+        builder.withConfigManager(projectConfigManager);
+        return this;
+    }
+
+    public Optimizely build() {
+        optimizely = builder.build();
+        return optimizely;
+    }
+
+    public void before() {
+        builder = Optimizely.builder();
+    }
+
+    public void after() {
+        if (optimizely == null) {
+            return;
+        }
+
+        // Blocks and waits for graceful shutdown.
+        optimizely.close();
+        optimizely = null;
+    }
+
+}

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyRule.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyRule.java
@@ -36,10 +36,10 @@ public class OptimizelyRule extends ExternalResource {
     private Optimizely.Builder builder;
     private Optimizely optimizely;
 
-//    public OptimizelyRule withEventProcessor(EventProcessor eventProcessor) {
-//        builder.withEventProcessor(eventProcessor);
-//        return this;
-//    }
+    public OptimizelyRule withEventProcessor(EventProcessor eventProcessor) {
+        builder.withEventProcessor(eventProcessor);
+        return this;
+    }
 
     public OptimizelyRule withDecisionService(DecisionService decisionService) {
         builder.withDecisionService(decisionService);

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -102,7 +102,7 @@ public class OptimizelyTest {
                 validConfigJsonV4(),
                 validConfigJsonV4(),
                 4,
-                (Supplier<EventProcessor>) BatchEventProcessor::new
+                (Supplier<EventProcessor>) () -> BatchEventProcessor.builder().build()
             }
         });
     }

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -937,25 +937,6 @@ public class OptimizelyTest {
     }
 
     /**
-     * Verify that {@link Optimizely#activate(String, String)} handles exceptions thrown by
-     * {@link EventHandler#dispatchEvent(LogEvent)} gracefully.
-     */
-    @Test
-    public void activateDispatchEventThrowsException() throws Exception {
-        Experiment experiment = noAudienceProjectConfig.getExperiments().get(0);
-
-        doThrow(new Exception("Test Exception")).when(mockEventHandler).dispatchEvent(any(LogEvent.class));
-
-        Optimizely optimizely = optimizelyBuilder
-            .withEventHandler(mockEventHandler)
-            .withConfig(noAudienceProjectConfig)
-            .build();
-
-        logbackVerifier.expectMessage(Level.ERROR, "Unexpected exception in event dispatcher");
-        optimizely.activate(experiment.getKey(), testUserId);
-    }
-
-    /**
      * Verify that {@link Optimizely#activate(String, String)} doesn't dispatch an event for an experiment with a
      * "Launched" status.
      */
@@ -1244,22 +1225,6 @@ public class OptimizelyTest {
         Optimizely optimizely = optimizelyBuilder.build();
         optimizely.track(eventType.getKey(), genericUserId, attributes);
         eventHandler.expectConversion(eventType.getKey(), genericUserId, attributes);
-    }
-
-    /**
-     * Verify that {@link Optimizely#track(String, String)} handles exceptions thrown by
-     * {@link EventHandler#dispatchEvent(LogEvent)} gracefully.
-     */
-    @Test
-    public void trackDispatchEventThrowsException() throws Exception {
-        EventType eventType = noAudienceProjectConfig.getEventTypes().get(0);
-
-        doThrow(new Exception("Test Exception")).when(mockEventHandler).dispatchEvent(any(LogEvent.class));
-
-        Optimizely optimizely = optimizelyBuilder.withEventHandler(mockEventHandler).build();
-        optimizely.track(eventType.getKey(), testUserId);
-
-        logbackVerifier.expectMessage(Level.ERROR, "Unexpected exception in event dispatcher");
     }
 
     /**

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -51,6 +51,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static com.optimizely.ab.config.DatafileProjectConfigTestUtils.*;
@@ -84,25 +85,27 @@ public class OptimizelyTest {
                 validConfigJsonV2(),
                 noAudienceProjectConfigJsonV2(),
                 2,
-                (Supplier<EventProcessor>) () -> null
+                (Function<EventHandler, EventProcessor>) (eventHandler) -> null
             },
             {
                 validConfigJsonV3(),
                 noAudienceProjectConfigJsonV3(),  // FIX-ME this is not a valid v3 datafile
                 3,
-                (Supplier<EventProcessor>) () -> null
+                (Function<EventHandler, EventProcessor>) (eventHandler) -> null
             },
             {
                 validConfigJsonV4(),
                 validConfigJsonV4(),
                 4,
-                (Supplier<EventProcessor>) () -> null
+                (Function<EventHandler, EventProcessor>) (eventHandler) -> null
             },
             {
                 validConfigJsonV4(),
                 validConfigJsonV4(),
                 4,
-                (Supplier<EventProcessor>) () -> BatchEventProcessor.builder().build()
+                (Function<EventHandler, EventProcessor>) (eventHandler) -> BatchEventProcessor.builder()
+                    .setEventHandler(eventHandler)
+                    .build()
             }
         });
     }
@@ -145,7 +148,7 @@ public class OptimizelyTest {
     public int datafileVersion;
 
     @Parameterized.Parameter(3)
-    public Supplier<EventProcessor> eventProcessorSupplier;
+    public Function<EventHandler, EventProcessor> eventProcessorSupplier;
 
     private ProjectConfig validProjectConfig;
     private ProjectConfig noAudienceProjectConfig;
@@ -159,7 +162,7 @@ public class OptimizelyTest {
         //assertEquals(validProjectConfig.getVersion(), noAudienceProjectConfig.getVersion());
 
         optimizelyBuilder
-            .withEventProcessor(eventProcessorSupplier.get())
+            .withEventProcessor(eventProcessorSupplier.apply(eventHandler))
             .withEventHandler(eventHandler)
             .withConfig(validProjectConfig);
     }

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -52,7 +52,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import static com.optimizely.ab.config.DatafileProjectConfigTestUtils.*;
 import static com.optimizely.ab.config.ValidProjectConfigV4.*;
@@ -104,7 +103,7 @@ public class OptimizelyTest {
                 validConfigJsonV4(),
                 4,
                 (Function<EventHandler, EventProcessor>) (eventHandler) -> BatchEventProcessor.builder()
-                    .setEventHandler(eventHandler)
+                    .withEventHandler(eventHandler)
                     .build()
             }
         });

--- a/core-api/src/test/java/com/optimizely/ab/event/BatchEventProcessorTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/event/BatchEventProcessorTest.java
@@ -144,10 +144,10 @@ public class BatchEventProcessorTest {
 
     private void setEventProcessor(EventHandler eventHandler) {
         eventProcessor = BatchEventProcessor.builder()
-            .setEventQueue(eventQueue)
-            .setBatchSize(MAX_BATCH_SIZE)
-            .setFlushInterval(MAX_DURATION_MS)
-            .setEventHandler(eventHandler)
+            .withEventQueue(eventQueue)
+            .withBatchSize(MAX_BATCH_SIZE)
+            .withFlushInterval(MAX_DURATION_MS)
+            .withEventHandler(eventHandler)
             .build();
     }
 

--- a/core-api/src/test/java/com/optimizely/ab/event/BatchEventProcessorTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/event/BatchEventProcessorTest.java
@@ -45,8 +45,6 @@ public class BatchEventProcessorTest {
     private static final String EVENT_ID = "eventId";
     private static final String EVENT_NAME = "eventName";
     private static final String USER_ID = "userId";
-    private static final Experiment EXPERIMENT = new Experiment("EXP_ID", "EXP_KEY", "LAYER_ID");
-    private static final Variation VARIATION = new Variation("VAR_ID", "VAR_KEY");
 
     private static final int MAX_BATCH_SIZE = 10;
     private static final int MAX_DURATION_MS = 1000;
@@ -123,22 +121,5 @@ public class BatchEventProcessorTest {
     private ConversionEvent buildConversionEvent(String eventName) {
         return UserEventFactory.createConversionEvent(projectConfig, USER_ID, EVENT_ID, eventName,
             Collections.emptyMap(), Collections.emptyMap());
-    }
-
-    // Not used
-    private static class BasicEvent implements UserEvent {
-
-        UserContext userContext;
-
-        private BasicEvent(ProjectConfig projectConfig) {
-            userContext = new UserContext.Builder()
-                .withProjectConfig(projectConfig)
-                .build();
-        }
-
-        @Override
-        public UserContext getUserContext() {
-            return userContext;
-        }
     }
 }

--- a/core-api/src/test/java/com/optimizely/ab/event/BatchEventProcessorTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/event/BatchEventProcessorTest.java
@@ -1,0 +1,144 @@
+/**
+ *
+ *    Copyright 2019, Optimizely and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.optimizely.ab.event;
+
+import com.optimizely.ab.EventHandlerRule;
+import com.optimizely.ab.config.Experiment;
+import com.optimizely.ab.config.ProjectConfig;
+import com.optimizely.ab.config.Variation;
+import com.optimizely.ab.event.internal.*;
+import com.optimizely.ab.event.internal.payload.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.*;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BatchEventProcessorTest {
+
+    private static final String EVENT_ID = "eventId";
+    private static final String EVENT_NAME = "eventName";
+    private static final String USER_ID = "userId";
+    private static final Experiment EXPERIMENT = new Experiment("EXP_ID", "EXP_KEY", "LAYER_ID");
+    private static final Variation VARIATION = new Variation("VAR_ID", "VAR_KEY");
+
+    private static final int MAX_BATCH_SIZE = 10;
+    private static final int MAX_DURATION_MS = 1000;
+
+    @Mock
+    private ProjectConfig projectConfig;
+
+    @Rule
+    public EventHandlerRule eventHandlerRule = new EventHandlerRule();
+
+    private BlockingQueue<Object> eventQueue;
+    private BatchEventProcessor eventProcessor;
+
+    @Before
+    public void setUp() throws Exception {
+        when(projectConfig.getRevision()).thenReturn("1");
+
+        eventQueue = new ArrayBlockingQueue<>(100);
+        eventProcessor = new BatchEventProcessor(eventQueue, MAX_BATCH_SIZE, MAX_DURATION_MS, null);
+        eventProcessor.addHandler(eventHandlerRule::dispatchEvent);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        eventProcessor.close();
+    }
+
+    @Test
+    public void testDrainOnClose() throws Exception {
+        UserEvent userEvent = buildConversionEvent(EVENT_NAME);
+        eventProcessor.process(userEvent);
+        eventProcessor.close();
+
+        assertEquals(0, eventQueue.size());
+        eventHandlerRule.expectConversion(EVENT_NAME, USER_ID);
+    }
+
+    @Test
+    public void testFlushOnMaxTimeout() throws Exception {
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        eventProcessor.addHandler(logEvent -> countDownLatch.countDown());
+
+        UserEvent userEvent = buildConversionEvent(EVENT_NAME);
+        eventProcessor.process(userEvent);
+        eventHandlerRule.expectConversion(EVENT_NAME, USER_ID);
+
+        if (!countDownLatch.await(MAX_DURATION_MS * 3, TimeUnit.MILLISECONDS)) {
+            fail("Exceeded timeout waiting for notification.");
+        }
+
+        eventProcessor.close();
+        assertEquals(0, eventQueue.size());
+    }
+
+    @Test
+    public void testFlushMaxBatchSize() throws Exception {
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        eventProcessor.addHandler(logEvent -> {
+            assertEquals(MAX_BATCH_SIZE, logEvent.getEventBatch().getVisitors().size());
+            countDownLatch.countDown();
+        });
+
+        for (int i = 0; i < MAX_BATCH_SIZE; i++) {
+            String eventName = EVENT_NAME + i;
+            UserEvent userEvent = buildConversionEvent(eventName);
+            eventProcessor.process(userEvent);
+            eventHandlerRule.expectConversion(eventName, USER_ID);
+        }
+
+        countDownLatch.await();
+        assertEquals(0, eventQueue.size());
+    }
+
+    private ConversionEvent buildConversionEvent(String eventName) {
+        return UserEventFactory.createConversionEvent(projectConfig, USER_ID, EVENT_ID, eventName,
+            Collections.emptyMap(), Collections.emptyMap());
+    }
+
+    // Not used
+    private static class BasicEvent implements UserEvent {
+
+        UserContext userContext;
+
+        private BasicEvent(ProjectConfig projectConfig) {
+            userContext = new UserContext.Builder()
+                .withProjectConfig(projectConfig)
+                .build();
+        }
+
+        @Override
+        public UserContext getUserContext() {
+            return userContext;
+        }
+    }
+}

--- a/core-api/src/test/java/com/optimizely/ab/event/BatchEventProcessorTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/event/BatchEventProcessorTest.java
@@ -17,11 +17,8 @@
 package com.optimizely.ab.event;
 
 import com.optimizely.ab.EventHandlerRule;
-import com.optimizely.ab.config.Experiment;
 import com.optimizely.ab.config.ProjectConfig;
-import com.optimizely.ab.config.Variation;
 import com.optimizely.ab.event.internal.*;
-import com.optimizely.ab.event.internal.payload.*;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -30,15 +27,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.*;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockingDetails;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -49,7 +42,7 @@ public class BatchEventProcessorTest {
     private static final String USER_ID = "userId";
 
     private static final int MAX_BATCH_SIZE = 10;
-    private static final int MAX_DURATION_MS = 1000;
+    private static final long MAX_DURATION_MS = 1000;
 
     @Mock
     private ProjectConfig projectConfig;
@@ -65,7 +58,11 @@ public class BatchEventProcessorTest {
         when(projectConfig.getRevision()).thenReturn("1");
 
         eventQueue = new ArrayBlockingQueue<>(100);
-        eventProcessor = new BatchEventProcessor(eventQueue, MAX_BATCH_SIZE, MAX_DURATION_MS, null);
+        eventProcessor = BatchEventProcessor.builder()
+            .setEventQueue(eventQueue)
+            .setBatchSize(MAX_BATCH_SIZE)
+            .setFlushInterval(MAX_DURATION_MS)
+            .build();
         eventProcessor.addHandler(eventHandlerRule::dispatchEvent);
     }
 

--- a/core-api/src/test/java/com/optimizely/ab/event/ForwardingEventProcessorTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/event/ForwardingEventProcessorTest.java
@@ -1,0 +1,55 @@
+/**
+ *
+ *    Copyright 2019, Optimizely and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.optimizely.ab.event;
+
+import com.optimizely.ab.event.internal.EventFactory;
+import com.optimizely.ab.event.internal.UserContext;
+import com.optimizely.ab.event.internal.UserEvent;
+import com.optimizely.ab.event.internal.payload.EventBatch;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.*;
+
+public class ForwardingEventProcessorTest {
+
+    private static final UserEvent SENTINAL = () -> null;
+    private ForwardingEventProcessor eventProcessor;
+
+    @Before
+    public void setUp() throws Exception {
+        eventProcessor = new ForwardingEventProcessor();
+    }
+
+    @Test
+    @Ignore("FIXME")
+    public void testAddHandler() {
+        AtomicBoolean atomicBoolean = new AtomicBoolean();
+        eventProcessor.addHandler(logEvent -> {
+            assertEquals(logEvent.getEventBatch(), SENTINAL);
+            assertEquals(logEvent.getRequestMethod(), LogEvent.RequestMethod.POST);
+            assertEquals(logEvent.getEndpointUrl(), EventFactory.EVENT_ENDPOINT);
+            atomicBoolean.set(true);
+        });
+
+        eventProcessor.process(SENTINAL);
+        assertTrue(atomicBoolean.get());
+    }
+}

--- a/core-api/src/test/java/com/optimizely/ab/event/ForwardingEventProcessorTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/event/ForwardingEventProcessorTest.java
@@ -37,46 +37,27 @@ public class ForwardingEventProcessorTest {
     private static final String USER_ID = "userId";
 
     private ForwardingEventProcessor eventProcessor;
+    private AtomicBoolean atomicBoolean = new AtomicBoolean();
 
     @Mock
     private ProjectConfig projectConfig;
 
     @Before
     public void setUp() throws Exception {
-        eventProcessor = new ForwardingEventProcessor();
-    }
-
-    @Test
-    public void testAddHandler() {
-        AtomicBoolean atomicBoolean = new AtomicBoolean();
-        eventProcessor.addHandler(logEvent -> {
+        atomicBoolean.set(false);
+        eventProcessor = new ForwardingEventProcessor(logEvent -> {
             assertNotNull(logEvent.getEventBatch());
             assertEquals(logEvent.getRequestMethod(), LogEvent.RequestMethod.POST);
             assertEquals(logEvent.getEndpointUrl(), EventFactory.EVENT_ENDPOINT);
             atomicBoolean.set(true);
         });
+    }
 
+    @Test
+    public void testAddHandler() {
         UserEvent userEvent = buildConversionEvent(EVENT_NAME);
         eventProcessor.process(userEvent);
         assertTrue(atomicBoolean.get());
-    }
-
-    private static class BasicEvent implements UserEvent {
-
-        @Override
-        public UserContext getUserContext() {
-            return null;
-        }
-
-        @Override
-        public String getUUID() {
-            return null;
-        }
-
-        @Override
-        public long getTimestamp() {
-            return 0;
-        }
     }
 
     private ConversionEvent buildConversionEvent(String eventName) {

--- a/core-api/src/test/java/com/optimizely/ab/notification/NotificationManagerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/notification/NotificationManagerTest.java
@@ -32,7 +32,7 @@ public class NotificationManagerTest {
     @Before
     public void setUp() {
         counter = new AtomicInteger();
-        notificationManager = new NotificationManager<>(TestNotification.class, counter);
+        notificationManager = new NotificationManager<>(counter);
     }
 
     @Test

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/event/AsyncEventHandler.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/event/AsyncEventHandler.java
@@ -114,7 +114,7 @@ public class AsyncEventHandler implements EventHandler, AutoCloseable {
 
         this.workerExecutor = new ThreadPoolExecutor(numWorkers, numWorkers,
             0L, TimeUnit.MILLISECONDS,
-            new ArrayBlockingQueue<Runnable>(queueCapacity),
+            new ArrayBlockingQueue<>(queueCapacity),
             new NamedThreadFactory("optimizely-event-dispatcher-thread-%s", true));
 
         this.closeTimeout = closeTimeout;


### PR DESCRIPTION
## Summary
- Introduces an EventProcessor interface.
- Introduces a BatchEventProcessor (maybe should name it BatchingEventProcessor)
- Introduces an OptimizelyRule to handle lifecycle management during unit testing.

Buffering events within a queue before dispatching is an optimization that should prevent SDK implementations from exhausting resources while increasing throughput. This implementation relies on a `BlockingQueue` to buffer events received from one-to-many producers. A single consumer thread continuously polls from this queue to build a batch before emitting the batched `LogEvent`.

Note that the `Optimizely` class only knows about the `EventProcessor` and `EventHandler` so that it can gracefully close those implementations, so not strictly necessary. The Optimizely class builds UserEvents via the `UserEventFactory` and passes those events to the `EventProcessor`. The `EventProcessor` emits `LogEvents` to a `NotificationManager<LogEvent>` which is subscribed to by the `EventHandler` for eventual dispatching.

## Trade-offs / alternatives:
- We could have the `EventProcessor` accept an EventHandler directly, not leverging the NotificationManager<LogEvent>
- We could go all in on NotificationCenter as a global registry as opposed to one off implementations.
