### PR TITLE
Fix blocking behavior when sending update notification.

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java
@@ -99,8 +99,8 @@ public abstract class PollingProjectConfigManager implements ProjectConfigManage
         logger.info("New datafile set with revision: {}. Old revision: {}", projectConfig.getRevision(), previousRevision);
 
         currentProjectConfig.set(projectConfig);
-        notificationCenter.send(SIGNAL);
         countDownLatch.countDown();
+        notificationCenter.send(SIGNAL);
     }
 
     public NotificationCenter getNotificationCenter() {


### PR DESCRIPTION
## Summary
- Trigger the UpdateConfigNotification after resolving the countdownlatch.

Since notifications are triggered synchronously in the calling thread, there was potential to unnecessarily block until the timeout if the notification listener was also calling `.getConfig()`

## Test plan
Unit test was added to confirm the issue, then validate the solution.