### PR TITLE
Add more documentation.

### DIFF
--- a/core-api/README.md
+++ b/core-api/README.md
@@ -1,7 +1,7 @@
 # Java SDK Core API
 This package contains the core APIs and interfaces for the Optimizely Full Stack API in Java.
 
-The full product documentation can be found on the the Optimizely developers site [here](https://docs.developers.optimizely.com/full-stack/docs/welcome).
+Full product documentation is in the [Optimizely developers documentation](https://docs.developers.optimizely.com/full-stack/docs/welcome).
 
 ## Installation
 
@@ -36,70 +36,71 @@ optimizely.track("conversion");
 ```
 
 ## ErrorHandler
-[`ErrorHandler`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/error/ErrorHandler.java)
+The [`ErrorHandler`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/error/ErrorHandler.java)
 interface is available for handling errors from the SDK without interfering with the host application.
 
 ### NoOpErrorHandler
-[`NoOpErrorHandler`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/error/NoOpErrorHandler.java)
+The [`NoOpErrorHandler`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/error/NoOpErrorHandler.java)
 is the default `ErrorHandler` implemetation that silently consumes all errors raised from the SDK.
 
 ### RaiseExceptionErrorHandler
-[`RaiseExceptionErrorHandler`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/error/RaiseExceptionErrorHandler.java)
+The [`RaiseExceptionErrorHandler`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/error/RaiseExceptionErrorHandler.java)
 is an implementation of `ErrorHandler` best suited for testing and development where **all** errors are raised, potentially crashing
 the hosting application.
 
 ## EventProcessor
-[`EventProcessor`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/EventProcessor.java) 
+The [`EventProcessor`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/EventProcessor.java) 
 interface is used to provide an intermediary processing stage within event production.
 It's assumed that the `EventProcessor` dispatches events via a provided `EventHandler`.
 
 ### BatchEventProcessor
 [`BatchEventProcessor`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java)
-is a batched implementation of the `EventProcessor`. Events passed to the `BatchEventProcessor` are immediately "offered" to a `BlockingQueue`.
-The `BatchEventProcessor` maintains a single consumer thread that pulls events off of the `BlockingQueue` and buffers them for either a 
-configured batch size or for a maximum duration before the resulting `LogEvent` is sent to the `EventDispatcher` and `NoticifactionCenter`.
+is an implemntation of `EventProcessor` where where events are batched prior to dispatch. The class maintains a single consumer thread that pulls 
+events off of the `BlockingQueue` and buffers them for either a
+configured batch size or a maximum duration before the resulting `LogEvent` is sent to the `EventDispatcher` and `NotificationCenter`.
 
 ### ForwardingEventProcessor
-[`ForwardingEventProcessor`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/ForwardingEventProcessor.java)
+The [`ForwardingEventProcessor`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/ForwardingEventProcessor.java)
 implements `EventProcessor` for backwards compatibility. Each event processed is converted into a [`LogEvent`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/ForwardingEventProcessor.java)
-message before getting synchronously sent to the supplied `EventHandler`.
+message before it is sent synchronously to the supplied `EventHandler`.
 
 ## EventHandler
-[`EventHandler`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/EventHandler.java)
-interface is used for dispatching events to the Optimizely event end-point. Implementations of `EventHandler#dispatchEvent(LogEvent)` are expected
+The [`EventHandler`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/EventHandler.java)
+interface is used for dispatching events to the Optimizely event endpoint. Implementations of `EventHandler#dispatchEvent(LogEvent)` are expected
 to make an HTTP request of type `getRequestMethod()` to the `LogEvent#getEndpointUrl()` location. The corresponding request parameters and body
 are available via `LogEvent#getRequestParams()` and `LogEvent#getBody()` respectively.
 
 ### NoopEventHandler
-[`NoopEventHandler`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/NoopEventHandler.java)
-implements `EventHandler` with no side-effects. Useful for testing or non-production environments.
+The [`NoopEventHandler`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/NoopEventHandler.java)
+implements `EventHandler` with no side-effects. `NoopEventHandler` is useful for testing or non-production environments.
 
 ## NotificationCenter
-[`NotificationCenter`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/notification/NotificationCenter.java)
+The [`NotificationCenter`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/notification/NotificationCenter.java)
 is the centralized component for subscribing to notifications from the SDK. Subscribers must implement the `NotificationHandler<T>` interface
 and are registered via `NotificationCenter#addNotificationHandler`. Notifications are currently sent synchronously, so be sure that 
 implementations do not block unnecessarily.
 
 ## ProjectConfig
-[`ProjectConfig`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/config/ProjectConfig.java)
+The [`ProjectConfig`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/config/ProjectConfig.java)
 represents the current state of the Optimizely project as configured through [optimizely.com](https://www.optimizely.com/).
-The interface is currently unstable and used only internally. All public access to these implementations are subject to change
+The interface is currently unstable and only used internally. All public access to this implementation is subject to change
 with each subsequent version.
 
 ### DatafileProjectConfig
-[`DatafileProjectConfig`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/config/DatafileProjectConfig.java)
+The [`DatafileProjectConfig`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/config/DatafileProjectConfig.java)
 is an implementation of `ProjectConfig` backed by a file, typically sourced from the Optimizely CDN.
 
 ## ProjectConfigManager
-[`ProjectConfigManager`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/config/ProjectConfigManager.java)
-is a factory class that serves a `ProjectConfig`. Implementations of this class provide a consistent representation
+The [`ProjectConfigManager`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/config/ProjectConfigManager.java)
+is a factory class that provides `ProjectConfig`. Implementations of this class provide a consistent representation
 of a `ProjectConfig` that can be references between service calls.
 
 ### AtomicProjectConfigManager
-[`AtomicProjectConfigManager`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/config/AtomicProjectConfigManager.java)
+The [`AtomicProjectConfigManager`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/config/AtomicProjectConfigManager.java)
 is a static provider that can be updated atomically to provide a consistent view of a `ProjectConfig`.
+is a staconfigured batch sizetic provider that can be updated atomically to provide a consistent view of a `ProjectConfig`.
 
 ### PollingProjectConfigManager
-[`PollingProjectConfigManager`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java)
-ia a abstract class that provides the framework for a dynamic factory that updates asynchronously within a background thread.
-Implementations of this class can be used to poll from externalized sourced without blocking the main application thread.
+The [`PollingProjectConfigManager`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java)
+is an abstract class that provides the framework for a dynamic factory that updates asynchronously within a background thread.
+Implementations of this class can be used to poll from an externalized sourced without blocking the main application thread.

--- a/core-api/README.md
+++ b/core-api/README.md
@@ -55,8 +55,8 @@ It's assumed that the `EventProcessor` dispatches events via a provided `EventHa
 
 ### BatchEventProcessor
 [`BatchEventProcessor`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java)
-is a batched implementation of the `EventProcessor`. Events passed to the BatchEventProcessor are immediately added to a BlockingQueue.
-The BatchEventProcessor maintains a single consumer thread that pulls events off of the BlockingQueue and buffers them for either a 
+is a batched implementation of the `EventProcessor`. Events passed to the `BatchEventProcessor` are immediately "offered" to a `BlockingQueue`.
+The `BatchEventProcessor` maintains a single consumer thread that pulls events off of the `BlockingQueue` and buffers them for either a 
 configured batch size or for a maximum duration before the resulting `LogEvent` is sent to the `EventDispatcher` and `NoticifactionCenter`.
 
 ### ForwardingEventProcessor

--- a/core-api/README.md
+++ b/core-api/README.md
@@ -1,6 +1,8 @@
 # Java SDK Core API
 This package contains the core APIs and interfaces for the Optimizely Full Stack API in Java.
 
+The full product documentation can be found on the the Optimizely developers site [here](https://docs.developers.optimizely.com/full-stack/docs/welcome).
+
 ## Installation
 
 ### Gradle
@@ -21,8 +23,6 @@ compile 'com.optimizely.ab:core-api:{VERSION}'
 ## Optimizely
 [`Optimizely`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/Optimizely.java)
 provides top level API access to the Full Stack project.
-
-The full product documentation can be found on the the Optimizely developers site [here](https://docs.developers.optimizely.com/full-stack/docs/welcome). 
 
 ### Usage
 ```Java

--- a/core-api/README.md
+++ b/core-api/README.md
@@ -27,8 +27,8 @@ The full product documentation can be found on the the Optimizely developers sit
 ### Usage
 ```Java
 Optimizely optimizely = Optimizely.builder()
-    .withConfigManager()
-    .withEventProcessor()
+    .withConfigManager(configManager)
+    .withEventProcessor(eventProcessor)
     .build();
 
 Variation variation = optimizely.activate("ad-test");
@@ -40,10 +40,13 @@ optimizely.track("conversion");
 interface is available for handling errors from the SDK without interfering with the host application.
 
 ### NoOpErrorHandler
-[`NoOpErrorHandler`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/error/ErrorHandler.java)
+[`NoOpErrorHandler`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/error/NoOpErrorHandler.java)
+is the default `ErrorHandler` implemetation that silently consumes all errors raised from the SDK.
 
 ### RaiseExceptionErrorHandler
 [`RaiseExceptionErrorHandler`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/error/RaiseExceptionErrorHandler.java)
+is an implementation of `ErrorHandler` best suited for testing and development where **all** errors are raised, potentially crashing
+the hosting application.
 
 ## EventProcessor
 [`EventProcessor`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/EventProcessor.java) 

--- a/core-api/README.md
+++ b/core-api/README.md
@@ -55,7 +55,7 @@ It's assumed that the `EventProcessor` dispatches events via a provided `EventHa
 
 ### BatchEventProcessor
 [`BatchEventProcessor`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java)
-is an implemntation of `EventProcessor` where where events are batched prior to dispatch. The class maintains a single consumer thread that pulls 
+is an implementation of `EventProcessor` where events are batched. The class maintains a single consumer thread that pulls
 events off of the `BlockingQueue` and buffers them for either a
 configured batch size or a maximum duration before the resulting `LogEvent` is sent to the `EventDispatcher` and `NotificationCenter`.
 
@@ -77,8 +77,8 @@ implements `EventHandler` with no side-effects. `NoopEventHandler` is useful for
 ## NotificationCenter
 The [`NotificationCenter`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/notification/NotificationCenter.java)
 is the centralized component for subscribing to notifications from the SDK. Subscribers must implement the `NotificationHandler<T>` interface
-and are registered via `NotificationCenter#addNotificationHandler`. Notifications are currently sent synchronously, so be sure that 
-implementations do not block unnecessarily.
+and are registered via `NotificationCenterxaddNotificationHandler`. Note that notifications are called synchronously and have the potential to
+block the main thread.
 
 ## ProjectConfig
 The [`ProjectConfig`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/config/ProjectConfig.java)
@@ -98,7 +98,6 @@ of a `ProjectConfig` that can be references between service calls.
 ### AtomicProjectConfigManager
 The [`AtomicProjectConfigManager`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/config/AtomicProjectConfigManager.java)
 is a static provider that can be updated atomically to provide a consistent view of a `ProjectConfig`.
-is a staconfigured batch sizetic provider that can be updated atomically to provide a consistent view of a `ProjectConfig`.
 
 ### PollingProjectConfigManager
 The [`PollingProjectConfigManager`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java)

--- a/core-api/README.md
+++ b/core-api/README.md
@@ -58,12 +58,12 @@ configured batch size or for a maximum duration before the resulting `LogEvent` 
 
 ### ForwardingEventProcessor
 [`ForwardingEventProcessor`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/ForwardingEventProcessor.java)
-implements `EventProcessor` for backwards compatibility. Each event Processed is translated into a [`LogEvent`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/ForwardingEventProcessor.java)
-before getting synchronously sent along to the supplied `EventHandler`.
+implements `EventProcessor` for backwards compatibility. Each event processed is converted into a [`LogEvent`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/ForwardingEventProcessor.java)
+message before getting synchronously sent to the supplied `EventHandler`.
 
 ## EventHandler
 [`EventHandler`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/EventHandler.java)
-interface is used for dispatching events to the Optimizely event end-point. Implementations of `dispatchEvent(LogEvent)` are expected
+interface is used for dispatching events to the Optimizely event end-point. Implementations of `EventHandler#dispatchEvent(LogEvent)` are expected
 to make an HTTP request of type `getRequestMethod()` to the `LogEvent#getEndpointUrl()` location. The corresponding request parameters and body
 are available via `LogEvent#getRequestParams()` and `LogEvent#getBody()` respectively.
 
@@ -84,13 +84,13 @@ The interface is currently unstable and used only internally. All public access 
 with each subsequent version.
 
 ### DatafileProjectConfig
-[`DatafileProjecyConfig](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/config/DatafileProjectConfig.java)
-is an implementation of `ProjectConfig` backed by a file typically located within the Optimizely CDN.
+[`DatafileProjectConfig`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/config/DatafileProjectConfig.java)
+is an implementation of `ProjectConfig` backed by a file, typically sourced from the Optimizely CDN.
 
 ## ProjectConfigManager
 [`ProjectConfigManager`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/config/ProjectConfigManager.java)
-is a factory class that serves a `ProjectConfig`. Implementations of this class serve to provide a consistent representation
-of a `ProjectConfig` that can be passed between services.
+is a factory class that serves a `ProjectConfig`. Implementations of this class provide a consistent representation
+of a `ProjectConfig` that can be references between service calls.
 
 ### AtomicProjectConfigManager
 [`AtomicProjectConfigManager`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/config/AtomicProjectConfigManager.java)
@@ -98,5 +98,5 @@ is a static provider that can be updated atomically to provide a consistent view
 
 ### PollingProjectConfigManager
 [`PollingProjectConfigManager`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java)
-ia a abstract class that provides the foundation for a dynamic factory that updates asynchronously within a background thread.
-Implementations of this class can be used to poll from a HTTP or file based datafile location.
+ia a abstract class that provides the framework for a dynamic factory that updates asynchronously within a background thread.
+Implementations of this class can be used to poll from externalized sourced without blocking the main application thread.

--- a/core-api/README.md
+++ b/core-api/README.md
@@ -1,0 +1,102 @@
+# Java SDK Core API
+This package contains the core APIs and interfaces for the Optimizely Full Stack API in Java.
+
+## Installation
+
+### Gradle
+```groovy
+compile 'com.optimizely.ab:core-api:{VERSION}'
+```
+
+### Maven
+```xml
+<dependency>
+    <groupId>com.optimizely.ab</groupId>
+    <artifactId>core-api</artifactId>
+    <version>{VERSION}</version>
+</dependency>
+
+```
+
+## Optimizely
+[`Optimizely`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/Optimizely.java)
+provides top level API access to the Full Stack project.
+
+The full product documentation can be found on the the Optimizely developers site [here](https://docs.developers.optimizely.com/full-stack/docs/welcome). 
+
+### Usage
+```Java
+Optimizely optimizely = Optimizely.builder()
+    .withConfigManager()
+    .withEventProcessor()
+    .build();
+
+Variation variation = optimizely.activate("ad-test");
+optimizely.track("conversion");
+```
+
+## ErrorHandler
+[`ErrorHandler`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/error/ErrorHandler.java)
+interface is available for handling errors from the SDK without interfering with the host application.
+
+### NoOpErrorHandler
+[`NoOpErrorHandler`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/error/ErrorHandler.java)
+
+### RaiseExceptionErrorHandler
+[`RaiseExceptionErrorHandler`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/error/RaiseExceptionErrorHandler.java)
+
+## EventProcessor
+[`EventProcessor`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/EventProcessor.java) 
+interface is used to provide an intermediary processing stage within event production.
+It's assumed that the `EventProcessor` dispatches events via a provided `EventHandler`.
+
+### BatchEventProcessor
+[`BatchEventProcessor`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java)
+is a batched implementation of the `EventProcessor`. Events passed to the BatchEventProcessor are immediately added to a BlockingQueue.
+The BatchEventProcessor maintains a single consumer thread that pulls events off of the BlockingQueue and buffers them for either a 
+configured batch size or for a maximum duration before the resulting `LogEvent` is sent to the `EventDispatcher` and `NoticifactionCenter`.
+
+### ForwardingEventProcessor
+[`ForwardingEventProcessor`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/ForwardingEventProcessor.java)
+implements `EventProcessor` for backwards compatibility. Each event Processed is translated into a [`LogEvent`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/ForwardingEventProcessor.java)
+before getting synchronously sent along to the supplied `EventHandler`.
+
+## EventHandler
+[`EventHandler`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/EventHandler.java)
+interface is used for dispatching events to the Optimizely event end-point. Implementations of `dispatchEvent(LogEvent)` are expected
+to make an HTTP request of type `getRequestMethod()` to the `LogEvent#getEndpointUrl()` location. The corresponding request parameters and body
+are available via `LogEvent#getRequestParams()` and `LogEvent#getBody()` respectively.
+
+### NoopEventHandler
+[`NoopEventHandler`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/NoopEventHandler.java)
+implements `EventHandler` with no side-effects. Useful for testing or non-production environments.
+
+## NotificationCenter
+[`NotificationCenter`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/notification/NotificationCenter.java)
+is the centralized component for subscribing to notifications from the SDK. Subscribers must implement the `NotificationHandler<T>` interface
+and are registered via `NotificationCenter#addNotificationHandler`. Notifications are currently sent synchronously, so be sure that 
+implementations do not block unnecessarily.
+
+## ProjectConfig
+[`ProjectConfig`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/config/ProjectConfig.java)
+represents the current state of the Optimizely project as configured through [optimizely.com](https://www.optimizely.com/).
+The interface is currently unstable and used only internally. All public access to these implementations are subject to change
+with each subsequent version.
+
+### DatafileProjectConfig
+[`DatafileProjecyConfig](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/config/DatafileProjectConfig.java)
+is an implementation of `ProjectConfig` backed by a file typically located within the Optimizely CDN.
+
+## ProjectConfigManager
+[`ProjectConfigManager`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/config/ProjectConfigManager.java)
+is a factory class that serves a `ProjectConfig`. Implementations of this class serve to provide a consistent representation
+of a `ProjectConfig` that can be passed between services.
+
+### AtomicProjectConfigManager
+[`AtomicProjectConfigManager`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/config/AtomicProjectConfigManager.java)
+is a static provider that can be updated atomically to provide a consistent view of a `ProjectConfig`.
+
+### PollingProjectConfigManager
+[`PollingProjectConfigManager`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java)
+ia a abstract class that provides the foundation for a dynamic factory that updates asynchronously within a background thread.
+Implementations of this class can be used to poll from a HTTP or file based datafile location.

--- a/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java
@@ -36,7 +36,8 @@ import static com.optimizely.ab.internal.SafetyUtils.tryClose;
  *
  * The BatchEventProcessor maintains a single consumer thread that pulls events off of
  * the BlockingQueue and buffers them for either a configured batch size or for a
- * maximum duration before the resulting LogEvent is sent to the NotificationManager.
+ * maximum duration before the resulting LogEvent is sent to the EventHandler
+ * and NotificationCenter.
  */
 public class BatchEventProcessor implements EventProcessor, AutoCloseable {
 

--- a/core-httpclient-impl/README.md
+++ b/core-httpclient-impl/README.md
@@ -232,7 +232,7 @@ Optimizely optimizely = OptimizelyFactory.newDefaultInstance();
 
 ### Event batching
 `OptimizelyFactory` uses the [`BatchEventProcessor`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java)
-to enabled request batching to the Optimizely logging endpoint. by default, a maximum of 10 events are included in each batch
-for a maximum interval of 30 seconds. These parameters are configurable via systems properties or through the 
-`OptimizelyFactory#setMaxEventBatchSize` and `OptimizelyFactory#setMaxEventBatchInterval` respectively.
-  
+to enabled request batching to the Optimizely logging endpoint. By default, a maximum of 10 events are included in each batch
+for a maximum interval of 30 seconds. These parameters are configurable via systems properties or through the
+`OptimizelyFactory#setMaxEventBatchSize` and `OptimizelyFactory#setMaxEventBatchInterval` methods.
+ 

--- a/core-httpclient-impl/README.md
+++ b/core-httpclient-impl/README.md
@@ -230,11 +230,9 @@ If you provide the SDK via a global property, use the empty signature:
 Optimizely optimizely = OptimizelyFactory.newDefaultInstance();
 ```
 
-### Convenience APIs
-|Method Name|Description|
-|---|---|
-|||
-
 ### Event batching
 `OptimizelyFactory` uses the [`BatchEventProcessor`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java)
-to enabled request batching to the Optimizely logging endpoint. The `Batch` 
+to enabled request batching to the Optimizely logging endpoint. by default, a maximum of 10 events are included in each batch
+for a maximum interval of 30 seconds. These parameters are configurable via systems properties or through the 
+`OptimizelyFactory#setMaxEventBatchSize` and `OptimizelyFactory#setMaxEventBatchInterval` respectively.
+  

--- a/core-httpclient-impl/README.md
+++ b/core-httpclient-impl/README.md
@@ -119,7 +119,6 @@ The following properties can be set to override the default configuration.
 |**async.event.handler.event.max.per.route**|20|Maximum number of connections per route|
 |**async.event.handler.validate.after**|5000|Time to maintain idol connections (in milliseconds)|
 
-
 ## HttpProjectConfigManager
 
 [`HttpProjectConfigManager`](https://github.com/optimizely/java-sdk/blob/master/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java)
@@ -230,3 +229,12 @@ If you provide the SDK via a global property, use the empty signature:
 ```Java
 Optimizely optimizely = OptimizelyFactory.newDefaultInstance();
 ```
+
+### Convenience APIs
+|Method Name|Description|
+|---|---|
+|||
+
+### Event batching
+`OptimizelyFactory` uses the [`BatchEventProcessor`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java)
+to enabled request batching to the Optimizely logging endpoint. The `Batch` 

--- a/core-httpclient-impl/README.md
+++ b/core-httpclient-impl/README.md
@@ -232,7 +232,7 @@ Optimizely optimizely = OptimizelyFactory.newDefaultInstance();
 
 ### Event batching
 `OptimizelyFactory` uses the [`BatchEventProcessor`](https://github.com/optimizely/java-sdk/blob/master/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java)
-to enabled request batching to the Optimizely logging endpoint. By default, a maximum of 10 events are included in each batch
+to enable request batching to the Optimizely logging endpoint. By default, a maximum of 10 events are included in each batch
 for a maximum interval of 30 seconds. These parameters are configurable via systems properties or through the
 `OptimizelyFactory#setMaxEventBatchSize` and `OptimizelyFactory#setMaxEventBatchInterval` methods.
  


### PR DESCRIPTION
## Summary
- Add README to core-api package
- Update docs in core-httpclient-impl package to include `BatchEventProcessor`

Historically documentation has been deferred to the developers site, but those documents are geared towards implementation rather than development. This PR aims to add more documentation coverage for developers of the Java SDK.