### PR TITLE
Add support for native http proxying.

### DIFF
--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyHttpClient.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyHttpClient.java
@@ -103,6 +103,7 @@ public class OptimizelyHttpClient implements Closeable {
                 .setDefaultRequestConfig(HttpClientUtils.DEFAULT_REQUEST_CONFIG)
                 .setConnectionManager(poolingHttpClientConnectionManager)
                 .disableCookieManagement()
+                .useSystemProperties()
                 .build();
 
             return new OptimizelyHttpClient(closableHttpClient);

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyHttpClientTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyHttpClientTest.java
@@ -22,6 +22,8 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.conn.HttpHostConnectException;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -31,6 +33,16 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class OptimizelyHttpClientTest {
+
+    @Before
+    public void setUp() {
+        System.setProperty("https.proxyHost", "localhost");
+    }
+
+    @After
+    public void tearDown() {
+        System.clearProperty("https.proxyHost");
+    }
 
     @Test
     public void testDefaultConfiguration() {
@@ -51,7 +63,6 @@ public class OptimizelyHttpClientTest {
 
     @Test(expected = HttpHostConnectException.class)
     public void testProxySettings() throws IOException {
-        System.setProperty("https.proxyHost", "localhost");
         OptimizelyHttpClient optimizelyHttpClient = OptimizelyHttpClient.builder().build();
 
         // If this request succeeds then the proxy config was not picked up.

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyHttpClientTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyHttpClientTest.java
@@ -16,12 +16,11 @@
  */
 package com.optimizely.ab;
 
-import org.apache.http.HttpResponse;
-import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.HttpClient;
 import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.conn.HttpHostConnectException;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Test;
 
@@ -48,6 +47,16 @@ public class OptimizelyHttpClientTest {
             .build();
 
         assertTrue(optimizelyHttpClient.getHttpClient() instanceof CloseableHttpClient);
+    }
+
+    @Test(expected = HttpHostConnectException.class)
+    public void testProxySettings() throws IOException {
+        System.setProperty("https.proxyHost", "localhost");
+        OptimizelyHttpClient optimizelyHttpClient = OptimizelyHttpClient.builder().build();
+
+        // If this request succeeds then the proxy config was not picked up.
+        HttpGet get = new HttpGet("https://www.optimizely.com");
+        optimizelyHttpClient.execute(get);
     }
 
     @Test

--- a/java-quickstart/build.gradle
+++ b/java-quickstart/build.gradle
@@ -9,6 +9,8 @@ dependencies {
 }
 
 task runExample(type: JavaExec) {
+    systemProperties System.properties
+
     main "com.optimizely.Example"
     classpath sourceSets.test.runtimeClasspath
 }


### PR DESCRIPTION
## Summary
- Use system properties with custom http client.

This enables http client settings (e.g. `http.proxyHost`, etc) to be set via system properties.

## Test plan
- Unit test ensuring system properties are getting pulled in.
- Manually tested by running a local proxy and the provided example via `./gradlew -Dhttps.proxyHost=localhost -Dhttps.proxyPort=8888 runExample`

## Issues
- OASIS-5725