### PR TITLE
Properly set logger name for AudienceIdCondition and ConditionUtils

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/config/audience/AudienceIdCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/AudienceIdCondition.java
@@ -40,7 +40,7 @@ public class AudienceIdCondition<T> implements Condition<T> {
     private Audience audience;
     final private String audienceId;
 
-    final private static Logger logger = LoggerFactory.getLogger("AudienceIdCondition");
+    final private static Logger logger = LoggerFactory.getLogger(AudienceIdCondition.class);
 
     /**
      * Constructor used in json parsing to store the audienceId parsed from Experiment.audienceConditions.

--- a/core-api/src/main/java/com/optimizely/ab/internal/ConditionUtils.java
+++ b/core-api/src/main/java/com/optimizely/ab/internal/ConditionUtils.java
@@ -35,7 +35,7 @@ import java.util.Map;
 
 public class ConditionUtils {
 
-    static Logger logger = LoggerFactory.getLogger("ConditionUtil");
+    static Logger logger = LoggerFactory.getLogger(ConditionUtils.class);
 
     static public <T> Condition parseConditions(Class<T> clazz, Object object) throws InvalidAudienceCondition {
 


### PR DESCRIPTION
## Summary

The Logger name for `AudienceIdCondition.java` is currently just the static string "AudienceIdCondition". This means that it's not possible to change the log level of this class using the `com.optimizely` group.

This should be changed to use the class `AudienceIdCondition.class` itself.