### PR TITLE
fix: decision metadata enabled fix.

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -425,15 +425,6 @@ public class Optimizely implements AutoCloseable {
         if (featureDecision.decisionSource != null) {
             decisionSource = featureDecision.decisionSource;
         }
-        sendImpression(
-            projectConfig,
-            featureDecision.experiment,
-            userId,
-            copiedAttributes,
-            featureDecision.variation,
-            featureKey,
-            decisionSource.toString(),
-            featureEnabled);
 
         if (featureDecision.variation != null) {
             // This information is only necessary for feature tests.
@@ -448,6 +439,15 @@ public class Optimizely implements AutoCloseable {
                 featureEnabled = true;
             }
         }
+        sendImpression(
+            projectConfig,
+            featureDecision.experiment,
+            userId,
+            copiedAttributes,
+            featureDecision.variation,
+            featureKey,
+            decisionSource.toString(),
+            featureEnabled);        
 
         DecisionNotification decisionNotification = DecisionNotification.newFeatureDecisionNotificationBuilder()
             .withUserId(userId)

--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -252,10 +252,10 @@ public class Optimizely implements AutoCloseable {
      * @param ruleType           It can either be experiment in case impression event is sent from activate or it's feature-test or rollout
      */
     private void sendImpression(@Nonnull ProjectConfig projectConfig,
-                                @Nonnull Experiment experiment,
+                                @Nullable Experiment experiment,
                                 @Nonnull String userId,
                                 @Nonnull Map<String, ?> filteredAttributes,
-                                @Nonnull Variation variation,
+                                @Nullable Variation variation,
                                 @Nonnull String flagKey,
                                 @Nonnull String ruleType,
                                 @Nonnull boolean enabled) {

--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -447,16 +447,6 @@ public class Optimizely implements AutoCloseable {
             featureDecision.variation,
             featureKey,
             decisionSource.toString(),
-            featureEnabled);        
-
-        sendImpression(
-            projectConfig,
-            featureDecision.experiment,
-            userId,
-            copiedAttributes,
-            featureDecision.variation,
-            featureKey,
-            decisionSource.toString(),
             featureEnabled);
 
         DecisionNotification decisionNotification = DecisionNotification.newFeatureDecisionNotificationBuilder()

--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -252,10 +252,10 @@ public class Optimizely implements AutoCloseable {
      * @param ruleType           It can either be experiment in case impression event is sent from activate or it's feature-test or rollout
      */
     private void sendImpression(@Nonnull ProjectConfig projectConfig,
-                                Experiment experiment,
+                                @Nonnull Experiment experiment,
                                 @Nonnull String userId,
                                 @Nonnull Map<String, ?> filteredAttributes,
-                                Variation variation,
+                                @Nonnull Variation variation,
                                 @Nonnull String flagKey,
                                 @Nonnull String ruleType,
                                 @Nonnull boolean enabled) {


### PR DESCRIPTION
## Summary
- IsFeatureEnabled was sending impression before finalizing all checks of feature enabled. Just made it after finalization.

## Test plan
- can't add unit tests. 
- only FSC should be passed.
