### PR TITLE
fix(NotificationManager): add thread-safety to NotificationManager

### DIFF
--- a/core-api/src/test/java/com/optimizely/ab/notification/NotificationManagerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/notification/NotificationManagerTest.java
@@ -100,7 +100,7 @@ public class NotificationManagerTest {
                 }
             });
         }
-        latch.await(10, TimeUnit.SECONDS);
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
         assertEquals(numThreads * numRepeats, notificationManager.size());
     }
 }

--- a/core-api/src/test/java/com/optimizely/ab/notification/NotificationManagerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/notification/NotificationManagerTest.java
@@ -20,6 +20,11 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.*;
@@ -69,5 +74,33 @@ public class NotificationManagerTest {
         List<TestNotification> messages = handler.getMessages();
         assertEquals(1, messages.size());
         assertEquals("message1", messages.get(0).getMessage());
+    }
+
+    @Test
+    public void testThreadSafety() throws InterruptedException {
+        int numThreads = 10;
+        int numRepeats = 2;
+        ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+        CountDownLatch latch = new CountDownLatch(numThreads);
+        AtomicBoolean failedAlready = new AtomicBoolean(false);
+
+        for(int i = 0; i < numThreads; i++) {
+            executor.execute(() -> {
+                try {
+                    for (int j = 0; j < numRepeats; j++) {
+                        if(!failedAlready.get()) {
+                            notificationManager.addHandler(new TestNotificationHandler<>());
+                            notificationManager.send(new TestNotification("message1"));
+                        }
+                    }
+                } catch (Exception e) {
+                    failedAlready.set(true);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await(10, TimeUnit.SECONDS);
+        assertEquals(numThreads * numRepeats, notificationManager.size());
     }
 }


### PR DESCRIPTION
## Summary
- Fix NotificationManager to be thread-safe (add-handler and send-notifications can happen concurrently)

## Test plan
- Add a unit test concurrently adding handlers and sending notifications.

## Issues
- OASIS-8135