### PR TITLE
fix(semantic-version): log debug instead of warning for missing attribute value

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/config/audience/match/SemanticVersionEqualsMatch.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/match/SemanticVersionEqualsMatch.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2020, Optimizely and contributors
+ *    Copyright 2020, 2022, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import javax.annotation.Nullable;
 class SemanticVersionEqualsMatch implements Match {
     @Nullable
     public Boolean eval(Object conditionValue, Object attributeValue) throws UnexpectedValueTypeException {
+        if (attributeValue == null) return null;  // stay silent (no WARNING) when attribute value is missing or empty.
         return SemanticVersion.compare(attributeValue, conditionValue) == 0;
     }
 }

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/match/SemanticVersionGEMatch.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/match/SemanticVersionGEMatch.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2020, Optimizely and contributors
+ *    Copyright 2020, 2022, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 class SemanticVersionGEMatch implements Match {
     @Nullable
     public Boolean eval(Object conditionValue, Object attributeValue) throws UnexpectedValueTypeException {
+        if (attributeValue == null) return null;  // stay silent (no WARNING) when attribute value is missing or empty.
         return SemanticVersion.compare(attributeValue, conditionValue) >= 0;
     }
 }

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/match/SemanticVersionGTMatch.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/match/SemanticVersionGTMatch.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2020, Optimizely and contributors
+ *    Copyright 2020, 2022, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import javax.annotation.Nullable;
 class SemanticVersionGTMatch implements Match {
     @Nullable
     public Boolean eval(Object conditionValue, Object attributeValue) throws UnexpectedValueTypeException {
+        if (attributeValue == null) return null;  // stay silent (no WARNING) when attribute value is missing or empty.
         return SemanticVersion.compare(attributeValue, conditionValue) > 0;
     }
 }

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/match/SemanticVersionLEMatch.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/match/SemanticVersionLEMatch.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2020, Optimizely and contributors
+ *    Copyright 2020, 2022, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 class SemanticVersionLEMatch implements Match {
     @Nullable
     public Boolean eval(Object conditionValue, Object attributeValue) throws UnexpectedValueTypeException {
+        if (attributeValue == null) return null;  // stay silent (no WARNING) when attribute value is missing or empty.
         return SemanticVersion.compare(attributeValue, conditionValue) <= 0;
     }
 }

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/match/SemanticVersionLTMatch.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/match/SemanticVersionLTMatch.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2020, Optimizely and contributors
+ *    Copyright 2020, 2022, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import javax.annotation.Nullable;
 class SemanticVersionLTMatch implements Match {
     @Nullable
     public Boolean eval(Object conditionValue, Object attributeValue) throws UnexpectedValueTypeException {
+        if (attributeValue == null) return null;  // stay silent (no WARNING) when attribute value is missing or empty.
         return SemanticVersion.compare(attributeValue, conditionValue) < 0;
     }
 }

--- a/core-api/src/test/java/com/optimizely/ab/config/audience/match/SemanticVersionTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/audience/match/SemanticVersionTest.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2020, Optimizely and contributors
+ *    Copyright 2020, 2022, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import static org.junit.Assert.*;
 public class SemanticVersionTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
-
 
     @Test
     public void semanticVersionInvalidOnlyDash() throws Exception {
@@ -165,4 +164,16 @@ public class SemanticVersionTest {
         assertTrue(SemanticVersion.compare("3.7.1-prerelease-prerelease+rc", "3.7.1-prerelease+build") > 0);
         assertTrue(SemanticVersion.compare("3.7.1-beta.2", "3.7.1-beta.1") > 0);
     }
+
+    @Test
+    public void testSilentForNullOrMissingAttributesValues() throws Exception {
+        // SemanticVersionMatcher will throw UnexpectedValueType exception for invalid condition or attribute values (this exception is handled to log WARNING messages).
+        // But, for missing (or null) attribute value, it should not throw the exception.
+        assertNull(new SemanticVersionEqualsMatch().eval("1.2.3", null));
+        assertNull(new SemanticVersionGEMatch().eval("1.2.3", null));
+        assertNull(new SemanticVersionGTMatch().eval("1.2.3", null));
+        assertNull(new SemanticVersionLEMatch().eval("1.2.3", null));
+        assertNull(new SemanticVersionLTMatch().eval("1.2.3", null));
+    }
+
 }


### PR DESCRIPTION
## Summary
- When an attribute value is missing, semantic-version matcher returns the "unexpected-value" error message as the WARNING level. 
- This is fixed to the "missing-attribute" message as the DEBUG level, to be consistent with other condition matchers.

## Test plan
- Unit tests for all semantic-version matchers with null attribute value.

## Issues
- OASIS-8029
- https://github.com/optimizely/java-sdk/issues/450