### PR TITLE
(chore): refactor batch event processor to use blocking queue poll and take so as not to spin too much.

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java
@@ -136,7 +136,7 @@ public class BatchEventProcessor implements EventProcessor, AutoCloseable {
             try {
                 int waitCount = 0;
 
-                QueueService polling = () -> eventQueue.poll(flushInterval, TimeUnit.MILLISECONDS);
+                QueueService polling = () -> eventQueue.poll(System.currentTimeMillis() - flushInterval, TimeUnit.MILLISECONDS);
                 QueueService take = () -> eventQueue.take();
                 QueueService using = polling;
 
@@ -151,12 +151,10 @@ public class BatchEventProcessor implements EventProcessor, AutoCloseable {
 
                     if (item == null) {
                         logger.debug("Empty item after waiting flush interval. Flushing.");
-                        flush();
                         waitCount++;
                         if (waitCount > DEFAULT_WAIT_COUNT) {
                             using = take;
                         }
-                        deadline = System.currentTimeMillis() + flushInterval;
                         continue;
                     }
 

--- a/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java
@@ -133,7 +133,7 @@ public class BatchEventProcessor implements EventProcessor, AutoCloseable {
                 int emptyCount = 0;
 
                 while (true) {
-                    if (System.currentTimeMillis() > deadline) {
+                    if (System.currentTimeMillis() >= deadline) {
                         logger.debug("Deadline exceeded flushing current batch.");
                         flush();
                         deadline = System.currentTimeMillis() + flushInterval;

--- a/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java
@@ -143,7 +143,7 @@ public class BatchEventProcessor implements EventProcessor, AutoCloseable {
                     Object item = emptyCount > DEFAULT_EMPTY_COUNT ? eventQueue.take() : eventQueue.poll(timeout, TimeUnit.MILLISECONDS);
 
                     if (item == null) {
-                        logger.debug("Empty item after waiting flush interval. Flushing.");
+                        logger.debug("Empty item after waiting flush interval.");
                         emptyCount++;
                         continue;
                     }

--- a/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java
@@ -136,10 +136,11 @@ public class BatchEventProcessor implements EventProcessor, AutoCloseable {
                         deadline = System.currentTimeMillis() + flushInterval;
                     }
 
-                    Object item = eventQueue.poll(50, TimeUnit.MILLISECONDS);
+                    Object item = eventQueue.poll(flushInterval, TimeUnit.MILLISECONDS);
                     if (item == null) {
-                        logger.debug("Empty item, sleeping for 50ms.");
-                        Thread.sleep(50);
+                        logger.debug("Empty item after waiting flush interval. Flushing.");
+                        flush();
+                        deadline = System.currentTimeMillis() + flushInterval;
                         continue;
                     }
 

--- a/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java
@@ -133,6 +133,7 @@ public class BatchEventProcessor implements EventProcessor, AutoCloseable {
                     if (System.currentTimeMillis() > deadline) {
                         logger.debug("Deadline exceeded flushing current batch.");
                         flush();
+                        deadline = System.currentTimeMillis() + flushInterval;
                     }
 
                     Object item = eventQueue.poll(50, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
## Summary
- pass in current time - flush interval to polling mechanism.
- use take instead of poll if we have been cycling more than twice.
- reset deadline once we hit it so it doesn't repeat until next flush interval.

## Test plan
FSC test?
