### PR TITLE
fix: add configurable evictIdleConnections

### DIFF
--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyFactory.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyFactory.java
@@ -124,6 +124,28 @@ public final class OptimizelyFactory {
     }
 
     /**
+     * Convenience method for setting the evict idle connections.
+     * {@link HttpProjectConfigManager.Builder#withEvictIdleConnections(long, TimeUnit)}
+     *
+     * @param maxIdleTime The connection idle time duration (0 to disable eviction)
+     * @param maxIdleTimeUnit The connection idle time unit
+     */
+    public static void setEvictIdleConnections(long maxIdleTime, TimeUnit maxIdleTimeUnit) {
+        if (maxIdleTimeUnit == null) {
+            logger.warn("TimeUnit cannot be null. Reverting to default configuration.");
+            return;
+        }
+
+        if (maxIdleTime < 0) {
+            logger.warn("Timeout cannot be < 0. Reverting to default configuration.");
+            return;
+        }
+
+        PropertyUtils.set(HttpProjectConfigManager.CONFIG_EVICT_DURATION, Long.toString(maxIdleTime));
+        PropertyUtils.set(HttpProjectConfigManager.CONFIG_EVICT_UNIT, maxIdleTimeUnit.toString());
+    }
+
+    /**
      * Convenience method for setting the polling interval on System properties.
      * {@link HttpProjectConfigManager.Builder#withPollingInterval(Long, TimeUnit)}
      *

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyFactoryTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyFactoryTest.java
@@ -153,6 +153,27 @@ public class OptimizelyFactoryTest {
     }
 
     @Test
+    public void setEvictIdleConnections() {
+        Long duration = 2000L;
+        TimeUnit timeUnit = TimeUnit.SECONDS;
+        OptimizelyFactory.setEvictIdleConnections(duration, timeUnit);
+
+        assertEquals(duration, PropertyUtils.getLong(HttpProjectConfigManager.CONFIG_EVICT_DURATION));
+        assertEquals(timeUnit, PropertyUtils.getEnum(HttpProjectConfigManager.CONFIG_EVICT_UNIT, TimeUnit.class));
+    }
+
+    @Test
+    public void setInvalidEvictIdleConnections() {
+        OptimizelyFactory.setEvictIdleConnections(-1, TimeUnit.MICROSECONDS);
+        assertNull(PropertyUtils.getLong(HttpProjectConfigManager.CONFIG_EVICT_DURATION));
+        assertNull(PropertyUtils.getEnum(HttpProjectConfigManager.CONFIG_EVICT_UNIT, TimeUnit.class));
+
+        OptimizelyFactory.setEvictIdleConnections(10, null);
+        assertNull(PropertyUtils.getLong(HttpProjectConfigManager.CONFIG_EVICT_DURATION));
+        assertNull(PropertyUtils.getEnum(HttpProjectConfigManager.CONFIG_EVICT_UNIT, TimeUnit.class));
+    }
+
+    @Test
     public void setSdkKey() {
         String expected = "sdk-key";
         OptimizelyFactory.setSdkKey(expected);

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyFactoryTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyFactoryTest.java
@@ -45,6 +45,8 @@ public class OptimizelyFactoryTest {
         PropertyUtils.clear(HttpProjectConfigManager.CONFIG_POLLING_UNIT);
         PropertyUtils.clear(HttpProjectConfigManager.CONFIG_BLOCKING_DURATION);
         PropertyUtils.clear(HttpProjectConfigManager.CONFIG_BLOCKING_UNIT);
+        PropertyUtils.clear(HttpProjectConfigManager.CONFIG_EVICT_DURATION);
+        PropertyUtils.clear(HttpProjectConfigManager.CONFIG_EVICT_UNIT);
         PropertyUtils.clear(HttpProjectConfigManager.CONFIG_SDK_KEY);
     }
 

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/config/HttpProjectConfigManagerTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/config/HttpProjectConfigManagerTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.optimizely.ab.config.HttpProjectConfigManager.*;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
@@ -252,6 +253,20 @@ public class HttpProjectConfigManagerTest {
         builder.withBlockingTimeout(10L, SECONDS);
         assertEquals(10, builder.blockingTimeoutPeriod);
         assertEquals(SECONDS, builder.blockingTimeoutUnit);
+    }
+
+    @Test
+    public void testEvictTime() {
+        Builder builder = builder();
+        long expectedPeriod = builder.evictConnectionIdleTimePeriod;
+        TimeUnit expectedTimeUnit = builder.evictConnectionIdleTimeUnit;
+
+        assertEquals(expectedPeriod, 1L);
+        assertEquals(expectedTimeUnit, MINUTES);
+
+        builder.withEvictIdleConnections(10L, SECONDS);
+        assertEquals(10, builder.evictConnectionIdleTimePeriod);
+        assertEquals(SECONDS, builder.evictConnectionIdleTimeUnit);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- With periodic polling, datafile fetches may fail with timeout intermittently. 
- Add configurable "evictIdleConnections" to HttpProjectConfigManager to force close persistent connection after idle time (evict after 1min idle time by default).

## Test plan

## Issues
- OASIS-7421