### PR TITLE
Update: Removed log4j properties from quick start application

### DIFF
--- a/java-quickstart/src/main/resources/log4j.properties
+++ b/java-quickstart/src/main/resources/log4j.properties
@@ -1,8 +1,0 @@
-# Root logger option
-log4j.rootLogger=INFO, stdout
-
-# Redirect log messages to console
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n


### PR DESCRIPTION
## Summary
- Removing log4j properties from quick start application for now.

## Test plan
All fsc and unit tests should pass.
