### PR TITLE
Update conditions to use StringBuilder instead of StringJoiner 

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/config/audience/AndCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/AndCondition.java
@@ -76,11 +76,13 @@ public class AndCondition<T> implements Condition<T> {
 
     @Override
     public String toJson() {
-        StringJoiner s = new StringJoiner(", ", "[", "]");
-        s.add("\"and\"");
+        StringBuilder s = new StringBuilder();
+        s.append("[\"and\"");
         for (int i = 0; i < conditions.size(); i++) {
-            s.add(conditions.get(i).toJson());
+            s.append(conditions.get(i).toJson());
+            s.append(", ");
         }
+        s.append("]");
         return s.toString();
     }
 

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/NotCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/NotCondition.java
@@ -56,9 +56,10 @@ public class NotCondition<T> implements Condition<T> {
 
     @Override
     public String toJson() {
-        StringJoiner s = new StringJoiner(", ","[","]");
-        s.add("\"not\"");
-        s.add(condition.toJson());
+        StringBuilder s = new StringBuilder();
+        s.append("[\"not\"");
+        s.append(condition.toJson());
+        s.append("]");
         return s.toString();
     }
 

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/OrCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/OrCondition.java
@@ -74,11 +74,13 @@ public class OrCondition<T> implements Condition<T> {
 
     @Override
     public String toJson() {
-        StringJoiner s = new StringJoiner(", ", "[", "]");
-        s.add("\"or\"");
+        StringBuilder s = new StringBuilder();
+        s.append("[\"or\"");
         for (int i = 0; i < conditions.size(); i++) {
-            s.add(conditions.get(i).toJson());
+            s.append(conditions.get(i).toJson());
+            s.append(", ");
         }
+        s.append("]");
         return s.toString();
     }
 


### PR DESCRIPTION
## Summary
- Changing StringJoiner to StringBuilder for compatibility with Android

Android does not support StringJoiner at this time

## Test plan
FSC and Unit Tests locally

## Issues
- N/A