### PR TITLE
(fix): use a ParserSupplier instead of java.util.Supplier to enable work on older versions of Android.

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/config/parser/DefaultConfigParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/DefaultConfigParser.java
@@ -39,14 +39,14 @@ public final class DefaultConfigParser {
 
     //======== Helper methods ========//
     @FunctionalInterface
-    public interface ParserSupplier<T> {
+    public interface ParserSupplier {
 
         /**
          * Gets a result.
          *
          * @return a result
          */
-        T get();
+        ConfigParser get();
     }
 
     public enum ConfigParserSupplier {
@@ -59,9 +59,9 @@ public final class DefaultConfigParser {
         JSON_SIMPLE_CONFIG_PARSER("org.json.simple.JSONObject", () -> { return new JsonSimpleConfigParser(); });
 
         private final String className;
-        private final ParserSupplier<ConfigParser> supplier;
+        private final ParserSupplier supplier;
 
-        ConfigParserSupplier(String className, ParserSupplier<ConfigParser> supplier) {
+        ConfigParserSupplier(String className, ParserSupplier supplier) {
             this.className = className;
             this.supplier = supplier;
         }

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/DefaultConfigParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/DefaultConfigParser.java
@@ -38,6 +38,16 @@ public final class DefaultConfigParser {
     }
 
     //======== Helper methods ========//
+    @FunctionalInterface
+    public interface ParserSupplier<T> {
+
+        /**
+         * Gets a result.
+         *
+         * @return a result
+         */
+        T get();
+    }
 
     public enum ConfigParserSupplier {
         // WARNING THESE MUST REMAIN LAMBDAS!!!
@@ -49,9 +59,9 @@ public final class DefaultConfigParser {
         JSON_SIMPLE_CONFIG_PARSER("org.json.simple.JSONObject", () -> { return new JsonSimpleConfigParser(); });
 
         private final String className;
-        private final Supplier<ConfigParser> supplier;
+        private final ParserSupplier<ConfigParser> supplier;
 
-        ConfigParserSupplier(String className, Supplier<ConfigParser> supplier) {
+        ConfigParserSupplier(String className, ParserSupplier<ConfigParser> supplier) {
             this.className = className;
             this.supplier = supplier;
         }


### PR DESCRIPTION
## Summary
- This has been tested on all supported versions and it works now.  We will also need to release 3.3.1 to patch this for Android.

## Test plan
Tested on Android.  It will also work on travis after this fix.  Travis builds won't pass with 3.3.0

## Issues
Android versions < API 24 can't use java.util.Supplier.  This replaces Supplier with a local ParserSupplier which allows it to work on all versions of Android.