### PR TITLE
chore: clean up datafile version log message

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java
@@ -100,7 +100,11 @@ public abstract class PollingProjectConfigManager implements ProjectConfigManage
             return;
         }
 
-        logger.info("New datafile set with revision: {}. Old revision: {}", projectConfig.getRevision(), previousRevision);
+        if (previousRevision == null) {
+            logger.info("New datafile set with revision: {}.", projectConfig.getRevision());
+        } else {
+            logger.info("New datafile set with revision: {}. Old revision: {}", projectConfig.getRevision(), previousRevision);
+        }
 
         currentProjectConfig.set(projectConfig);
         currentOptimizelyConfig.set(new OptimizelyConfigService(projectConfig).getConfig());

--- a/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java
@@ -100,7 +100,7 @@ public abstract class PollingProjectConfigManager implements ProjectConfigManage
             return;
         }
 
-        if (previousRevision == null) {
+        if (oldProjectConfig == null) {
             logger.info("New datafile set with revision: {}.", projectConfig.getRevision());
         } else {
             logger.info("New datafile set with revision: {}. Old revision: {}", projectConfig.getRevision(), previousRevision);


### PR DESCRIPTION
## Summary
- When datafile is parsed first time, it returns "null" for the previous version. The log message with "null previous version" can be confusing. Clean it up.

## Issues
- "OASIS-7388"