### PR TITLE
fix: add Optimizely builder option for client-engine info

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -1486,7 +1486,7 @@ public class Optimizely implements AutoCloseable {
         }
 
         /**
-         * The withEventHandler has has been moved to the EventProcessor which takes a EventHandler in it's builder
+         * The withEventHandler has been moved to the EventProcessor which takes a EventHandler in it's builder
          * method.
          * {@link com.optimizely.ab.event.BatchEventProcessor.Builder#withEventHandler(com.optimizely.ab.event.EventHandler)}  label}
          * Please use that builder method instead.
@@ -1516,6 +1516,13 @@ public class Optimizely implements AutoCloseable {
             return this;
         }
 
+        /**
+         * Override the SDK name and version (for client SDKs like android-sdk wrapping the core java-sdk) to be included in events.
+         *
+         * @param clientEngine the client engine type.
+         * @param clientVersion the client SDK version.
+         * @return An Optimizely builder
+         */
         public Builder withClientInfo(EventBatch.ClientEngine clientEngine, String clientVersion) {
             ClientEngineInfo.setClientEngine(clientEngine);
             BuildVersionInfo.setClientVersion(clientVersion);

--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -25,10 +25,7 @@ import com.optimizely.ab.config.parser.ConfigParseException;
 import com.optimizely.ab.error.ErrorHandler;
 import com.optimizely.ab.error.NoOpErrorHandler;
 import com.optimizely.ab.event.*;
-import com.optimizely.ab.event.internal.ClientEngineInfo;
-import com.optimizely.ab.event.internal.EventFactory;
-import com.optimizely.ab.event.internal.UserEvent;
-import com.optimizely.ab.event.internal.UserEventFactory;
+import com.optimizely.ab.event.internal.*;
 import com.optimizely.ab.event.internal.payload.EventBatch;
 import com.optimizely.ab.notification.*;
 import com.optimizely.ab.optimizelyconfig.OptimizelyConfig;
@@ -1516,6 +1513,12 @@ public class Optimizely implements AutoCloseable {
 
         public Builder withUserProfileService(UserProfileService userProfileService) {
             this.userProfileService = userProfileService;
+            return this;
+        }
+
+        public Builder withClientInfo(EventBatch.ClientEngine clientEngine, String clientVersion) {
+            ClientEngineInfo.setClientEngine(clientEngine);
+            BuildVersionInfo.setClientVersion(clientVersion);
             return this;
         }
 

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/BuildVersionInfo.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/BuildVersionInfo.java
@@ -30,20 +30,23 @@ import javax.annotation.concurrent.Immutable;
 /**
  * Helper class to retrieve the SDK version information.
  */
-@Immutable
 public final class BuildVersionInfo {
 
     private static final Logger logger = LoggerFactory.getLogger(BuildVersionInfo.class);
 
-    public static String VERSION = readVersionNumber();
+    @Deprecated
+    public final static String VERSION = readVersionNumber();
 
-    // can be overridden by other wrapper client (android-sdk)
+    // can be overridden by other wrapper client (android-sdk, etc)
+
+    private static String clientVersion = readVersionNumber();
+
     public static void setClientVersion(String version) {
-         VERSION = version;
+         clientVersion = version;
     }
 
     public static String getClientVersion() {
-        return VERSION;
+        return clientVersion;
     }
 
     private static String readVersionNumber() {

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/BuildVersionInfo.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/BuildVersionInfo.java
@@ -42,7 +42,11 @@ public final class BuildVersionInfo {
     private static String clientVersion = readVersionNumber();
 
     public static void setClientVersion(String version) {
-         clientVersion = version;
+        if (version == null || version.isEmpty()) {
+            logger.warn("ClientVersion cannot be empty, defaulting to the core java-sdk version.");
+            return;
+        }
+        clientVersion = version;
     }
 
     public static String getClientVersion() {

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/BuildVersionInfo.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/BuildVersionInfo.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2016-2017, 2019, Optimizely and contributors
+ *    Copyright 2016-2017, 2019, 2022, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -35,7 +35,16 @@ public final class BuildVersionInfo {
 
     private static final Logger logger = LoggerFactory.getLogger(BuildVersionInfo.class);
 
-    public final static String VERSION = readVersionNumber();
+    public static String VERSION = readVersionNumber();
+
+    // can be overridden by other wrapper client (android-sdk)
+    public static void setClientVersion(String version) {
+         VERSION = version;
+    }
+
+    public static String getClientVersion() {
+        return VERSION;
+    }
 
     private static String readVersionNumber() {
         BufferedReader bufferedReader = null;

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/EventFactory.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/EventFactory.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2016-2020, Optimizely and contributors
+ *    Copyright 2016-2020, 2022, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -73,7 +73,7 @@ public class EventFactory {
 
             builder
                 .setClientName(ClientEngineInfo.getClientEngine().getClientEngineValue())
-                .setClientVersion(BuildVersionInfo.VERSION)
+                .setClientVersion(BuildVersionInfo.getClientVersion())
                 .setAccountId(projectConfig.getAccountId())
                 .setAnonymizeIp(projectConfig.getAnonymizeIP())
                 .setProjectId(projectConfig.getProjectId())

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/payload/EventBatch.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/payload/EventBatch.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2018-2019, Optimizely and contributors
+ *    Copyright 2018-2019, 2022, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -165,7 +165,7 @@ public class EventBatch {
     public static class Builder {
 
         private String clientName = ClientEngine.JAVA_SDK.getClientEngineValue();
-        private String clientVersion = BuildVersionInfo.VERSION;
+        private String clientVersion = BuildVersionInfo.getClientVersion();
         private String accountId;
         private List<Visitor> visitors;
         private Boolean anonymizeIp;

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyBuilderTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyBuilderTest.java
@@ -219,9 +219,21 @@ public class OptimizelyBuilderTest {
         assertEquals(argument.getValue().getEventBatch().getClientName(), "java-sdk");
         assertEquals(argument.getValue().getEventBatch().getClientVersion(), BuildVersionInfo.getClientVersion());
 
+        // invalid override with null inputs
+
+        reset(eventHandler);
+        optimizely = Optimizely.builder(validConfigJsonV4(), eventHandler)
+            .withClientInfo(null, null)
+            .build();
+        optimizely.track("basic_event", "tester");
+
+        verify(eventHandler, timeout(5000)).dispatchEvent(argument.capture());
+        assertEquals(argument.getValue().getEventBatch().getClientName(), "java-sdk");
+        assertEquals(argument.getValue().getEventBatch().getClientVersion(), BuildVersionInfo.getClientVersion());
+
         // override client-engine info
 
-        eventHandler = mock(EventHandler.class);
+        reset(eventHandler);
         optimizely = Optimizely.builder(validConfigJsonV4(), eventHandler)
             .withClientInfo(EventBatch.ClientEngine.ANDROID_SDK, "1.2.3")
             .build();

--- a/core-api/src/test/java/com/optimizely/ab/event/internal/EventFactoryTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/event/internal/EventFactoryTest.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2016-2020, Optimizely and contributors
+ *    Copyright 2016-2020, 2022, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -157,7 +157,7 @@ public class EventFactoryTest {
         assertThat(eventBatch.getAccountId(), is(validProjectConfig.getAccountId()));
         assertThat(eventBatch.getVisitors().get(0).getAttributes(), is(expectedUserFeatures));
         assertThat(eventBatch.getClientName(), is(EventBatch.ClientEngine.JAVA_SDK.getClientEngineValue()));
-        assertThat(eventBatch.getClientVersion(), is(BuildVersionInfo.VERSION));
+        assertThat(eventBatch.getClientVersion(), is(BuildVersionInfo.getClientVersion()));
         assertNull(eventBatch.getVisitors().get(0).getSessionId());
     }
 
@@ -224,7 +224,7 @@ public class EventFactoryTest {
         assertThat(eventBatch.getAccountId(), is(validProjectConfig.getAccountId()));
         assertThat(eventBatch.getVisitors().get(0).getAttributes(), is(expectedUserFeatures));
         assertThat(eventBatch.getClientName(), is(EventBatch.ClientEngine.JAVA_SDK.getClientEngineValue()));
-        assertThat(eventBatch.getClientVersion(), is(BuildVersionInfo.VERSION));
+        assertThat(eventBatch.getClientVersion(), is(BuildVersionInfo.getClientVersion()));
         assertNull(eventBatch.getVisitors().get(0).getSessionId());
     }
 
@@ -649,7 +649,7 @@ public class EventFactoryTest {
         assertEquals(conversion.getAnonymizeIp(), validProjectConfig.getAnonymizeIP());
         assertTrue(conversion.getEnrichDecisions());
         assertEquals(conversion.getClientName(), EventBatch.ClientEngine.JAVA_SDK.getClientEngineValue());
-        assertEquals(conversion.getClientVersion(), BuildVersionInfo.VERSION);
+        assertEquals(conversion.getClientVersion(), BuildVersionInfo.getClientVersion());
     }
 
     /**
@@ -717,7 +717,7 @@ public class EventFactoryTest {
         assertEquals(conversion.getAnonymizeIp(), validProjectConfig.getAnonymizeIP());
         assertTrue(conversion.getEnrichDecisions());
         assertEquals(conversion.getClientName(), EventBatch.ClientEngine.JAVA_SDK.getClientEngineValue());
-        assertEquals(conversion.getClientVersion(), BuildVersionInfo.VERSION);
+        assertEquals(conversion.getClientVersion(), BuildVersionInfo.getClientVersion());
     }
 
     /**
@@ -961,7 +961,7 @@ public class EventFactoryTest {
 
         assertThat(impression.getVisitors().get(0).getAttributes(), is(expectedUserFeatures));
         assertThat(impression.getClientName(), is(EventBatch.ClientEngine.JAVA_SDK.getClientEngineValue()));
-        assertThat(impression.getClientVersion(), is(BuildVersionInfo.VERSION));
+        assertThat(impression.getClientVersion(), is(BuildVersionInfo.getClientVersion()));
         assertNull(impression.getVisitors().get(0).getSessionId());
     }
 
@@ -1034,7 +1034,7 @@ public class EventFactoryTest {
         assertEquals(conversion.getAnonymizeIp(), validProjectConfig.getAnonymizeIP());
         assertTrue(conversion.getEnrichDecisions());
         assertEquals(conversion.getClientName(), EventBatch.ClientEngine.JAVA_SDK.getClientEngineValue());
-        assertEquals(conversion.getClientVersion(), BuildVersionInfo.VERSION);
+        assertEquals(conversion.getClientVersion(), BuildVersionInfo.getClientVersion());
     }
 
 


### PR DESCRIPTION
## Summary
- Add an option to specify client-engine version (android-sdk, etc) in the Optimizely builder.

## Test plan
- Add a unit test for builder with client-engine version.

## Issues
- OASIS-8188