### PR TITLE
[HttpProjectConfigManager] Change "Fetching datafile from" log to deb…

### DIFF
--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
@@ -110,7 +110,7 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
             httpGet.setHeader(HttpHeaders.IF_MODIFIED_SINCE, datafileLastModified);
         }
 
-        logger.info("Fetching datafile from: {}", httpGet.getURI());
+        logger.debug("Fetching datafile from: {}", httpGet.getURI());
         try {
             HttpResponse response = httpClient.execute(httpGet);
             String datafile = getDatafileFromResponse(response);


### PR DESCRIPTION
…ug level

Info level logging on this is causing us two problems:

1) It's spamming our logs (which company wide are info) with this log line
2) We don't want the datafile name, which happens to correspond to the api key in our logs either

Debug solves both of these and we can optionally turn it on if we are seeing issues with datafile fetching.

## Summary
- The "what"; a concise description of each logical change
- Another change

The "why", or other context.

## Test plan

## Issues
- "THING-1234" or "Fixes #123"