### PR TITLE
feat(decide): clone user-context before calling optimizely decide

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/OptimizelyUserContext.java
+++ b/core-api/src/main/java/com/optimizely/ab/OptimizelyUserContext.java
@@ -61,11 +61,15 @@ public class OptimizelyUserContext {
     }
 
     public Map<String, Object> getAttributes() {
-        return new HashMap<String, Object>(attributes);
+        return attributes;
     }
 
     public Optimizely getOptimizely() {
         return optimizely;
+    }
+
+    public OptimizelyUserContext copy() {
+        return new OptimizelyUserContext(optimizely, userId, attributes);
     }
 
     /**
@@ -89,7 +93,7 @@ public class OptimizelyUserContext {
      */
     public OptimizelyDecision decide(@Nonnull String key,
                                      @Nonnull List<OptimizelyDecideOption> options) {
-        return optimizely.decide(this, key, options);
+        return optimizely.decide(copy(), key, options);
     }
 
     /**
@@ -114,7 +118,7 @@ public class OptimizelyUserContext {
      */
     public Map<String, OptimizelyDecision> decideForKeys(@Nonnull List<String> keys,
                                                          @Nonnull List<OptimizelyDecideOption> options) {
-        return optimizely.decideForKeys(this, keys, options);
+        return optimizely.decideForKeys(copy(), keys, options);
     }
 
     /**
@@ -134,7 +138,7 @@ public class OptimizelyUserContext {
      * @return All decision results mapped by flag keys.
      */
     public Map<String, OptimizelyDecision> decideAll(@Nonnull List<OptimizelyDecideOption> options) {
-        return optimizely.decideAll(this, options);
+        return optimizely.decideAll(copy(), options);
     }
 
     /**

--- a/core-api/src/main/java/com/optimizely/ab/OptimizelyUserContext.java
+++ b/core-api/src/main/java/com/optimizely/ab/OptimizelyUserContext.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2020, Optimizely and contributors
+ *    Copyright 2020-2021, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/optimizelydecision/OptimizelyDecision.java
+++ b/core-api/src/main/java/com/optimizely/ab/optimizelydecision/OptimizelyDecision.java
@@ -26,23 +26,44 @@ import java.util.Collections;
 import java.util.List;
 
 public class OptimizelyDecision {
+    /**
+     * The variation key of the decision. This value will be null when decision making fails.
+     */
     @Nullable
     private final String variationKey;
 
+    /**
+     * The boolean value indicating if the flag is enabled or not.
+     */
     private final boolean enabled;
 
+    /**
+     * The collection of variables associated with the decision.
+     */
     @Nonnull
     private final OptimizelyJSON variables;
 
+    /**
+     * The rule key of the decision.
+     */
     @Nullable
     private final String ruleKey;
 
+    /**
+     * The flag key for which the decision has been made for.
+     */
     @Nonnull
     private final String flagKey;
 
+    /**
+     * A copy of the user context for which the decision has been made for.
+     */
     @Nonnull
     private final OptimizelyUserContext userContext;
 
+    /**
+     * An array of error/info messages describing why the decision has been made.
+     */
     @Nonnull
     private List<String> reasons;
 

--- a/core-api/src/main/java/com/optimizely/ab/optimizelydecision/OptimizelyDecision.java
+++ b/core-api/src/main/java/com/optimizely/ab/optimizelydecision/OptimizelyDecision.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2020, Optimizely and contributors
+ *    Copyright 2020-2021, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
Clone the current user-context and pass it to optimizely.decide()
- user context can be changed while processing the decide request.
- with this fix, decide can return the copy of the original user-context as a part of the decision

## Test plan
- Validate user-context are copied and passed as expected