### PR TITLE
Update deprecated warning to OptimizelyFeature, getExperimentsMap().

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/optimizelyconfig/OptimizelyFeature.java
+++ b/core-api/src/main/java/com/optimizely/ab/optimizelyconfig/OptimizelyFeature.java
@@ -61,6 +61,10 @@ public class OptimizelyFeature implements IdKeyMapped {
         return key;
     }
 
+    /**
+     * @deprecated use {@link #getExperimentRules()} and {@link #getDeliveryRules()} instead
+     */
+    @Deprecated
     public Map<String, OptimizelyExperiment> getExperimentsMap() {
         return experimentsMap;
     }


### PR DESCRIPTION
## Summary
- Addition of deprecated warning for OptimizelyFeature.getExperimentsMap()

This function and member of OptimizelyFeature should no longer be used.
ExperimentRules and DeliveryRules including their getters are to be used in its place.

## Test plan
- FSC and IDE verification of Deprecation
## Issues
- N/A