### PR TITLE
(fix) change log level to warn when experiment not in datafile

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/config/DatafileProjectConfig.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/DatafileProjectConfig.java
@@ -221,7 +221,7 @@ public class DatafileProjectConfig implements ProjectConfig {
         // if the given experiment key isn't present in the config, log an exception to the error handler
         if (experiment == null) {
             String unknownExperimentError = String.format("Experiment \"%s\" is not in the datafile.", experimentKey);
-            logger.error(unknownExperimentError);
+            logger.warn(unknownExperimentError);
             errorHandler.handleError(new UnknownExperimentException(unknownExperimentError));
         }
 
@@ -247,7 +247,7 @@ public class DatafileProjectConfig implements ProjectConfig {
         // if the given event name isn't present in the config, log an exception to the error handler
         if (eventType == null) {
             String unknownEventTypeError = String.format("Event \"%s\" is not in the datafile.", eventName);
-            logger.error(unknownEventTypeError);
+            logger.warn(unknownEventTypeError);
             errorHandler.handleError(new UnknownEventTypeException(unknownEventTypeError));
         }
 

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -531,7 +531,7 @@ public class OptimizelyTest {
         Experiment unknownExperiment = createUnknownExperiment();
         Optimizely optimizely = optimizelyBuilder.withErrorHandler(new NoOpErrorHandler()).build();
 
-        logbackVerifier.expectMessage(Level.ERROR, "Experiment \"unknown_experiment\" is not in the datafile.");
+        logbackVerifier.expectMessage(Level.WARN, "Experiment \"unknown_experiment\" is not in the datafile.");
         logbackVerifier.expectMessage(Level.INFO,
             "Not activating user \"userId\" for experiment \"unknown_experiment\".");
 
@@ -986,7 +986,7 @@ public class OptimizelyTest {
 
         Optimizely optimizely = optimizelyBuilder.withErrorHandler(new NoOpErrorHandler()).build();
 
-        logbackVerifier.expectMessage(Level.ERROR, "Event \"unknown_event_type\" is not in the datafile.");
+        logbackVerifier.expectMessage(Level.WARN, "Event \"unknown_event_type\" is not in the datafile.");
         logbackVerifier.expectMessage(Level.INFO, "Not tracking event \"unknown_event_type\" for user \"userId\".");
         optimizely.track(unknownEventType.getKey(), testUserId);
     }
@@ -1333,7 +1333,7 @@ public class OptimizelyTest {
             .withErrorHandler(new NoOpErrorHandler())
             .build();
 
-        logbackVerifier.expectMessage(Level.ERROR, "Experiment \"unknown_experiment\" is not in the datafile.");
+        logbackVerifier.expectMessage(Level.WARN, "Experiment \"unknown_experiment\" is not in the datafile.");
 
         // since we use a NoOpErrorHandler, we should fail and return null
         Variation actualVariation = optimizely.getVariation(unknownExperiment.getKey(), testUserId);


### PR DESCRIPTION
## Summary
- This changes the log severity level to be `WARN` when experiment and event names are passed that are not in the datafile. Currently it is an `ERROR`, however that seems to be too severe since the situation is completely recoverable. (see #353)

## Test plan
- Pass in experiment name and event name that does not exist, make sure error is logged at `WARN` severity level

## Issues
- fixes #353