### PR TITLE
Fix: SendImpressionEvent will return false when event is not sent

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -255,14 +255,14 @@ public class Optimizely implements AutoCloseable {
      * @param flagKey            It can either be empty if ruleType is experiment or it's feature key in case ruleType is feature-test or rollout
      * @param ruleType           It can either be experiment in case impression event is sent from activate or it's feature-test or rollout
      */
-    private void sendImpression(@Nonnull ProjectConfig projectConfig,
-                                @Nullable Experiment experiment,
-                                @Nonnull String userId,
-                                @Nonnull Map<String, ?> filteredAttributes,
-                                @Nullable Variation variation,
-                                @Nonnull String flagKey,
-                                @Nonnull String ruleType,
-                                @Nonnull boolean enabled) {
+    private boolean sendImpression(@Nonnull ProjectConfig projectConfig,
+                                   @Nullable Experiment experiment,
+                                   @Nonnull String userId,
+                                   @Nonnull Map<String, ?> filteredAttributes,
+                                   @Nullable Variation variation,
+                                   @Nonnull String flagKey,
+                                   @Nonnull String ruleType,
+                                   @Nonnull boolean enabled) {
 
         UserEvent userEvent = UserEventFactory.createImpressionEvent(
             projectConfig,
@@ -275,7 +275,7 @@ public class Optimizely implements AutoCloseable {
             enabled);
 
         if (userEvent == null) {
-            return;
+            return false;
         }
         eventProcessor.process(userEvent);
         if (experiment != null) {
@@ -290,6 +290,7 @@ public class Optimizely implements AutoCloseable {
                 experiment, userId, filteredAttributes, variation, impressionEvent);
             notificationCenter.send(activateNotification);
         }
+        return true;
     }
 
     //======== track calls ========//
@@ -1218,7 +1219,7 @@ public class Optimizely implements AutoCloseable {
         String ruleKey = flagDecision.experiment != null ? flagDecision.experiment.getKey() : null;
 
         if (!allOptions.contains(OptimizelyDecideOption.DISABLE_DECISION_EVENT)) {
-            sendImpression(
+            decisionEventDispatched = sendImpression(
                 projectConfig,
                 flagDecision.experiment,
                 userId,
@@ -1227,7 +1228,6 @@ public class Optimizely implements AutoCloseable {
                 key,
                 decisionSource.toString(),
                 flagEnabled);
-            decisionEventDispatched = true;
         }
 
         DecisionNotification decisionNotification = DecisionNotification.newFlagDecisionNotificationBuilder()

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyUserContextTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyUserContextTest.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2020, Optimizely and contributors
+ *    Copyright 2021, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyUserContextTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyUserContextTest.java
@@ -495,6 +495,112 @@ public class OptimizelyUserContextTest {
         OptimizelyDecision decision = user.decide(flagKey, Arrays.asList(OptimizelyDecideOption.DISABLE_DECISION_EVENT));
 
         assertEquals(decision.getVariationKey(), "variation_with_traffic");
+
+        // impression event not expected here
+    }
+
+    @Test
+    public void decide_sendEvent_featureTest_withSendFlagDecisionsOn() {
+        optimizely = new Optimizely.Builder()
+            .withDatafile(datafile)
+            .withEventProcessor(new ForwardingEventProcessor(eventHandler, null))
+            .build();
+
+        Map<String, Object> attributes = Collections.singletonMap("gender", "f");
+        OptimizelyUserContext user = optimizely.createUserContext(userId, attributes);
+
+        optimizely.addDecisionNotificationHandler(
+            decisionNotification -> {
+                Assert.assertEquals(decisionNotification.getDecisionInfo().get(DECISION_EVENT_DISPATCHED), true);
+                isListenerCalled = true;
+            });
+
+        String flagKey = "feature_2";
+        String experimentId = "10420810910";
+        String variationId = "10418551353";
+        isListenerCalled = false;
+        user.decide(flagKey);
+        assertTrue(isListenerCalled);
+
+        eventHandler.expectImpression(experimentId, variationId, userId, attributes);
+    }
+
+    @Test
+    public void decide_sendEvent_rollout_withSendFlagDecisionsOn() {
+        optimizely = new Optimizely.Builder()
+            .withDatafile(datafile)
+            .withEventProcessor(new ForwardingEventProcessor(eventHandler, null))
+            .build();
+
+        Map<String, Object> attributes = Collections.singletonMap("gender", "f");
+        OptimizelyUserContext user = optimizely.createUserContext(userId, attributes);
+
+        optimizely.addDecisionNotificationHandler(
+            decisionNotification -> {
+                Assert.assertEquals(decisionNotification.getDecisionInfo().get(DECISION_EVENT_DISPATCHED), true);
+                isListenerCalled = true;
+            });
+
+        String flagKey = "feature_3";
+        String experimentId = null;
+        String variationId = null;
+        isListenerCalled = false;
+        user.decide(flagKey);
+        assertTrue(isListenerCalled);
+
+        eventHandler.expectImpression(null, "", userId, attributes);
+    }
+
+    @Test
+    public void decide_sendEvent_featureTest_withSendFlagDecisionsOff() {
+        String datafileWithSendFlagDecisionsOff = datafile.replace("\"sendFlagDecisions\": true", "\"sendFlagDecisions\": false");
+        optimizely = new Optimizely.Builder()
+            .withDatafile(datafileWithSendFlagDecisionsOff)
+            .withEventProcessor(new ForwardingEventProcessor(eventHandler, null))
+            .build();
+
+        Map<String, Object> attributes = Collections.singletonMap("gender", "f");
+        OptimizelyUserContext user = optimizely.createUserContext(userId, attributes);
+
+        optimizely.addDecisionNotificationHandler(
+            decisionNotification -> {
+                Assert.assertEquals(decisionNotification.getDecisionInfo().get(DECISION_EVENT_DISPATCHED), true);
+                isListenerCalled = true;
+            });
+
+        String flagKey = "feature_2";
+        String experimentId = "10420810910";
+        String variationId = "10418551353";
+        isListenerCalled = false;
+        user.decide(flagKey);
+        assertTrue(isListenerCalled);
+
+        eventHandler.expectImpression(experimentId, variationId, userId, attributes);
+    }
+
+    @Test
+    public void decide_sendEvent_rollout_withSendFlagDecisionsOff() {
+        String datafileWithSendFlagDecisionsOff = datafile.replace("\"sendFlagDecisions\": true", "\"sendFlagDecisions\": false");
+        optimizely = new Optimizely.Builder()
+            .withDatafile(datafileWithSendFlagDecisionsOff)
+            .withEventProcessor(new ForwardingEventProcessor(eventHandler, null))
+            .build();
+
+        Map<String, Object> attributes = Collections.singletonMap("gender", "f");
+        OptimizelyUserContext user = optimizely.createUserContext(userId, attributes);
+
+        optimizely.addDecisionNotificationHandler(
+            decisionNotification -> {
+                Assert.assertEquals(decisionNotification.getDecisionInfo().get(DECISION_EVENT_DISPATCHED), false);
+                isListenerCalled = true;
+            });
+
+        String flagKey = "feature_3";
+        isListenerCalled = false;
+        user.decide(flagKey);
+        assertTrue(isListenerCalled);
+
+        // impression event not expected here
     }
 
     // notifications


### PR DESCRIPTION
## Summary
- SendImpressionEvent will return false when event is not sent and return true when sent successfully
- In case of userEvent is null it will return false
