### PR TITLE
Update changelog for 3.3.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Optimizely Java X SDK Changelog
 
+## 3.3.0
+October 1st, 2019
+
+### New Features:
+- Introduced `EventProcessor` interface with `BatchEventProcessor` implementation.
+- Introduced `LogEvent` notification.
+- Added `BatchEventProcessor` as the default implementation within the `OptimizelyFactory` class.
+
+### Deprecated
+- `LogEvent` was deprecated from `TrackNotification` and `ActivateNotification` notifications in favor of explicit `LogEvent` notification.
+
 ## 3.2.1
 August 19th, 2019
 


### PR DESCRIPTION
Updates the changelog for 3.3.0 release.

Note: the 3.3.0 release is based on the same commit as 3.4.0-beta but will cherry pick in this commit along with https://github.com/optimizely/java-sdk/commit/1395729dec031bc375e1a16896f31583027c076f which was patched into 3.2.1, but never included in 3.4.0-beta.