### PR TITLE
Fix: GetVariationForFeatureInRollout to return null decisionResponse when rolloutRulesLength is zero

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/bucketing/DecisionService.java
+++ b/core-api/src/main/java/com/optimizely/ab/bucketing/DecisionService.java
@@ -283,6 +283,9 @@ public class DecisionService {
 
         // for all rules before the everyone else rule
         int rolloutRulesLength = rollout.getExperiments().size();
+        if (rolloutRulesLength == 0) {
+            return new DecisionResponse(new FeatureDecision(null, null, null), reasons);
+        }
         String bucketingId = getBucketingId(userId, filteredAttributes);
 
         Variation variation;


### PR DESCRIPTION
## Summary
- GetVariationForFeatureInRollout to return null decisionResponse when rolloutRulesLength is zero
