### PR TITLE
Create experimentRules array directly instead of from Map Values

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/optimizelyconfig/OptimizelyConfigService.java
+++ b/core-api/src/main/java/com/optimizely/ab/optimizelyconfig/OptimizelyConfigService.java
@@ -26,6 +26,7 @@ public class OptimizelyConfigService {
     private ProjectConfig projectConfig;
     private OptimizelyConfig optimizelyConfig;
     private List<OptimizelyAudience> audiences;
+    private List<OptimizelyExperiment> experimentRules;
     private Map<String, String> audiencesMap;
     private Map<String, List<FeatureVariable>> featureIdToVariablesMap = new HashMap<>();
     private Map<String, OptimizelyExperiment> experimentMapByExperimentId = new HashMap<>();
@@ -221,10 +222,8 @@ public class OptimizelyConfigService {
         Map<String, OptimizelyFeature> optimizelyFeatureKeyMap = new HashMap<>();
         for (FeatureFlag featureFlag : featureFlags) {
             Map<String, OptimizelyExperiment> experimentsMapForFeature =
-                getExperimentsMapForFeature(featureFlag.getExperimentIds(), allExperimentsMap);
+                getExperimentsMapForFeature(featureFlag.getExperimentIds());
 
-            List<OptimizelyExperiment> experimentRules =
-                new ArrayList<OptimizelyExperiment>(experimentsMapForFeature.values());
             List<OptimizelyExperiment> deliveryRules =
                 this.getDeliveryRules(featureFlag.getRolloutId(), featureFlag.getId());
 
@@ -267,16 +266,22 @@ public class OptimizelyConfigService {
     }
 
     @VisibleForTesting
-    Map<String, OptimizelyExperiment> getExperimentsMapForFeature(List<String> experimentIds, Map<String, OptimizelyExperiment> allExperimentsMap) {
+    Map<String, OptimizelyExperiment> getExperimentsMapForFeature(List<String> experimentIds) {
         if (experimentIds == null) {
             return Collections.emptyMap();
         }
 
+        List<OptimizelyExperiment> experimentRulesList = new ArrayList<>();
+
         Map<String, OptimizelyExperiment> optimizelyExperimentKeyMap = new HashMap<>();
         for (String experimentId : experimentIds) {
             Experiment experiment = projectConfig.getExperimentIdMapping().get(experimentId);
-            optimizelyExperimentKeyMap.put(experiment.getKey(), experimentMapByExperimentId.get(experiment.getId()));
+            OptimizelyExperiment optimizelyExperiment = experimentMapByExperimentId.get(experiment.getId());
+            optimizelyExperimentKeyMap.put(experiment.getKey(), optimizelyExperiment);
+            experimentRulesList.add(optimizelyExperiment);
         }
+
+        this.experimentRules = experimentRulesList;
 
         return optimizelyExperimentKeyMap;
     }

--- a/core-api/src/test/java/com/optimizely/ab/optimizelyconfig/OptimizelyConfigServiceTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/optimizelyconfig/OptimizelyConfigServiceTest.java
@@ -87,7 +87,7 @@ public class OptimizelyConfigServiceTest {
     public void testGetExperimentsMapForFeature() {
         List<String> experimentIds = projectConfig.getFeatureFlags().get(1).getExperimentIds();
         Map<String, OptimizelyExperiment> optimizelyFeatureExperimentMap =
-            optimizelyConfigService.getExperimentsMapForFeature(experimentIds, optimizelyConfigService.getExperimentsMap());
+            optimizelyConfigService.getExperimentsMapForFeature(experimentIds);
         assertEquals(expectedConfig.getFeaturesMap().get("multi_variate_feature").getExperimentsMap().size(), optimizelyFeatureExperimentMap.size());
     }
 


### PR DESCRIPTION
## Summary
- Build ExperimentRules array instead of from Map.values()

Causing an order issue with Android-SDK

## Test plan
FSC

## Issues
- N/A