### PR TITLE
feat(flag-decisions): Add support for sending flag decisions along with decision metadata. 

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -216,7 +216,7 @@ public class Optimizely implements AutoCloseable {
             return null;
         }
 
-        sendImpression(projectConfig, experiment, userId, copiedAttributes, variation, experiment.getKey(), "experiment");
+        sendImpression(projectConfig, experiment, userId, copiedAttributes, variation, "experiment");
 
         return variation;
     }
@@ -229,8 +229,27 @@ public class Optimizely implements AutoCloseable {
      * @param userId             the ID of the user
      * @param filteredAttributes the attributes of the user
      * @param variation          the variation that was returned from activate.
-     * @param flagKey            It can either be experiment key in case if flagType is experiment or it's feature key in case flagType is feature-test or rollout
-     * @param flagType           It can either be experiment in case impression event is sent from activate or it's feature-test or rollout
+     * @param ruleType           It can either be experiment in case impression event is sent from activate or it's feature-test or rollout
+     */
+    private void sendImpression(@Nonnull ProjectConfig projectConfig,
+                                @Nonnull Experiment experiment,
+                                @Nonnull String userId,
+                                @Nonnull Map<String, ?> filteredAttributes,
+                                @Nonnull Variation variation,
+                                @Nonnull String ruleType) {
+        sendImpression(projectConfig, experiment, userId, filteredAttributes, variation, "", ruleType);
+    }
+
+    /**
+     * Creates and sends impression event.
+     *
+     * @param projectConfig      the current projectConfig
+     * @param experiment         the experiment user bucketed into and dispatch an impression event
+     * @param userId             the ID of the user
+     * @param filteredAttributes the attributes of the user
+     * @param variation          the variation that was returned from activate.
+     * @param flagKey            It can either be experiment key in case if ruleType is experiment or it's feature key in case ruleType is feature-test or rollout
+     * @param ruleType           It can either be experiment in case impression event is sent from activate or it's feature-test or rollout
      */
     private void sendImpression(@Nonnull ProjectConfig projectConfig,
                                 @Nonnull Experiment experiment,
@@ -238,7 +257,7 @@ public class Optimizely implements AutoCloseable {
                                 @Nonnull Map<String, ?> filteredAttributes,
                                 @Nonnull Variation variation,
                                 @Nonnull String flagKey,
-                                @Nonnull String flagType) {
+                                @Nonnull String ruleType) {
 
         UserEvent userEvent = UserEventFactory.createImpressionEvent(
             projectConfig,
@@ -247,7 +266,7 @@ public class Optimizely implements AutoCloseable {
             userId,
             filteredAttributes,
             flagKey,
-            flagType);
+            ruleType);
 
         if (userEvent == null) {
             return;

--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -216,7 +216,7 @@ public class Optimizely implements AutoCloseable {
             return null;
         }
 
-        sendImpression(projectConfig, experiment, userId, copiedAttributes, variation);
+        sendImpression(projectConfig, experiment, userId, copiedAttributes, variation, experiment.getKey(), "experiment");
 
         return variation;
     }
@@ -225,22 +225,26 @@ public class Optimizely implements AutoCloseable {
                                 @Nonnull Experiment experiment,
                                 @Nonnull String userId,
                                 @Nonnull Map<String, ?> filteredAttributes,
-                                @Nonnull Variation variation) {
-        if (!experiment.isRunning()) {
-            logger.info("Experiment has \"Launched\" status so not dispatching event during activation.");
-            return;
-        }
+                                @Nonnull Variation variation,
+                                @Nonnull String flagKey,
+                                @Nonnull String flagType) {
 
         UserEvent userEvent = UserEventFactory.createImpressionEvent(
             projectConfig,
             experiment,
             variation,
             userId,
-            filteredAttributes);
+            filteredAttributes,
+            flagKey,
+            flagType);
 
+        if (userEvent == null) {
+            return;
+        }
         eventProcessor.process(userEvent);
-        logger.info("Activating user \"{}\" in experiment \"{}\".", userId, experiment.getKey());
-
+        if (experiment != null) {
+            logger.info("Activating user \"{}\" in experiment \"{}\".", userId, experiment.getKey());
+        }
         // Kept For backwards compatibility.
         // This notification is deprecated and the new DecisionNotifications
         // are sent via their respective method calls.
@@ -386,16 +390,22 @@ public class Optimizely implements AutoCloseable {
         FeatureDecision featureDecision = decisionService.getVariationForFeature(featureFlag, userId, copiedAttributes, projectConfig);
         Boolean featureEnabled = false;
         SourceInfo sourceInfo = new RolloutSourceInfo();
+        if (featureDecision.decisionSource != null) {
+            decisionSource = featureDecision.decisionSource;
+        }
+        sendImpression(
+            projectConfig,
+            featureDecision.experiment,
+            userId,
+            copiedAttributes,
+            featureDecision.variation,
+            featureKey,
+            decisionSource.toString());
 
         if (featureDecision.variation != null) {
+            // This information is only necessary for feature tests.
+            // For rollouts experiments and variations are an implementation detail only.
             if (featureDecision.decisionSource.equals(FeatureDecision.DecisionSource.FEATURE_TEST)) {
-                sendImpression(
-                    projectConfig,
-                    featureDecision.experiment,
-                    userId,
-                    copiedAttributes,
-                    featureDecision.variation);
-                decisionSource = featureDecision.decisionSource;
                 sourceInfo = new FeatureTestSourceInfo(featureDecision.experiment.getKey(), featureDecision.variation.getKey());
             } else {
                 logger.info("The user \"{}\" is not included in an experiment for feature \"{}\".",

--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -248,7 +248,7 @@ public class Optimizely implements AutoCloseable {
      * @param userId             the ID of the user
      * @param filteredAttributes the attributes of the user
      * @param variation          the variation that was returned from activate.
-     * @param flagKey            It can either be experiment key in case if ruleType is experiment or it's feature key in case ruleType is feature-test or rollout
+     * @param flagKey            It can either be empty if ruleType is experiment or it's feature key in case ruleType is feature-test or rollout
      * @param ruleType           It can either be experiment in case impression event is sent from activate or it's feature-test or rollout
      */
     private void sendImpression(@Nonnull ProjectConfig projectConfig,

--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -221,6 +221,17 @@ public class Optimizely implements AutoCloseable {
         return variation;
     }
 
+    /**
+     * Creates and sends impression event.
+     *
+     * @param projectConfig      the current projectConfig
+     * @param experiment         the experiment user bucketed into and dispatch an impression event
+     * @param userId             the ID of the user
+     * @param filteredAttributes the attributes of the user
+     * @param variation          the variation that was returned from activate.
+     * @param flagKey            It can either be experiment key in case if flagType is experiment or it's feature key in case flagType is feature-test or rollout
+     * @param flagType           It can either be experiment in case impression event is sent from activate or it's feature-test or rollout
+     */
     private void sendImpression(@Nonnull ProjectConfig projectConfig,
                                 @Nonnull Experiment experiment,
                                 @Nonnull String userId,

--- a/core-api/src/main/java/com/optimizely/ab/config/DatafileProjectConfig.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/DatafileProjectConfig.java
@@ -61,6 +61,7 @@ public class DatafileProjectConfig implements ProjectConfig {
     private final String revision;
     private final String version;
     private final boolean anonymizeIP;
+    private final boolean sendFlagDecisions;
     private final Boolean botFiltering;
     private final List<Attribute> attributes;
     private final List<Audience> audiences;
@@ -103,6 +104,7 @@ public class DatafileProjectConfig implements ProjectConfig {
         this(
             accountId,
             anonymizeIP,
+            false,
             null,
             projectId,
             revision,
@@ -121,6 +123,7 @@ public class DatafileProjectConfig implements ProjectConfig {
     // v4 constructor
     public DatafileProjectConfig(String accountId,
                                  boolean anonymizeIP,
+                                 boolean sendFlagDecisions,
                                  Boolean botFiltering,
                                  String projectId,
                                  String revision,
@@ -139,6 +142,7 @@ public class DatafileProjectConfig implements ProjectConfig {
         this.version = version;
         this.revision = revision;
         this.anonymizeIP = anonymizeIP;
+        this.sendFlagDecisions = sendFlagDecisions;
         this.botFiltering = botFiltering;
 
         this.attributes = Collections.unmodifiableList(attributes);
@@ -321,6 +325,9 @@ public class DatafileProjectConfig implements ProjectConfig {
     public String getRevision() {
         return revision;
     }
+
+    @Override
+    public boolean getSendFlagDecisions() { return sendFlagDecisions; }
 
     @Override
     public boolean getAnonymizeIP() {

--- a/core-api/src/main/java/com/optimizely/ab/config/ProjectConfig.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/ProjectConfig.java
@@ -55,6 +55,8 @@ public interface ProjectConfig {
 
     String getRevision();
 
+    boolean getSendFlagDecisions();
+
     boolean getAnonymizeIP();
 
     Boolean getBotFiltering();

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/DatafileGsonDeserializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/DatafileGsonDeserializer.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2016-2019, Optimizely and contributors
+ *    Copyright 2016-2020, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -83,9 +83,11 @@ public class DatafileGsonDeserializer implements JsonDeserializer<ProjectConfig>
             anonymizeIP = jsonObject.get("anonymizeIP").getAsBoolean();
         }
 
+
         List<FeatureFlag> featureFlags = null;
         List<Rollout> rollouts = null;
         Boolean botFiltering = null;
+        boolean sendFlagDecisions = false;
         if (datafileVersion >= Integer.parseInt(DatafileProjectConfig.Version.V4.toString())) {
             Type featureFlagsType = new TypeToken<List<FeatureFlag>>() {
             }.getType();
@@ -95,11 +97,14 @@ public class DatafileGsonDeserializer implements JsonDeserializer<ProjectConfig>
             rollouts = context.deserialize(jsonObject.get("rollouts").getAsJsonArray(), rolloutsType);
             if (jsonObject.has("botFiltering"))
                 botFiltering = jsonObject.get("botFiltering").getAsBoolean();
+            if (jsonObject.has("sendFlagDecisions"))
+                sendFlagDecisions = jsonObject.get("sendFlagDecisions").getAsBoolean();
         }
 
         return new DatafileProjectConfig(
             accountId,
             anonymizeIP,
+            sendFlagDecisions,
             botFiltering,
             projectId,
             revision,

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/DatafileJacksonDeserializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/DatafileJacksonDeserializer.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2016-2019, Optimizely and contributors
+ *    Copyright 2016-2020, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -64,17 +64,22 @@ class DatafileJacksonDeserializer extends JsonDeserializer<DatafileProjectConfig
         List<FeatureFlag> featureFlags = null;
         List<Rollout> rollouts = null;
         Boolean botFiltering = null;
+        boolean sendFlagDecisions = false;
         if (datafileVersion >= Integer.parseInt(DatafileProjectConfig.Version.V4.toString())) {
             featureFlags = JacksonHelpers.arrayNodeToList(node.get("featureFlags"), FeatureFlag.class, codec);
             rollouts = JacksonHelpers.arrayNodeToList(node.get("rollouts"), Rollout.class, codec);
             if (node.hasNonNull("botFiltering")) {
                 botFiltering = node.get("botFiltering").asBoolean();
             }
+            if (node.hasNonNull("sendFlagDecisions")) {
+                sendFlagDecisions = node.get("sendFlagDecisions").asBoolean();
+            }
         }
 
         return new DatafileProjectConfig(
             accountId,
             anonymizeIP,
+            sendFlagDecisions,
             botFiltering,
             projectId,
             revision,

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/JsonConfigParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/JsonConfigParser.java
@@ -73,16 +73,20 @@ final public class JsonConfigParser implements ConfigParser {
             List<FeatureFlag> featureFlags = null;
             List<Rollout> rollouts = null;
             Boolean botFiltering = null;
+            boolean sendFlagDecisions = false;
             if (datafileVersion >= Integer.parseInt(ProjectConfig.Version.V4.toString())) {
                 featureFlags = parseFeatureFlags(rootObject.getJSONArray("featureFlags"));
                 rollouts = parseRollouts(rootObject.getJSONArray("rollouts"));
                 if (rootObject.has("botFiltering"))
                     botFiltering = rootObject.getBoolean("botFiltering");
+                if (rootObject.has("sendFlagDecisions"))
+                    sendFlagDecisions = rootObject.getBoolean("sendFlagDecisions");
             }
 
             return new DatafileProjectConfig(
                 accountId,
                 anonymizeIP,
+                sendFlagDecisions,
                 botFiltering,
                 projectId,
                 revision,

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/JsonSimpleConfigParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/JsonSimpleConfigParser.java
@@ -80,16 +80,20 @@ final public class JsonSimpleConfigParser implements ConfigParser {
             List<FeatureFlag> featureFlags = null;
             List<Rollout> rollouts = null;
             Boolean botFiltering = null;
+            boolean sendFlagDecisions = false;
             if (datafileVersion >= Integer.parseInt(DatafileProjectConfig.Version.V4.toString())) {
                 featureFlags = parseFeatureFlags((JSONArray) rootObject.get("featureFlags"));
                 rollouts = parseRollouts((JSONArray) rootObject.get("rollouts"));
                 if (rootObject.containsKey("botFiltering"))
                     botFiltering = (Boolean) rootObject.get("botFiltering");
+                if (rootObject.containsKey("sendFlagDecisions"))
+                    sendFlagDecisions = (Boolean) rootObject.get("sendFlagDecisions");
             }
 
             return new DatafileProjectConfig(
                 accountId,
                 anonymizeIP,
+                sendFlagDecisions,
                 botFiltering,
                 projectId,
                 revision,

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/EventFactory.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/EventFactory.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2016-2019, Optimizely and contributors
+ *    Copyright 2016-2020, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -99,6 +99,7 @@ public class EventFactory {
             .setCampaignId(impressionEvent.getLayerId())
             .setExperimentId(impressionEvent.getExperimentId())
             .setVariationId(impressionEvent.getVariationId())
+            .setMetadata(impressionEvent.getMetadata())
             .setIsCampaignHoldback(false)
             .build();
 

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/ImpressionEvent.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/ImpressionEvent.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2019, Optimizely and contributors
+ *    Copyright 2019-2020, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
  */
 package com.optimizely.ab.event.internal;
 
+import com.optimizely.ab.event.internal.payload.DecisionMetadata;
+
 import java.util.StringJoiner;
 
 /**
@@ -28,19 +30,22 @@ public class ImpressionEvent extends BaseEvent implements UserEvent {
     private final String experimentKey;
     private final String variationKey;
     private final String variationId;
+    private final DecisionMetadata metadata;
 
     private ImpressionEvent(UserContext userContext,
                             String layerId,
                             String experimentId,
                             String experimentKey,
                             String variationKey,
-                            String variationId) {
+                            String variationId,
+                            DecisionMetadata metadata) {
         this.userContext = userContext;
         this.layerId = layerId;
         this.experimentId = experimentId;
         this.experimentKey = experimentKey;
         this.variationKey = variationKey;
         this.variationId = variationId;
+        this.metadata = metadata;
     }
 
     @Override
@@ -68,6 +73,8 @@ public class ImpressionEvent extends BaseEvent implements UserEvent {
         return variationId;
     }
 
+    public DecisionMetadata getMetadata() { return metadata; }
+
     public static class Builder {
 
         private UserContext userContext;
@@ -76,6 +83,7 @@ public class ImpressionEvent extends BaseEvent implements UserEvent {
         private String experimentKey;
         private String variationKey;
         private String variationId;
+        private DecisionMetadata metadata;
 
         public Builder withUserContext(UserContext userContext) {
             this.userContext = userContext;
@@ -107,8 +115,13 @@ public class ImpressionEvent extends BaseEvent implements UserEvent {
             return this;
         }
 
+        public Builder withMetadata(DecisionMetadata metadata) {
+            this.metadata = metadata;
+            return this;
+        }
+
         public ImpressionEvent build() {
-            return new ImpressionEvent(userContext, layerId, experimentId, experimentKey, variationKey, variationId);
+            return new ImpressionEvent(userContext, layerId, experimentId, experimentKey, variationKey, variationId, metadata);
         }
     }
 

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/UserEventFactory.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/UserEventFactory.java
@@ -46,7 +46,6 @@ public class UserEventFactory {
 
         String variationKey = "";
         String variationID = "";
-        String finalRuleType = "";
         String layerID = null;
         String experimentId = null;
         String experimentKey = "";
@@ -54,7 +53,6 @@ public class UserEventFactory {
         if (variation != null) {
             variationKey = variation.getKey();
             variationID = variation.getId();
-            finalRuleType = ruleType;
             layerID = activatedExperiment.getLayerId();
             experimentId = activatedExperiment.getId();
             experimentKey = activatedExperiment.getKey();
@@ -69,7 +67,7 @@ public class UserEventFactory {
         DecisionMetadata metadata = new DecisionMetadata.Builder()
             .setFlagKey(flagKey)
             .setRuleKey(experimentKey)
-            .setRuleType(finalRuleType)
+            .setRuleType(ruleType)
             .setVariationKey(variationKey)
             .build();
 

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/UserEventFactory.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/UserEventFactory.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Map;
-import java.util.UUID;
 
 public class UserEventFactory {
     private static final Logger logger = LoggerFactory.getLogger(UserEventFactory.class);
@@ -38,24 +37,24 @@ public class UserEventFactory {
                                                         @Nonnull String userId,
                                                         @Nonnull Map<String, ?> attributes,
                                                         @Nonnull String flagKey,
-                                                        @Nonnull String flagType) {
+                                                        @Nonnull String ruleType) {
 
-        if ((FeatureDecision.DecisionSource.ROLLOUT.toString().equals(flagType)  || variation == null) && !projectConfig.getSendFlagDecisions())
+        if ((FeatureDecision.DecisionSource.ROLLOUT.toString().equals(ruleType)  || variation == null) && !projectConfig.getSendFlagDecisions())
         {
             return null;
         }
 
-        String variationKey = null;
-        String variationID = null;
+        String variationKey = "";
+        String variationID = "";
+        String finalRuleType = "";
+        String layerID = null;
+        String experimentId = null;
+        String experimentKey = "";
+
         if (variation != null) {
             variationKey = variation.getKey();
             variationID = variation.getId();
-        }
-
-        String layerID = null;
-        String experimentId = null;
-        String experimentKey = null;
-        if (activatedExperiment != null) {
+            finalRuleType = ruleType;
             layerID = activatedExperiment.getLayerId();
             experimentId = activatedExperiment.getId();
             experimentKey = activatedExperiment.getKey();
@@ -69,7 +68,8 @@ public class UserEventFactory {
 
         DecisionMetadata metadata = new DecisionMetadata.Builder()
             .setFlagKey(flagKey)
-            .setFlagType(flagType)
+            .setRuleKey(experimentKey)
+            .setRuleType(finalRuleType)
             .setVariationKey(variationKey)
             .build();
 

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/UserEventFactory.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/UserEventFactory.java
@@ -39,7 +39,7 @@ public class UserEventFactory {
                                                         @Nonnull String flagKey,
                                                         @Nonnull String flagType) {
 
-        if ((FeatureDecision.DecisionSource.ROLLOUT.equals(flagType)  || variation == null) && !projectConfig.getSendFlagDecisions())
+        if ((FeatureDecision.DecisionSource.ROLLOUT.toString().equals(flagType)  || variation == null) && !projectConfig.getSendFlagDecisions())
         {
             return null;
         }

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/UserEventFactory.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/UserEventFactory.java
@@ -25,6 +25,7 @@ import com.optimizely.ab.internal.EventTagUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.UUID;
 
@@ -32,8 +33,8 @@ public class UserEventFactory {
     private static final Logger logger = LoggerFactory.getLogger(UserEventFactory.class);
 
     public static ImpressionEvent createImpressionEvent(@Nonnull ProjectConfig projectConfig,
-                                                        @Nonnull Experiment activatedExperiment,
-                                                        @Nonnull Variation variation,
+                                                        @Nullable Experiment activatedExperiment,
+                                                        @Nullable Variation variation,
                                                         @Nonnull String userId,
                                                         @Nonnull Map<String, ?> attributes,
                                                         @Nonnull String flagKey,

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/payload/Decision.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/payload/Decision.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2018-2019, Optimizely and contributors
+ *    Copyright 2018-2020, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -28,16 +28,19 @@ public class Decision {
     String variationId;
     @JsonProperty("is_campaign_holdback")
     boolean isCampaignHoldback;
+    @JsonProperty("metadata")
+    DecisionMetadata metadata;
 
     @VisibleForTesting
     public Decision() {
     }
 
-    public Decision(String campaignId, String experimentId, String variationId, boolean isCampaignHoldback) {
+    public Decision(String campaignId, String experimentId, String variationId, boolean isCampaignHoldback, DecisionMetadata metadata) {
         this.campaignId = campaignId;
         this.experimentId = experimentId;
         this.variationId = variationId;
         this.isCampaignHoldback = isCampaignHoldback;
+        this.metadata = metadata;
     }
 
     public String getCampaignId() {
@@ -55,6 +58,8 @@ public class Decision {
     public boolean getIsCampaignHoldback() {
         return isCampaignHoldback;
     }
+
+    public DecisionMetadata getMetadata() { return metadata; }
 
     @Override
     public boolean equals(Object o) {
@@ -74,6 +79,7 @@ public class Decision {
         int result = campaignId.hashCode();
         result = 31 * result + experimentId.hashCode();
         result = 31 * result + variationId.hashCode();
+        result = 31 * result + metadata.hashCode();
         result = 31 * result + (isCampaignHoldback ? 1 : 0);
         return result;
     }
@@ -84,6 +90,7 @@ public class Decision {
         private String experimentId;
         private String variationId;
         private boolean isCampaignHoldback;
+        private DecisionMetadata metadata;
 
         public Builder setCampaignId(String campaignId) {
             this.campaignId = campaignId;
@@ -92,6 +99,11 @@ public class Decision {
 
         public Builder setExperimentId(String experimentId) {
             this.experimentId = experimentId;
+            return this;
+        }
+
+        public Builder setMetadata(DecisionMetadata metadata) {
+            this.metadata = metadata;
             return this;
         }
 
@@ -106,7 +118,7 @@ public class Decision {
         }
 
         public Decision build() {
-            return new Decision(campaignId, experimentId, variationId, isCampaignHoldback);
+            return new Decision(campaignId, experimentId, variationId, isCampaignHoldback, metadata);
         }
     }
 }

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/payload/DecisionMetadata.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/payload/DecisionMetadata.java
@@ -49,9 +49,13 @@ public class DecisionMetadata {
         return ruleKey;
     }
 
-    public String getFlagKey() { return flagKey; }
+    public String getFlagKey() {
+        return flagKey;
+    }
 
-    public String getVariationKey() { return variationKey; }
+    public String getVariationKey() {
+        return variationKey;
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/payload/DecisionMetadata.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/payload/DecisionMetadata.java
@@ -20,10 +20,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.optimizely.ab.annotations.VisibleForTesting;
 
 public class DecisionMetadata {
-    @JsonProperty("flag_type")
-    String flagType;
+
     @JsonProperty("flag_key")
     String flagKey;
+    @JsonProperty("rule_key")
+    String ruleKey;
+    @JsonProperty("rule_type")
+    String ruleType;
     @JsonProperty("variation_key")
     String variationKey;
 
@@ -31,14 +34,19 @@ public class DecisionMetadata {
     public DecisionMetadata() {
     }
 
-    public DecisionMetadata(String flagType, String flagKey, String variationKey) {
-        this.flagType = flagType;
+    public DecisionMetadata(String flagKey, String ruleKey, String ruleType, String variationKey) {
         this.flagKey = flagKey;
+        this.ruleKey = ruleKey;
+        this.ruleType = ruleType;
         this.variationKey = variationKey;
     }
 
-    public String getFlagType() {
-        return flagType;
+    public String getRuleType() {
+        return ruleType;
+    }
+
+    public String getRuleKey() {
+        return ruleKey;
     }
 
     public String getFlagKey() { return flagKey; }
@@ -52,27 +60,35 @@ public class DecisionMetadata {
 
         DecisionMetadata that = (DecisionMetadata) o;
 
-        if (!flagType.equals(that.flagType)) return false;
+        if (!ruleType.equals(that.ruleType)) return false;
+        if (!ruleKey.equals(that.ruleKey)) return false;
         if (!flagKey.equals(that.flagKey)) return false;
         return variationKey.equals(that.variationKey);
     }
 
     @Override
     public int hashCode() {
-        int result = flagType.hashCode();
+        int result = ruleType.hashCode();
         result = 31 * result + flagKey.hashCode();
+        result = 31 * result + ruleKey.hashCode();
         result = 31 * result + variationKey.hashCode();
         return result;
     }
 
     public static class Builder {
 
-        private String flagType;
+        private String ruleType;
+        private String ruleKey;
         private String flagKey;
         private String variationKey;
 
-        public Builder setFlagType(String flagType) {
-            this.flagType = flagType;
+        public Builder setRuleType(String ruleType) {
+            this.ruleType = ruleType;
+            return this;
+        }
+
+        public Builder setRuleKey(String ruleKey) {
+            this.ruleKey = ruleKey;
             return this;
         }
 
@@ -87,7 +103,7 @@ public class DecisionMetadata {
         }
 
         public DecisionMetadata build() {
-            return new DecisionMetadata(flagType, flagKey, variationKey);
+            return new DecisionMetadata(flagKey, ruleKey, ruleType, variationKey);
         }
     }
 }

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/payload/DecisionMetadata.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/payload/DecisionMetadata.java
@@ -1,0 +1,93 @@
+/**
+ *
+ *    Copyright 2020, Optimizely and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.optimizely.ab.event.internal.payload;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.optimizely.ab.annotations.VisibleForTesting;
+
+public class DecisionMetadata {
+    @JsonProperty("flag_type")
+    String flagType;
+    @JsonProperty("flag_key")
+    String flagKey;
+    @JsonProperty("variation_key")
+    String variationKey;
+
+    @VisibleForTesting
+    public DecisionMetadata() {
+    }
+
+    public DecisionMetadata(String flagType, String flagKey, String variationKey) {
+        this.flagType = flagType;
+        this.flagKey = flagKey;
+        this.variationKey = variationKey;
+    }
+
+    public String getFlagType() {
+        return flagType;
+    }
+
+    public String getFlagKey() { return flagKey; }
+
+    public String getVariationKey() { return variationKey; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        DecisionMetadata that = (DecisionMetadata) o;
+
+        if (!flagType.equals(that.flagType)) return false;
+        if (!flagKey.equals(that.flagKey)) return false;
+        return variationKey.equals(that.variationKey);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = flagType.hashCode();
+        result = 31 * result + flagKey.hashCode();
+        result = 31 * result + variationKey.hashCode();
+        return result;
+    }
+
+    public static class Builder {
+
+        private String flagType;
+        private String flagKey;
+        private String variationKey;
+
+        public Builder setFlagType(String flagType) {
+            this.flagType = flagType;
+            return this;
+        }
+
+        public Builder setFlagKey(String flagKey) {
+            this.flagKey = flagKey;
+            return this;
+        }
+
+        public Builder setVariationKey(String variationKey) {
+            this.variationKey = variationKey;
+            return this;
+        }
+
+        public DecisionMetadata build() {
+            return new DecisionMetadata(flagType, flagKey, variationKey);
+        }
+    }
+}

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -491,7 +491,7 @@ public class OptimizelyTest {
         assertTrue(optimizely.setForcedVariation(activatedExperiment.getKey(), testUserId, null));
         assertNull(optimizely.getForcedVariation(activatedExperiment.getKey(), testUserId));
         assertFalse(optimizely.isFeatureEnabled(FEATURE_FLAG_MULTI_VARIATE_FEATURE.getKey(), testUserId));
-        eventHandler.expectImpression(null, null, testUserId);
+        eventHandler.expectImpression(null, "", testUserId);
     }
 
     /**
@@ -1684,13 +1684,13 @@ public class OptimizelyTest {
         List<String> featureFlags = optimizely.getEnabledFeatures(testUserId, Collections.emptyMap());
         assertEquals(2, featureFlags.size());
 
-        eventHandler.expectImpression(null, null, testUserId);
-        eventHandler.expectImpression(null, null, testUserId);
+        eventHandler.expectImpression(null, "", testUserId);
+        eventHandler.expectImpression(null, "", testUserId);
         eventHandler.expectImpression("3794675122", "589640735", testUserId);
-        eventHandler.expectImpression(null, null, testUserId);
-        eventHandler.expectImpression(null, null, testUserId);
-        eventHandler.expectImpression(null, null, testUserId);
-        eventHandler.expectImpression(null, null, testUserId);
+        eventHandler.expectImpression(null, "", testUserId);
+        eventHandler.expectImpression(null, "", testUserId);
+        eventHandler.expectImpression(null, "", testUserId);
+        eventHandler.expectImpression(null, "", testUserId);
         eventHandler.expectImpression("1786133852", "1619235542", testUserId);
 
         // Verify that listener being called
@@ -1727,14 +1727,14 @@ public class OptimizelyTest {
         // Verify that listener not being called
         assertFalse(isListenerCalled);
 
-        eventHandler.expectImpression(null, null, genericUserId);
-        eventHandler.expectImpression(null, null, genericUserId);
-        eventHandler.expectImpression(null, null, genericUserId);
-        eventHandler.expectImpression(null, null, genericUserId);
-        eventHandler.expectImpression(null, null, genericUserId);
-        eventHandler.expectImpression(null, null, genericUserId);
-        eventHandler.expectImpression(null, null, genericUserId);
-        eventHandler.expectImpression(null, null, genericUserId);
+        eventHandler.expectImpression(null, "", genericUserId);
+        eventHandler.expectImpression(null, "", genericUserId);
+        eventHandler.expectImpression(null, "", genericUserId);
+        eventHandler.expectImpression(null, "", genericUserId);
+        eventHandler.expectImpression(null, "", genericUserId);
+        eventHandler.expectImpression(null, "", genericUserId);
+        eventHandler.expectImpression(null, "", genericUserId);
+        eventHandler.expectImpression(null, "", genericUserId);
 
         assertTrue(optimizely.notificationCenter.removeNotificationListener(notificationId));
     }
@@ -1888,7 +1888,7 @@ public class OptimizelyTest {
             "Feature \"" + validFeatureKey +
                 "\" is enabled for user \"" + genericUserId + "\"? false"
         );
-        eventHandler.expectImpression(null, null, genericUserId);
+        eventHandler.expectImpression(null, "", genericUserId);
 
         // Verify that listener being called
         assertTrue(isListenerCalled);
@@ -3190,7 +3190,7 @@ public class OptimizelyTest {
             "Feature \"" + validFeatureKey +
                 "\" is enabled for user \"" + genericUserId + "\"? false"
         );
-        eventHandler.expectImpression(null, null, genericUserId);
+        eventHandler.expectImpression(null, "", genericUserId);
 
         verify(mockDecisionService).getVariationForFeature(
             eq(FEATURE_FLAG_MULTI_VARIATE_FEATURE),
@@ -3440,10 +3440,10 @@ public class OptimizelyTest {
         List<String> featureFlags = optimizely.getEnabledFeatures(genericUserId, Collections.emptyMap());
         assertFalse(featureFlags.isEmpty());
 
-        eventHandler.expectImpression(null, null, genericUserId);
-        eventHandler.expectImpression(null, null, genericUserId);
+        eventHandler.expectImpression(null, "", genericUserId);
+        eventHandler.expectImpression(null, "", genericUserId);
         eventHandler.expectImpression("3794675122", "589640735", genericUserId);
-        eventHandler.expectImpression(null, null, genericUserId);
+        eventHandler.expectImpression(null, "", genericUserId);
         eventHandler.expectImpression("1785077004", "1566407342", genericUserId);
         eventHandler.expectImpression("828245624", "3137445031", genericUserId);
         eventHandler.expectImpression("828245624", "3137445031", genericUserId);
@@ -3464,10 +3464,10 @@ public class OptimizelyTest {
         List<String> featureFlags = optimizely.getEnabledFeatures("", Collections.emptyMap());
         assertFalse(featureFlags.isEmpty());
 
-        eventHandler.expectImpression(null, null, "");
-        eventHandler.expectImpression(null, null, "");
+        eventHandler.expectImpression(null, "", "");
+        eventHandler.expectImpression(null, "", "");
         eventHandler.expectImpression("3794675122", "589640735", "");
-        eventHandler.expectImpression(null, null, "");
+        eventHandler.expectImpression(null, "", "");
         eventHandler.expectImpression("1785077004", "1566407342", "");
         eventHandler.expectImpression("828245624", "3137445031", "");
         eventHandler.expectImpression("828245624", "3137445031", "");
@@ -3520,14 +3520,14 @@ public class OptimizelyTest {
             Collections.<String, String>emptyMap());
         assertTrue(featureFlags.isEmpty());
 
-        eventHandler.expectImpression(null, null, genericUserId);
-        eventHandler.expectImpression(null, null, genericUserId);
-        eventHandler.expectImpression(null, null, genericUserId);
-        eventHandler.expectImpression(null, null, genericUserId);
-        eventHandler.expectImpression(null, null, genericUserId);
-        eventHandler.expectImpression(null, null, genericUserId);
-        eventHandler.expectImpression(null, null, genericUserId);
-        eventHandler.expectImpression(null, null, genericUserId);
+        eventHandler.expectImpression(null, "", genericUserId);
+        eventHandler.expectImpression(null, "", genericUserId);
+        eventHandler.expectImpression(null, "", genericUserId);
+        eventHandler.expectImpression(null, "", genericUserId);
+        eventHandler.expectImpression(null, "", genericUserId);
+        eventHandler.expectImpression(null, "", genericUserId);
+        eventHandler.expectImpression(null, "", genericUserId);
+        eventHandler.expectImpression(null, "", genericUserId);
     }
 
     /**

--- a/core-api/src/test/java/com/optimizely/ab/config/ValidProjectConfigV4.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/ValidProjectConfigV4.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2017-2019, Optimizely and contributors
+ *    Copyright 2017-2020, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ public class ValidProjectConfigV4 {
     private static final String PROJECT_ID = "3918735994";
     private static final String REVISION = "1480511547";
     private static final String VERSION = "4";
+    private static final Boolean SEND_FLAG_DECISIONS = true;
 
     // attributes
     private static final String ATTRIBUTE_HOUSE_ID = "553339214";
@@ -1429,6 +1430,7 @@ public class ValidProjectConfigV4 {
         return new DatafileProjectConfig(
             ACCOUNT_ID,
             ANONYMIZE_IP,
+            SEND_FLAG_DECISIONS,
             BOT_FILTERING,
             PROJECT_ID,
             REVISION,

--- a/core-api/src/test/java/com/optimizely/ab/event/internal/EventFactoryTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/event/internal/EventFactoryTest.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2016-2019, Optimizely and contributors
+ *    Copyright 2016-2020, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import com.optimizely.ab.bucketing.Bucketer;
 import com.optimizely.ab.config.*;
 import com.optimizely.ab.event.LogEvent;
 import com.optimizely.ab.event.internal.payload.Decision;
+import com.optimizely.ab.event.internal.payload.DecisionMetadata;
 import com.optimizely.ab.event.internal.payload.EventBatch;
 import com.optimizely.ab.internal.ControlAttribute;
 import com.optimizely.ab.internal.ReservedEventKey;
@@ -98,14 +99,16 @@ public class EventFactoryTest {
         Variation bucketedVariation = activatedExperiment.getVariations().get(0);
         Attribute attribute = validProjectConfig.getAttributes().get(0);
         String userId = "userId";
+        String flagType = "experiment";
         Map<String, String> attributeMap = new HashMap<String, String>();
         attributeMap.put(attribute.getKey(), "value");
         attributeMap.put(ControlAttribute.USER_AGENT_ATTRIBUTE.toString(), "Chrome");
-
+        DecisionMetadata metadata = new DecisionMetadata(flagType, activatedExperiment.getKey(), "variationKey");
         Decision expectedDecision = new Decision.Builder()
             .setCampaignId(activatedExperiment.getLayerId())
             .setExperimentId(activatedExperiment.getId())
             .setVariationId(bucketedVariation.getId())
+            .setMetadata(metadata)
             .setIsCampaignHoldback(false)
             .build();
 
@@ -169,10 +172,17 @@ public class EventFactoryTest {
         String userId = "userId";
         Map<String, String> attributeMap = Collections.singletonMap(attribute.getKey(), "value");
 
+        DecisionMetadata decisionMetadata = new DecisionMetadata.Builder()
+            .setFlagKey(activatedExperiment.getKey())
+            .setFlagType("experiment")
+            .setVariationKey(bucketedVariation.getKey())
+            .build();
+
         Decision expectedDecision = new Decision.Builder()
             .setCampaignId(activatedExperiment.getLayerId())
             .setExperimentId(activatedExperiment.getId())
             .setVariationId(bucketedVariation.getId())
+            .setMetadata(decisionMetadata)
             .setIsCampaignHoldback(false)
             .build();
 
@@ -1050,7 +1060,9 @@ public class EventFactoryTest {
             activatedExperiment,
             variation,
             userId,
-            attributes);
+            attributes,
+            activatedExperiment.getKey(),
+            "experiment");
 
         return EventFactory.createLogEvent(userEvent);
         

--- a/core-api/src/test/java/com/optimizely/ab/event/internal/EventFactoryTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/event/internal/EventFactoryTest.java
@@ -99,11 +99,11 @@ public class EventFactoryTest {
         Variation bucketedVariation = activatedExperiment.getVariations().get(0);
         Attribute attribute = validProjectConfig.getAttributes().get(0);
         String userId = "userId";
-        String flagType = "experiment";
+        String ruleType = "experiment";
         Map<String, String> attributeMap = new HashMap<String, String>();
         attributeMap.put(attribute.getKey(), "value");
         attributeMap.put(ControlAttribute.USER_AGENT_ATTRIBUTE.toString(), "Chrome");
-        DecisionMetadata metadata = new DecisionMetadata(flagType, activatedExperiment.getKey(), "variationKey");
+        DecisionMetadata metadata = new DecisionMetadata(activatedExperiment.getKey(), activatedExperiment.getKey(), ruleType, "variationKey");
         Decision expectedDecision = new Decision.Builder()
             .setCampaignId(activatedExperiment.getLayerId())
             .setExperimentId(activatedExperiment.getId())
@@ -174,7 +174,7 @@ public class EventFactoryTest {
 
         DecisionMetadata decisionMetadata = new DecisionMetadata.Builder()
             .setFlagKey(activatedExperiment.getKey())
-            .setFlagType("experiment")
+            .setRuleType("experiment")
             .setVariationKey(bucketedVariation.getKey())
             .build();
 

--- a/core-api/src/test/java/com/optimizely/ab/event/internal/UserEventFactoryTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/event/internal/UserEventFactoryTest.java
@@ -67,7 +67,7 @@ public class UserEventFactoryTest {
     public void setUp() {
         experiment = new Experiment(EXPERIMENT_ID, EXPERIMENT_KEY, LAYER_ID);
         variation = new Variation(VARIATION_ID, VARIATION_KEY);
-        decisionMetadata = new DecisionMetadata(EXPERIMENT_KEY, EXPERIMENT_KEY, "experiment", VARIATION_KEY);
+        decisionMetadata = new DecisionMetadata("", EXPERIMENT_KEY, "experiment", VARIATION_KEY);
     }
 
     @Test
@@ -93,7 +93,7 @@ public class UserEventFactoryTest {
             variation,
             USER_ID,
             ATTRIBUTES,
-            EXPERIMENT_KEY,
+            "",
             "experiment"
         );
 

--- a/core-api/src/test/java/com/optimizely/ab/event/internal/UserEventFactoryTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/event/internal/UserEventFactoryTest.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2019, Optimizely and contributors
+ *    Copyright 2019-2020, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import com.optimizely.ab.config.Experiment;
 import com.optimizely.ab.config.ProjectConfig;
 import com.optimizely.ab.config.Variation;
+import com.optimizely.ab.event.internal.payload.DecisionMetadata;
 import com.optimizely.ab.internal.ReservedEventKey;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,11 +61,28 @@ public class UserEventFactoryTest {
 
     private Experiment experiment;
     private Variation variation;
+    private DecisionMetadata decisionMetadata;
 
     @Before
     public void setUp() {
         experiment = new Experiment(EXPERIMENT_ID, EXPERIMENT_KEY, LAYER_ID);
         variation = new Variation(VARIATION_ID, VARIATION_KEY);
+        decisionMetadata = new DecisionMetadata("experiment", EXPERIMENT_KEY, VARIATION_KEY);
+    }
+
+    @Test
+    public void createImpressionEventNull() {
+
+        ImpressionEvent actual = UserEventFactory.createImpressionEvent(
+            projectConfig,
+            experiment,
+            null,
+            USER_ID,
+            ATTRIBUTES,
+            EXPERIMENT_KEY,
+            "rollout"
+        );
+        assertNull(actual);
     }
 
     @Test
@@ -74,7 +92,9 @@ public class UserEventFactoryTest {
             experiment,
             variation,
             USER_ID,
-            ATTRIBUTES
+            ATTRIBUTES,
+            EXPERIMENT_KEY,
+            "experiment"
         );
 
         assertTrue(actual.getTimestamp() > 0);
@@ -90,6 +110,7 @@ public class UserEventFactoryTest {
         assertEquals(EXPERIMENT_KEY, actual.getExperimentKey());
         assertEquals(VARIATION_ID, actual.getVariationId());
         assertEquals(VARIATION_KEY, actual.getVariationKey());
+        assertEquals(decisionMetadata, actual.getMetadata());
     }
 
     @Test

--- a/core-api/src/test/java/com/optimizely/ab/event/internal/UserEventFactoryTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/event/internal/UserEventFactoryTest.java
@@ -67,7 +67,7 @@ public class UserEventFactoryTest {
     public void setUp() {
         experiment = new Experiment(EXPERIMENT_ID, EXPERIMENT_KEY, LAYER_ID);
         variation = new Variation(VARIATION_ID, VARIATION_KEY);
-        decisionMetadata = new DecisionMetadata("experiment", EXPERIMENT_KEY, VARIATION_KEY);
+        decisionMetadata = new DecisionMetadata(EXPERIMENT_KEY, EXPERIMENT_KEY, "experiment", VARIATION_KEY);
     }
 
     @Test

--- a/core-api/src/test/java/com/optimizely/ab/optimizelyconfig/OptimizelyConfigServiceTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/optimizelyconfig/OptimizelyConfigServiceTest.java
@@ -149,6 +149,7 @@ public class OptimizelyConfigServiceTest {
             "2360254204",
             true,
             true,
+            true,
             "3918735994",
             "1480511547",
             "4",

--- a/core-api/src/test/resources/config/valid-project-config-v4.json
+++ b/core-api/src/test/resources/config/valid-project-config-v4.json
@@ -2,6 +2,7 @@
   "accountId": "2360254204",
   "anonymizeIP": true,
   "botFiltering": true,
+  "sendFlagDecisions": true,
   "projectId": "3918735994",
   "revision": "1480511547",
   "version": "4",


### PR DESCRIPTION
## Summary
* Add experiment/feature flag key, variation key and type to impression events.
* Send events for **ALL** decision types.
* Add `Metadata` field to EventBatch.Decisions to capture flag type, key and variation key.

## Test plan
* All FSC and unit tests should pass