### PR TITLE
chore: remove the redundant settings.gradle from quickstart

### DIFF
--- a/java-quickstart/gradle/wrapper/gradle-wrapper.properties
+++ b/java-quickstart/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/java-quickstart/settings.gradle
+++ b/java-quickstart/settings.gradle
@@ -1,2 +1,0 @@
-rootProject.name = 'java-quickstart'
-


### PR DESCRIPTION
## Summary
- remove the redundant settings.gradle from quickstart (it makes build failed with Intellij 2021.3)
- upgrade gradle to 6.5 for quickstart