### PR TITLE
 Add LogEvent notification.

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -964,6 +964,13 @@ public class Optimizely implements AutoCloseable {
     }
 
     /**
+     * Convenience method for adding LogEvent Notification Handlers
+     */
+    public int addLogEventNotificationHandler(NotificationHandler<LogEvent> handler) {
+        return addNotificationHandler(LogEvent.class, handler);
+    }
+
+    /**
      * Convenience method for adding NotificationHandlers
      */
     public <T> int addNotificationHandler(Class<T> clazz, NotificationHandler<T> handler) {

--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -1097,11 +1097,6 @@ public class Optimizely implements AutoCloseable {
                 decisionService = new DecisionService(bucketer, errorHandler, userProfileService);
             }
 
-            // For backwards compatibility
-            if (eventProcessor == null) {
-                eventProcessor = new ForwardingEventProcessor(eventHandler);
-            }
-
             if (projectConfig == null && datafile != null && !datafile.isEmpty()) {
                 try {
                     projectConfig = new DatafileProjectConfig.Builder().withDatafile(datafile).build();
@@ -1123,6 +1118,11 @@ public class Optimizely implements AutoCloseable {
 
             if (notificationCenter == null) {
                 notificationCenter = new NotificationCenter();
+            }
+
+            // For backwards compatibility
+            if (eventProcessor == null) {
+                eventProcessor = new ForwardingEventProcessor(eventHandler, notificationCenter);
             }
 
             return new Optimizely(eventHandler, eventProcessor, errorHandler, decisionService, userProfileService, projectConfigManager, notificationCenter);

--- a/core-api/src/main/java/com/optimizely/ab/event/ForwardingEventProcessor.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/ForwardingEventProcessor.java
@@ -18,6 +18,7 @@ package com.optimizely.ab.event;
 
 import com.optimizely.ab.event.internal.EventFactory;
 import com.optimizely.ab.event.internal.UserEvent;
+import com.optimizely.ab.notification.NotificationCenter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,14 +31,20 @@ public class ForwardingEventProcessor implements EventProcessor {
     private static final Logger logger = LoggerFactory.getLogger(ForwardingEventProcessor.class);
 
     private final EventHandler eventHandler;
+    private final NotificationCenter notificationCenter;
 
-    public ForwardingEventProcessor(EventHandler eventHandler) {
+    public ForwardingEventProcessor(EventHandler eventHandler, NotificationCenter notificationCenter) {
         this.eventHandler = eventHandler;
+        this.notificationCenter = notificationCenter;
     }
 
     @Override
     public void process(UserEvent userEvent) {
         LogEvent logEvent = EventFactory.createLogEvent(userEvent);
+
+        if (notificationCenter != null) {
+            notificationCenter.send(logEvent);
+        }
 
         try {
             eventHandler.dispatchEvent(logEvent);

--- a/core-api/src/main/java/com/optimizely/ab/notification/ActivateNotification.java
+++ b/core-api/src/main/java/com/optimizely/ab/notification/ActivateNotification.java
@@ -74,6 +74,12 @@ public final class ActivateNotification {
         return variation;
     }
 
+    /**
+     * This interface is deprecated since this is no longer a one-to-one mapping.
+     * Please use a {@link NotificationHandler} explicitly for LogEvent messages.
+     * {@link com.optimizely.ab.Optimizely#addLogEventNotificationHandler(NotificationHandler)}
+     */
+    @Deprecated
     public LogEvent getEvent() {
         return event;
     }

--- a/core-api/src/main/java/com/optimizely/ab/notification/NotificationCenter.java
+++ b/core-api/src/main/java/com/optimizely/ab/notification/NotificationCenter.java
@@ -17,6 +17,7 @@
 package com.optimizely.ab.notification;
 
 import com.optimizely.ab.OptimizelyRuntimeException;
+import com.optimizely.ab.event.LogEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -94,6 +95,7 @@ public class NotificationCenter {
         validManagers.put(TrackNotification.class, new NotificationManager<TrackNotification>(counter));
         validManagers.put(DecisionNotification.class, new NotificationManager<DecisionNotification>(counter));
         validManagers.put(UpdateConfigNotification.class, new NotificationManager<UpdateConfigNotification>(counter));
+        validManagers.put(LogEvent.class, new NotificationManager<LogEvent>(counter));
 
         notifierMap = Collections.unmodifiableMap(validManagers);
     }

--- a/core-api/src/main/java/com/optimizely/ab/notification/TrackNotification.java
+++ b/core-api/src/main/java/com/optimizely/ab/notification/TrackNotification.java
@@ -68,6 +68,12 @@ public final class TrackNotification {
         return eventTags;
     }
 
+    /**
+     * This interface is deprecated since this is no longer a one-to-one mapping.
+     * Please use a {@link NotificationHandler} explicitly for LogEvent messages.
+     * {@link com.optimizely.ab.Optimizely#addLogEventNotificationHandler(NotificationHandler)}
+     */
+    @Deprecated
     public LogEvent getEvent() {
         return event;
     }

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyRule.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyRule.java
@@ -87,7 +87,8 @@ public class OptimizelyRule extends ExternalResource {
 
     public void after() {
         if (optimizely == null) {
-            return;
+            // Build so we can shut everything down.
+            build();
         }
 
         // Blocks and waits for graceful shutdown.

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -4186,6 +4186,16 @@ public class OptimizelyTest {
         assertTrue(manager.remove(notificationId));
     }
 
+    @Test
+    public void testAddLogEventNotificationHandler() {
+        Optimizely optimizely = optimizelyBuilder.withConfigManager(() -> null).build();
+        NotificationManager<LogEvent> manager = optimizely.getNotificationCenter()
+            .getNotificationManager(LogEvent.class);
+
+        int notificationId = optimizely.addLogEventNotificationHandler(message -> {});
+        assertTrue(manager.remove(notificationId));
+    }
+
     //======== Helper methods ========//
 
     private Experiment createUnknownExperiment() {

--- a/core-api/src/test/java/com/optimizely/ab/event/ForwardingEventProcessorTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/event/ForwardingEventProcessorTest.java
@@ -18,6 +18,7 @@ package com.optimizely.ab.event;
 
 import com.optimizely.ab.config.ProjectConfig;
 import com.optimizely.ab.event.internal.*;
+import com.optimizely.ab.notification.NotificationCenter;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,6 +39,7 @@ public class ForwardingEventProcessorTest {
 
     private ForwardingEventProcessor eventProcessor;
     private AtomicBoolean atomicBoolean = new AtomicBoolean();
+    private NotificationCenter notificationCenter = new NotificationCenter();
 
     @Mock
     private ProjectConfig projectConfig;
@@ -50,14 +52,24 @@ public class ForwardingEventProcessorTest {
             assertEquals(logEvent.getRequestMethod(), LogEvent.RequestMethod.POST);
             assertEquals(logEvent.getEndpointUrl(), EventFactory.EVENT_ENDPOINT);
             atomicBoolean.set(true);
-        });
+        }, notificationCenter);
     }
 
     @Test
-    public void testAddHandler() {
+    public void testEventHandler() {
         UserEvent userEvent = buildConversionEvent(EVENT_NAME);
         eventProcessor.process(userEvent);
         assertTrue(atomicBoolean.get());
+    }
+
+    @Test
+    public void testNotifications() {
+        AtomicBoolean notifcationTriggered = new AtomicBoolean();
+        notificationCenter.addNotificationHandler(LogEvent.class, x -> notifcationTriggered.set(true));
+        UserEvent userEvent = buildConversionEvent(EVENT_NAME);
+        eventProcessor.process(userEvent);
+        assertTrue(atomicBoolean.get());
+        assertTrue(notifcationTriggered.get());
     }
 
     private ConversionEvent buildConversionEvent(String eventName) {

--- a/core-api/src/test/java/com/optimizely/ab/notification/NotificationCenterTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/notification/NotificationCenterTest.java
@@ -28,6 +28,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import javax.annotation.Nonnull;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -177,6 +178,7 @@ public class NotificationCenterTest {
         assertEquals(2, notificationCenter.addNotificationHandler(DecisionNotification.class, x -> {}));
         assertEquals(3, notificationCenter.addNotificationHandler(TrackNotification.class, x -> {}));
         assertEquals(4, notificationCenter.addNotificationHandler(UpdateConfigNotification.class, x -> {}));
+        assertEquals(5, notificationCenter.addNotificationHandler(LogEvent.class, x -> {}));
     }
 
     @Test
@@ -233,6 +235,7 @@ public class NotificationCenterTest {
         testSendWithNotification(new TrackNotification());
         testSendWithNotification(new DecisionNotification());
         testSendWithNotification(new ActivateNotification());
+        testSendWithNotification(new LogEvent(LogEvent.RequestMethod.GET, "localhost", Collections.emptyMap(), null));
     }
 
     private void testSendWithNotification(Object notification) {


### PR DESCRIPTION
## Summary
- Add explicit notification for LogEvent.
- Deprecate LogEvent in track and activate notifications.

With the introduction of the BatchEventProcessor we no longer have a one-to-one mapping of Optimizely API calls to LogEvents dispatched. This PR adds a notification every time a LogEvent is built and submitted to the EventHandler. This can be subscribed to by adding a `NotificationHandler<LogEvent>` directly to the `NotificationCenter` or via the `Optimizely#addLogEventNotificationHandler(NotificationHandler)` convenience method.

We're also deprecating the LogEvent as a member of the `TrackNotification` and `ActivateNotification` models.