### PR TITLE
Fix: logging issue in quick-start application

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ jobs:
         FULLSTACK_TEST_REPO=ProdTesting
         
     - stage: 'Source Clear'
+      if: type = cron
       addons:
         srcclr: true
       before_install: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,6 @@ jobs:
         FULLSTACK_TEST_REPO=ProdTesting
         
     - stage: 'Source Clear'
-      if: type = cron
       addons:
         srcclr: true
       before_install: skip

--- a/java-quickstart/build.gradle
+++ b/java-quickstart/build.gradle
@@ -4,7 +4,8 @@ dependencies {
 
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.12'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.13.3'
+    compile group: 'org.slf4j', name: 'slf4j-log4j12', version: '2.0.0-alpha1'
+
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 

--- a/java-quickstart/build.gradle
+++ b/java-quickstart/build.gradle
@@ -4,8 +4,7 @@ dependencies {
 
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.12'
-    compile group: 'org.slf4j', name: 'slf4j-log4j12', version: '2.0.0-alpha1'
-
+    compile group: 'org.slf4j', name: 'slf4j-simple', version: '2.0.0-alpha1'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 


### PR DESCRIPTION
## Summary
- Replaced slf4j-log4j12 lib with slf4j-simple due to vulnerability issue in log4j 1.2 version,
- Also this PR will resolve the logging issue in quick-start application

## Test plan
FSC and all unit tests should pass.
