### PR TITLE
feat: add support for authenticated datafile access

### DIFF
--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyFactory.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyFactory.java
@@ -179,6 +179,18 @@ public final class OptimizelyFactory {
      * @param fallback Fallback datafile string used by the ProjectConfigManager to be immediately available.
      */
     public static Optimizely newDefaultInstance(String sdkKey, String fallback) {
+        String datafileAuthToken = PropertyUtils.get(HttpProjectConfigManager.CONFIG_DATAFILE_AUTH_TOKEN);
+        return newDefaultInstance(sdkKey, fallback, datafileAuthToken);
+    }
+
+    /**
+     * Returns a new Optimizely instance with authenticated datafile support.
+     *
+     * @param sdkKey   SDK key used to build the ProjectConfigManager.
+     * @param fallback Fallback datafile string used by the ProjectConfigManager to be immediately available.
+     * @param datafileAuthToken  Token for authenticated datafile access.
+     */
+    public static Optimizely newDefaultInstance(String sdkKey, String fallback, String datafileAuthToken) {
         NotificationCenter notificationCenter = new NotificationCenter();
 
         HttpProjectConfigManager.Builder builder = HttpProjectConfigManager.builder()
@@ -186,24 +198,9 @@ public final class OptimizelyFactory {
             .withNotificationCenter(notificationCenter)
             .withSdkKey(sdkKey);
 
-        return newDefaultInstance(builder.build(), notificationCenter);
-    }
-
-    /**
-     * Returns a new Optimizely instance with authenticated datafile support.
-     *
-     * @param sdkKey   SDK key used to build the ProjectConfigManager.
-     * @param datafileAuthToken  Token for authenticated datafile access.
-     * @param fallback Fallback datafile string used by the ProjectConfigManager to be immediately available.
-     */
-    public static Optimizely newDefaultInstance(String sdkKey, String datafileAuthToken, String fallback) {
-        NotificationCenter notificationCenter = new NotificationCenter();
-
-        HttpProjectConfigManager.Builder builder = HttpProjectConfigManager.builder()
-            .withDatafile(fallback)
-            .withNotificationCenter(notificationCenter)
-            .withSdkKey(sdkKey)
-            .withDatafileAuthToken(datafileAuthToken);
+        if (datafileAuthToken != null) {
+            builder.withDatafileAuthToken(datafileAuthToken);
+        }
 
         return newDefaultInstance(builder.build(), notificationCenter);
     }

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyFactory.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyFactory.java
@@ -179,8 +179,8 @@ public final class OptimizelyFactory {
      * @param fallback Fallback datafile string used by the ProjectConfigManager to be immediately available.
      */
     public static Optimizely newDefaultInstance(String sdkKey, String fallback) {
-        String datafileAuthToken = PropertyUtils.get(HttpProjectConfigManager.CONFIG_DATAFILE_AUTH_TOKEN);
-        return newDefaultInstance(sdkKey, fallback, datafileAuthToken);
+        String datafileAccessToken = PropertyUtils.get(HttpProjectConfigManager.CONFIG_DATAFILE_AUTH_TOKEN);
+        return newDefaultInstance(sdkKey, fallback, datafileAccessToken);
     }
 
     /**
@@ -188,9 +188,9 @@ public final class OptimizelyFactory {
      *
      * @param sdkKey   SDK key used to build the ProjectConfigManager.
      * @param fallback Fallback datafile string used by the ProjectConfigManager to be immediately available.
-     * @param datafileAuthToken  Token for authenticated datafile access.
+     * @param datafileAccessToken  Token for authenticated datafile access.
      */
-    public static Optimizely newDefaultInstance(String sdkKey, String fallback, String datafileAuthToken) {
+    public static Optimizely newDefaultInstance(String sdkKey, String fallback, String datafileAccessToken) {
         NotificationCenter notificationCenter = new NotificationCenter();
 
         HttpProjectConfigManager.Builder builder = HttpProjectConfigManager.builder()
@@ -198,8 +198,8 @@ public final class OptimizelyFactory {
             .withNotificationCenter(notificationCenter)
             .withSdkKey(sdkKey);
 
-        if (datafileAuthToken != null) {
-            builder.withDatafileAuthToken(datafileAuthToken);
+        if (datafileAccessToken != null) {
+            builder.withDatafileAccessToken(datafileAccessToken);
         }
 
         return newDefaultInstance(builder.build(), notificationCenter);

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyFactory.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyFactory.java
@@ -190,6 +190,25 @@ public final class OptimizelyFactory {
     }
 
     /**
+     * Returns a new Optimizely instance with authenticated datafile support.
+     *
+     * @param sdkKey   SDK key used to build the ProjectConfigManager.
+     * @param authDatafileToken  Token for authenticated datafile access.
+     * @param fallback Fallback datafile string used by the ProjectConfigManager to be immediately available.
+     */
+    public static Optimizely newDefaultInstance(String sdkKey, String authDatafileToken, String fallback) {
+        NotificationCenter notificationCenter = new NotificationCenter();
+
+        HttpProjectConfigManager.Builder builder = HttpProjectConfigManager.builder()
+            .withDatafile(fallback)
+            .withNotificationCenter(notificationCenter)
+            .withSdkKey(sdkKey)
+            .withAuthDatafileToken(authDatafileToken);
+
+        return newDefaultInstance(builder.build(), notificationCenter);
+    }
+
+    /**
      * Returns a new Optimizely instance based on preset configuration.
      * EventHandler - {@link AsyncEventHandler}
      *

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyFactory.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyFactory.java
@@ -193,17 +193,17 @@ public final class OptimizelyFactory {
      * Returns a new Optimizely instance with authenticated datafile support.
      *
      * @param sdkKey   SDK key used to build the ProjectConfigManager.
-     * @param authDatafileToken  Token for authenticated datafile access.
+     * @param datafileAuthToken  Token for authenticated datafile access.
      * @param fallback Fallback datafile string used by the ProjectConfigManager to be immediately available.
      */
-    public static Optimizely newDefaultInstance(String sdkKey, String authDatafileToken, String fallback) {
+    public static Optimizely newDefaultInstance(String sdkKey, String datafileAuthToken, String fallback) {
         NotificationCenter notificationCenter = new NotificationCenter();
 
         HttpProjectConfigManager.Builder builder = HttpProjectConfigManager.builder()
             .withDatafile(fallback)
             .withNotificationCenter(notificationCenter)
             .withSdkKey(sdkKey)
-            .withAuthDatafileToken(authDatafileToken);
+            .withDatafileAuthToken(datafileAuthToken);
 
         return newDefaultInstance(builder.build(), notificationCenter);
     }

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
@@ -45,6 +45,7 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
     public static final String CONFIG_BLOCKING_DURATION = "http.project.config.manager.blocking.duration";
     public static final String CONFIG_BLOCKING_UNIT     = "http.project.config.manager.blocking.unit";
     public static final String CONFIG_SDK_KEY           = "http.project.config.manager.sdk.key";
+    public static final String CONFIG_DATAFILE_AUTH_TOKEN = "http.project.config.manager.datafile.auth.token";
 
     public static final long DEFAULT_POLLING_DURATION  = 5;
     public static final TimeUnit DEFAULT_POLLING_UNIT  = TimeUnit.MINUTES;

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
@@ -54,21 +54,21 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
 
     private final OptimizelyHttpClient httpClient;
     private final URI uri;
-    private final String authDatafileToken;
+    private final String datafileAuthToken;
     private String datafileLastModified;
 
     private HttpProjectConfigManager(long period,
                                      TimeUnit timeUnit,
                                      OptimizelyHttpClient httpClient,
                                      String url,
-                                     String authDatafileToken,
+                                     String datafileAuthToken,
                                      long blockingTimeoutPeriod,
                                      TimeUnit blockingTimeoutUnit,
                                      NotificationCenter notificationCenter) {
         super(period, timeUnit, blockingTimeoutPeriod, blockingTimeoutUnit, notificationCenter);
         this.httpClient = httpClient;
         this.uri = URI.create(url);
-        this.authDatafileToken = authDatafileToken;
+        this.datafileAuthToken = datafileAuthToken;
     }
 
     public URI getUri() {
@@ -133,8 +133,8 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
     HttpGet createHttpRequest() {
         HttpGet httpGet = new HttpGet(uri);
 
-        if (authDatafileToken != null) {
-            httpGet.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + authDatafileToken);
+        if (datafileAuthToken != null) {
+            httpGet.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + datafileAuthToken);
         }
 
         if (datafileLastModified != null) {
@@ -151,7 +151,7 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
     public static class Builder {
         private String datafile;
         private String url;
-        private String authDatafileToken = null;
+        private String datafileAuthToken = null;
         private String format = "https://cdn.optimizely.com/datafiles/%s.json";
         private String authFormat = "https://config.optimizely.com/datafiles/auth/%s.json";
         private OptimizelyHttpClient httpClient;
@@ -174,8 +174,8 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
             return this;
         }
 
-        public Builder withAuthDatafileToken(String token) {
-            this.authDatafileToken = token;
+        public Builder withDatafileAuthToken(String token) {
+            this.datafileAuthToken = token;
             return this;
         }
 
@@ -287,7 +287,7 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
                     throw new NullPointerException("sdkKey cannot be null");
                 }
 
-                if (authDatafileToken == null) {
+                if (datafileAuthToken == null) {
                     url = String.format(format, sdkKey);
                 } else {
                     url = String.format(authFormat, sdkKey);
@@ -303,7 +303,7 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
                 timeUnit,
                 httpClient,
                 url,
-                authDatafileToken,
+                datafileAuthToken,
                 blockingTimeoutPeriod,
                 blockingTimeoutUnit,
                 notificationCenter);

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
@@ -56,21 +56,21 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
 
     private final OptimizelyHttpClient httpClient;
     private final URI uri;
-    private final String datafileAuthToken;
+    private final String datafileAccessToken;
     private String datafileLastModified;
 
     private HttpProjectConfigManager(long period,
                                      TimeUnit timeUnit,
                                      OptimizelyHttpClient httpClient,
                                      String url,
-                                     String datafileAuthToken,
+                                     String datafileAccessToken,
                                      long blockingTimeoutPeriod,
                                      TimeUnit blockingTimeoutUnit,
                                      NotificationCenter notificationCenter) {
         super(period, timeUnit, blockingTimeoutPeriod, blockingTimeoutUnit, notificationCenter);
         this.httpClient = httpClient;
         this.uri = URI.create(url);
-        this.datafileAuthToken = datafileAuthToken;
+        this.datafileAccessToken = datafileAccessToken;
     }
 
     public URI getUri() {
@@ -136,8 +136,8 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
     HttpGet createHttpRequest() {
         HttpGet httpGet = new HttpGet(uri);
 
-        if (datafileAuthToken != null) {
-            httpGet.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + datafileAuthToken);
+        if (datafileAccessToken != null) {
+            httpGet.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + datafileAccessToken);
         }
 
         if (datafileLastModified != null) {
@@ -154,7 +154,7 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
     public static class Builder {
         private String datafile;
         private String url;
-        private String datafileAuthToken = null;
+        private String datafileAccessToken = null;
         private String format = "https://cdn.optimizely.com/datafiles/%s.json";
         private String authFormat = "https://config.optimizely.com/datafiles/auth/%s.json";
         private OptimizelyHttpClient httpClient;
@@ -177,8 +177,8 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
             return this;
         }
 
-        public Builder withDatafileAuthToken(String token) {
-            this.datafileAuthToken = token;
+        public Builder withDatafileAccessToken(String token) {
+            this.datafileAccessToken = token;
             return this;
         }
 
@@ -290,7 +290,7 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
                     throw new NullPointerException("sdkKey cannot be null");
                 }
 
-                if (datafileAuthToken == null) {
+                if (datafileAccessToken == null) {
                     url = String.format(format, sdkKey);
                 } else {
                     url = String.format(authFormat, sdkKey);
@@ -306,7 +306,7 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
                 timeUnit,
                 httpClient,
                 url,
-                datafileAuthToken,
+                datafileAccessToken,
                 blockingTimeoutPeriod,
                 blockingTimeoutUnit,
                 notificationCenter);

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
@@ -18,6 +18,7 @@ package com.optimizely.ab.config;
 
 import com.optimizely.ab.HttpClientUtils;
 import com.optimizely.ab.OptimizelyHttpClient;
+import com.optimizely.ab.annotations.VisibleForTesting;
 import com.optimizely.ab.config.parser.ConfigParseException;
 import com.optimizely.ab.internal.PropertyUtils;
 import com.optimizely.ab.notification.NotificationCenter;
@@ -130,6 +131,7 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
         return null;
     }
 
+    @VisibleForTesting
     HttpGet createHttpRequest() {
         HttpGet httpGet = new HttpGet(uri);
 

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
@@ -113,15 +113,7 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
 
     @Override
     protected ProjectConfig poll() {
-        HttpGet httpGet = new HttpGet(uri);
-
-        if (authDatafileToken != null) {
-            httpGet.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + authDatafileToken);
-        }
-
-        if (datafileLastModified != null) {
-            httpGet.setHeader(HttpHeaders.IF_MODIFIED_SINCE, datafileLastModified);
-        }
+        HttpGet httpGet = createHttpRequest();
 
         logger.debug("Fetching datafile from: {}", httpGet.getURI());
         try {
@@ -136,6 +128,20 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
         }
 
         return null;
+    }
+
+    HttpGet createHttpRequest() {
+        HttpGet httpGet = new HttpGet(uri);
+
+        if (authDatafileToken != null) {
+            httpGet.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + authDatafileToken);
+        }
+
+        if (datafileLastModified != null) {
+            httpGet.setHeader(HttpHeaders.IF_MODIFIED_SINCE, datafileLastModified);
+        }
+
+        return httpGet;
     }
 
     public static Builder builder() {

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
@@ -153,7 +153,7 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
         private String url;
         private String authDatafileToken = null;
         private String format = "https://cdn.optimizely.com/datafiles/%s.json";
-        private String authFormat = "https://www.optimizely-cdn.com/datafiles/auth/%s.json";
+        private String authFormat = "https://config.optimizely.com/datafiles/auth/%s.json";
         private OptimizelyHttpClient httpClient;
         private NotificationCenter notificationCenter;
 

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyFactoryTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyFactoryTest.java
@@ -192,6 +192,13 @@ public class OptimizelyFactoryTest {
     }
 
     @Test
+    public void newDefaultInstanceWithAuthDatafileToken() throws Exception {
+        String datafileString = Resources.toString(Resources.getResource("valid-project-config-v4.json"), Charsets.UTF_8);
+        optimizely = OptimizelyFactory.newDefaultInstance("sdk-key", "auth-token", datafileString);
+        assertTrue(optimizely.isValid());
+    }
+
+    @Test
     public void newDefaultInstanceWithProjectConfig() throws Exception {
         optimizely = OptimizelyFactory.newDefaultInstance(() -> null);
         assertFalse(optimizely.isValid());

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyFactoryTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyFactoryTest.java
@@ -194,7 +194,7 @@ public class OptimizelyFactoryTest {
     @Test
     public void newDefaultInstanceWithDatafileAuthToken() throws Exception {
         String datafileString = Resources.toString(Resources.getResource("valid-project-config-v4.json"), Charsets.UTF_8);
-        optimizely = OptimizelyFactory.newDefaultInstance("sdk-key", "auth-token", datafileString);
+        optimizely = OptimizelyFactory.newDefaultInstance("sdk-key", datafileString, "auth-token");
         assertTrue(optimizely.isValid());
     }
 

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyFactoryTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyFactoryTest.java
@@ -192,7 +192,7 @@ public class OptimizelyFactoryTest {
     }
 
     @Test
-    public void newDefaultInstanceWithAuthDatafileToken() throws Exception {
+    public void newDefaultInstanceWithDatafileAuthToken() throws Exception {
         String datafileString = Resources.toString(Resources.getResource("valid-project-config-v4.json"), Charsets.UTF_8);
         optimizely = OptimizelyFactory.newDefaultInstance("sdk-key", "auth-token", datafileString);
         assertTrue(optimizely.isValid());

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyFactoryTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyFactoryTest.java
@@ -192,7 +192,7 @@ public class OptimizelyFactoryTest {
     }
 
     @Test
-    public void newDefaultInstanceWithDatafileAuthToken() throws Exception {
+    public void newDefaultInstanceWithDatafileAccessToken() throws Exception {
         String datafileString = Resources.toString(Resources.getResource("valid-project-config-v4.json"), Charsets.UTF_8);
         optimizely = OptimizelyFactory.newDefaultInstance("sdk-key", datafileString, "auth-token");
         assertTrue(optimizely.isValid());

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/config/HttpProjectConfigManagerTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/config/HttpProjectConfigManagerTest.java
@@ -128,7 +128,7 @@ public class HttpProjectConfigManagerTest {
         projectConfigManager = builder()
             .withOptimizelyHttpClient(mockHttpClient)
             .withSdkKey("sdk-key")
-            .withDatafileAuthToken("auth-token")
+            .withDatafileAccessToken("auth-token")
             .build();
 
         URI actual = projectConfigManager.getUri();
@@ -143,7 +143,7 @@ public class HttpProjectConfigManagerTest {
             .withOptimizelyHttpClient(mockHttpClient)
             .withUrl(expected)
             .withSdkKey("sdk-key")
-            .withDatafileAuthToken("auth-token")
+            .withDatafileAccessToken("auth-token")
             .build();
 
         URI actual = projectConfigManager.getUri();
@@ -167,7 +167,7 @@ public class HttpProjectConfigManagerTest {
         projectConfigManager = builder()
             .withOptimizelyHttpClient(mockHttpClient)
             .withSdkKey("sdk-key")
-            .withDatafileAuthToken("auth-token")
+            .withDatafileAccessToken("auth-token")
             .build();
 
         HttpGet request = projectConfigManager.createHttpRequest();

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/config/HttpProjectConfigManagerTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/config/HttpProjectConfigManagerTest.java
@@ -43,9 +43,7 @@ import static com.optimizely.ab.config.HttpProjectConfigManager.*;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HttpProjectConfigManagerTest {
@@ -123,6 +121,58 @@ public class HttpProjectConfigManagerTest {
 
         URI actual = projectConfigManager.getUri();
         assertEquals(new URI(expected), actual);
+    }
+
+    @Test
+    public void testHttpGetBySdkKeyForAuthDatafile() throws Exception {
+        projectConfigManager = builder()
+            .withOptimizelyHttpClient(mockHttpClient)
+            .withSdkKey("sdk-key")
+            .withAuthDatafileToken("auth-token")
+            .build();
+
+        URI actual = projectConfigManager.getUri();
+        assertEquals(new URI("https://www.optimizely-cdn.com/datafiles/auth/sdk-key.json"), actual);
+    }
+    
+    @Test
+    public void testHttpGetByCustomUrlForAuthDatafile() throws Exception {
+        String expected = "https://custom.optimizely.com/custom-location.json";
+
+        projectConfigManager = builder()
+            .withOptimizelyHttpClient(mockHttpClient)
+            .withUrl(expected)
+            .withSdkKey("sdk-key")
+            .withAuthDatafileToken("auth-token")
+            .build();
+
+        URI actual = projectConfigManager.getUri();
+        assertEquals(new URI(expected), actual);
+    }
+
+    @Test
+    public void testCreateHttpRequest() throws Exception {
+        projectConfigManager = builder()
+            .withOptimizelyHttpClient(mockHttpClient)
+            .withSdkKey("sdk-key")
+            .build();
+
+        HttpGet request = projectConfigManager.createHttpRequest();
+        assertEquals(request.getURI().toString(), "https://cdn.optimizely.com/datafiles/sdk-key.json");
+        assertEquals(request.getHeaders("Authorization").length, 0);
+    }
+
+    @Test
+    public void testCreateHttpRequestForAuthDatafile() throws Exception {
+        projectConfigManager = builder()
+            .withOptimizelyHttpClient(mockHttpClient)
+            .withSdkKey("sdk-key")
+            .withAuthDatafileToken("auth-token")
+            .build();
+
+        HttpGet request = projectConfigManager.createHttpRequest();
+        assertEquals(request.getURI().toString(), "https://www.optimizely-cdn.com/datafiles/auth/sdk-key.json");
+        assertEquals(request.getHeaders("Authorization")[0].getValue(), "Bearer auth-token");
     }
 
     @Test

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/config/HttpProjectConfigManagerTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/config/HttpProjectConfigManagerTest.java
@@ -128,13 +128,13 @@ public class HttpProjectConfigManagerTest {
         projectConfigManager = builder()
             .withOptimizelyHttpClient(mockHttpClient)
             .withSdkKey("sdk-key")
-            .withAuthDatafileToken("auth-token")
+            .withDatafileAuthToken("auth-token")
             .build();
 
         URI actual = projectConfigManager.getUri();
-        assertEquals(new URI("https://www.optimizely-cdn.com/datafiles/auth/sdk-key.json"), actual);
+        assertEquals(new URI("https://config.optimizely.com/datafiles/auth/sdk-key.json"), actual);
     }
-    
+
     @Test
     public void testHttpGetByCustomUrlForAuthDatafile() throws Exception {
         String expected = "https://custom.optimizely.com/custom-location.json";
@@ -143,7 +143,7 @@ public class HttpProjectConfigManagerTest {
             .withOptimizelyHttpClient(mockHttpClient)
             .withUrl(expected)
             .withSdkKey("sdk-key")
-            .withAuthDatafileToken("auth-token")
+            .withDatafileAuthToken("auth-token")
             .build();
 
         URI actual = projectConfigManager.getUri();
@@ -167,11 +167,11 @@ public class HttpProjectConfigManagerTest {
         projectConfigManager = builder()
             .withOptimizelyHttpClient(mockHttpClient)
             .withSdkKey("sdk-key")
-            .withAuthDatafileToken("auth-token")
+            .withDatafileAuthToken("auth-token")
             .build();
 
         HttpGet request = projectConfigManager.createHttpRequest();
-        assertEquals(request.getURI().toString(), "https://www.optimizely-cdn.com/datafiles/auth/sdk-key.json");
+        assertEquals(request.getURI().toString(), "https://config.optimizely.com/datafiles/auth/sdk-key.json");
         assertEquals(request.getHeaders("Authorization")[0].getValue(), "Bearer auth-token");
     }
 


### PR DESCRIPTION
## Summary
- add support for authenticated datafile access
- auth-token can be set by calling either
   (1) Optimizely optimizely = OptimizelyFactory.newDefaultInstance(String sdkKey, 
                                                                            String authDatafileToken, 
                                                                            String fallback); or
   (2) HttpProjectConfigManager.Builder builder = HttpProjectConfigManager.builder()
            .withSdkKey(sdkKey)
            .withAuthDatafileToken(authDatafileToken);
        Optimizely optimizely = OptimizelyFactory.newDefaultInstance(builder.build());

## Test plan
- test the target url and authenticated header are set appropriately both when auth-token is specified (authenticated datafile) or not (regular datafaile) 