### PR TITLE
chore: fix http-httpclient module tests not included in travis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ allprojects {
     }
 
     jacoco {
-        toolVersion = '0.8.0'
+        toolVersion = '0.8.7'
     }
 }
 

--- a/core-httpclient-impl/build.gradle
+++ b/core-httpclient-impl/build.gradle
@@ -5,3 +5,7 @@ dependencies {
 
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version: httpClientVersion
 }
+
+task exhaustiveTest {
+    dependsOn('test')
+}

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyHttpClientTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyHttpClientTest.java
@@ -40,6 +40,8 @@ public class OptimizelyHttpClientTest {
     @Before
     public void setUp() {
         System.setProperty("https.proxyHost", "localhost");
+        // default port (80) returns 404 instead of HttpHostConnectException
+        System.setProperty("https.proxyPort", "12345");
     }
 
     @After


### PR DESCRIPTION
## Summary
- http-httpclient module is not covered by travis (gradlew exhaustiveTest), which has been fixed.
- Fix a proxy testing not covered by travis.
- Upgrade jacoco to support Java 11