### PR TITLE
fix:Change Log level from WARN to DEBUG for number values in Audience Conditions for revisionNumber

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/config/audience/UserAttribute.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/UserAttribute.java
@@ -111,7 +111,7 @@ public class UserAttribute<T> implements Condition<T> {
                 }
             }
         } catch (UnknownMatchTypeException | UnexpectedValueTypeException e) {
-            logger.warn("Audience condition \"{}\" " + e.getMessage(), this);
+            logger.debug("Audience condition \"{}\" " + e.getMessage(), this);
         } catch (NullPointerException e) {
             logger.error("attribute or value null for match {}", match != null ? match : "legacy condition", e);
         }

--- a/core-api/src/test/java/com/optimizely/ab/config/audience/AudienceConditionEvaluationTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/audience/AudienceConditionEvaluationTest.java
@@ -22,7 +22,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.internal.matchers.Or;
 
 import java.math.BigInteger;
 import java.util.*;
@@ -165,7 +164,7 @@ public class AudienceConditionEvaluationTest {
     public void invalidMatch() throws Exception {
         UserAttribute testInstance = new UserAttribute("browser_type", "custom_attribute", "blah", "chrome");
         assertNull(testInstance.evaluate(null, testUserAttributes));
-        logbackVerifier.expectMessage(Level.WARN,
+        logbackVerifier.expectMessage(Level.DEBUG,
             "Audience condition \"{name='browser_type', type='custom_attribute', match='blah', value='chrome'}\" uses an unknown match type. You may need to upgrade to a newer release of the Optimizely SDK");
     }
 

--- a/core-api/src/test/java/com/optimizely/ab/config/audience/AudienceConditionEvaluationTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/audience/AudienceConditionEvaluationTest.java
@@ -226,6 +226,17 @@ public class AudienceConditionEvaluationTest {
     }
 
     /**
+     * Verify that UserAttribute.evaluate results of log level of DEBUG for number values passed for revisionNumber
+     */
+    @Test
+    public void missingConditionType() throws Exception {
+        UserAttribute testInstance = new UserAttribute("revisionNumber", "custom_attribute", "exact", 17065555);
+        assertNull(testInstance.evaluate(null, testUserAttributes));
+        logbackVerifier.expectMessage(Level.DEBUG,
+            "Audience condition \"{name='revisionNumber', type='custom_attribute', match='exact', value=17065555}\" has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.");
+    }
+
+    /**
      * Verify that UserAttribute.evaluate for EXIST match type returns true for known visitor
      * attributes with non-null instances and empty string.
      */

--- a/core-api/src/test/java/com/optimizely/ab/internal/ExperimentUtilsTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/internal/ExperimentUtilsTest.java
@@ -262,7 +262,7 @@ public class ExperimentUtilsTest {
 
         logbackVerifier.expectMessage(Level.DEBUG,
             "Starting to evaluate audience \"2196265320\" with conditions: [and, [or, [or, {name='nationality', type='custom_attribute', match='null', value='English'}, {name='nationality', type='custom_attribute', match='null', value=null}]]].");
-        logbackVerifier.expectMessage(Level.WARN,
+        logbackVerifier.expectMessage(Level.DEBUG,
             "Audience condition \"{name='nationality', type='custom_attribute', match='null', value=null}\" has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.");
         logbackVerifier.expectMessage(Level.DEBUG,
             "Audience \"2196265320\" evaluated to null.");
@@ -283,7 +283,7 @@ public class ExperimentUtilsTest {
 
         logbackVerifier.expectMessage(Level.DEBUG,
             "Starting to evaluate audience \"2196265320\" with conditions: [and, [or, [or, {name='nationality', type='custom_attribute', match='null', value='English'}, {name='nationality', type='custom_attribute', match='null', value=null}]]].");
-        logbackVerifier.expectMessage(Level.WARN,
+        logbackVerifier.expectMessage(Level.DEBUG,
             "Audience condition \"{name='nationality', type='custom_attribute', match='null', value=null}\" has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.");
         logbackVerifier.expectMessage(Level.DEBUG,
             "Audience \"2196265320\" evaluated to null.");


### PR DESCRIPTION
## Summary
- Changing log level from WARN to DEBUG for Audience Conditions when UnknownMatchTypeException or UnexpectedValueTypeException are caught.

Several customers have expressed concerns with logs being blown up with warnings due to usage of numbers for revisionNumber and other instances that require the use of a number value in their application where the SDK expects a string value. To avoid warnings in production environments, the log-level has been changed to DEBUG only now for those instances.

## Test plan
- New Unit Test
- FSC

## Issues
- "OASIS-8129"