### PR TITLE
fix:update OptimizelyDecisionContext to check null for flagKey

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/OptimizelyDecisionContext.java
+++ b/core-api/src/main/java/com/optimizely/ab/OptimizelyDecisionContext.java
@@ -27,6 +27,7 @@ public class OptimizelyDecisionContext {
     private String ruleKey;
 
     public OptimizelyDecisionContext(@Nonnull String flagKey, @Nullable String ruleKey) {
+        if (flagKey == null) throw new NullPointerException("FlagKey must not be null, please provide a valid input.");
         this.flagKey = flagKey;
         this.ruleKey = ruleKey;
     }


### PR DESCRIPTION
## Summary
- Add null check to OptimizelyDecisionContext constructor for flagKey

We want to confirm the user is not passing a null value as flagKey in addition to the @NonNull annotation provided to ensure the object is valid

## Test plan
- FSC

## Issues
N/A