### PR TITLE
fix(log-level) Adjusting log level on audience evaluation logs

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/config/audience/AudienceIdCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/AudienceIdCondition.java
@@ -76,7 +76,7 @@ public class AudienceIdCondition<T> implements Condition<T> {
         }
         logger.debug("Starting to evaluate audience {} with conditions: \"{}\"", audience.getName(), audience.getConditions());
         Boolean result = audience.getConditions().evaluate(config, attributes);
-        logger.info("Audience {} evaluated to {}", audience.getName(), result);
+        logger.debug("Audience {} evaluated to {}", audience.getName(), result);
         return result;
     }
 

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/AudienceIdCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/AudienceIdCondition.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2018-2019, Optimizely and contributors
+ *    Copyright 2018-2020, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/internal/ExperimentUtils.java
+++ b/core-api/src/main/java/com/optimizely/ab/internal/ExperimentUtils.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2017-2020, Optimizely and contributors
+ *    Copyright 2017-2019, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/internal/ExperimentUtils.java
+++ b/core-api/src/main/java/com/optimizely/ab/internal/ExperimentUtils.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2017-2019, Optimizely and contributors
+ *    Copyright 2017-2020, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/internal/ExperimentUtilsTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/internal/ExperimentUtilsTest.java
@@ -142,7 +142,7 @@ public class ExperimentUtilsTest {
             "Evaluating audiences for experiment \"etag1\": \"[100]\"");
         logbackVerifier.expectMessage(Level.DEBUG,
             "Starting to evaluate audience not_firefox_users with conditions: \"[and, [or, [not, [or, {name='browser_type', type='custom_attribute', match='null', value='firefox'}]]]]\"");
-        logbackVerifier.expectMessage(Level.INFO,
+        logbackVerifier.expectMessage(Level.DEBUG,
             "Audience not_firefox_users evaluated to true");
         logbackVerifier.expectMessage(Level.INFO,
             "Audiences for experiment etag1 collectively evaluated to true");
@@ -163,7 +163,7 @@ public class ExperimentUtilsTest {
             "Evaluating audiences for experiment \"etag1\": \"[100]\"");
         logbackVerifier.expectMessage(Level.DEBUG,
             "Starting to evaluate audience not_firefox_users with conditions: \"[and, [or, [not, [or, {name='browser_type', type='custom_attribute', match='null', value='firefox'}]]]]\"");
-        logbackVerifier.expectMessage(Level.INFO,
+        logbackVerifier.expectMessage(Level.DEBUG,
             "Audience not_firefox_users evaluated to true");
         logbackVerifier.expectMessage(Level.INFO,
             "Audiences for experiment etag1 collectively evaluated to true");
@@ -184,7 +184,7 @@ public class ExperimentUtilsTest {
             "Evaluating audiences for experiment \"typed_audience_experiment\": \"[or, 3468206643, 3468206644, 3468206646, 3468206645]\"");
         logbackVerifier.expectMessage(Level.DEBUG,
             "Starting to evaluate audience BOOL with conditions: \"[and, [or, [or, {name='booleanKey', type='custom_attribute', match='exact', value=true}]]]\"");
-        logbackVerifier.expectMessage(Level.INFO,
+        logbackVerifier.expectMessage(Level.DEBUG,
             "Audience BOOL evaluated to true");
         logbackVerifier.expectMessage(Level.INFO,
             "Audiences for experiment typed_audience_experiment collectively evaluated to true");
@@ -205,7 +205,7 @@ public class ExperimentUtilsTest {
             "Evaluating audiences for experiment \"etag1\": \"[100]\"");
         logbackVerifier.expectMessage(Level.DEBUG,
             "Starting to evaluate audience not_firefox_users with conditions: \"[and, [or, [not, [or, {name='browser_type', type='custom_attribute', match='null', value='firefox'}]]]]\"");
-        logbackVerifier.expectMessage(Level.INFO,
+        logbackVerifier.expectMessage(Level.DEBUG,
             "Audience not_firefox_users evaluated to true");
         logbackVerifier.expectMessage(Level.INFO,
             "Audiences for experiment etag1 collectively evaluated to true");
@@ -226,7 +226,7 @@ public class ExperimentUtilsTest {
             "Evaluating audiences for experiment \"etag1\": \"[100]\"");
         logbackVerifier.expectMessage(Level.DEBUG,
             "Starting to evaluate audience not_firefox_users with conditions: \"[and, [or, [not, [or, {name='browser_type', type='custom_attribute', match='null', value='firefox'}]]]]\"");
-        logbackVerifier.expectMessage(Level.INFO,
+        logbackVerifier.expectMessage(Level.DEBUG,
             "Audience not_firefox_users evaluated to false");
         logbackVerifier.expectMessage(Level.INFO,
             "Audiences for experiment etag1 collectively evaluated to false");
@@ -262,7 +262,7 @@ public class ExperimentUtilsTest {
             "Starting to evaluate audience audience_with_missing_value with conditions: \"[and, [or, [or, {name='nationality', type='custom_attribute', match='null', value='English'}, {name='nationality', type='custom_attribute', match='null', value=null}]]]\"");
         logbackVerifier.expectMessage(Level.WARN,
             "Audience condition \"{name='nationality', type='custom_attribute', match='null', value=null}\" has an unexpected value type. You may need to upgrade to a newer release of the Optimizely SDK");
-        logbackVerifier.expectMessage(Level.INFO,
+        logbackVerifier.expectMessage(Level.DEBUG,
             "Audience audience_with_missing_value evaluated to null");
         logbackVerifier.expectMessage(Level.INFO,
             "Audiences for experiment experiment_with_malformed_audience collectively evaluated to null");
@@ -283,7 +283,7 @@ public class ExperimentUtilsTest {
             "Starting to evaluate audience audience_with_missing_value with conditions: \"[and, [or, [or, {name='nationality', type='custom_attribute', match='null', value='English'}, {name='nationality', type='custom_attribute', match='null', value=null}]]]\"");
         logbackVerifier.expectMessage(Level.WARN,
             "Audience condition \"{name='nationality', type='custom_attribute', match='null', value=null}\" has an unexpected value type. You may need to upgrade to a newer release of the Optimizely SDK");
-        logbackVerifier.expectMessage(Level.INFO,
+        logbackVerifier.expectMessage(Level.DEBUG,
             "Audience audience_with_missing_value evaluated to null");
         logbackVerifier.expectMessage(Level.INFO,
             "Audiences for experiment experiment_with_malformed_audience collectively evaluated to null");


### PR DESCRIPTION
## Summary
- Updating audience evaluation log level to be debug. The only info level log will be the one corresponding to the result of overall evaluation of an audience.
