### PR TITLE
feat: Add ODP Segments support in Audience Evaluation

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - name: Setup tmate session

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -45,7 +45,7 @@ jobs:
   
   test:
     if: startsWith(github.ref, 'refs/tags/') != true
-    runs-on: macos-10.15
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -14,6 +14,12 @@ on:
         description: Set SNAPSHOT true to publish
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
   lint_markdown_files:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -14,12 +14,6 @@ on:
         description: Set SNAPSHOT true to publish
 
 jobs:
-  build:
-    runs-on: ubuntu-18.04
-    steps:
-    - uses: actions/checkout@v2
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
   lint_markdown_files:
     runs-on: ubuntu-latest
     steps:
@@ -51,7 +45,7 @@ jobs:
   
   test:
     if: startsWith(github.ref, 'refs/tags/') != true
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -45,7 +45,7 @@ jobs:
   
   test:
     if: startsWith(github.ref, 'refs/tags/') != true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -45,7 +45,7 @@ jobs:
   
   test:
     if: startsWith(github.ref, 'refs/tags/') != true
-    runs-on: ubuntu-18.04
+    runs-on: macos-10.15
     strategy:
       fail-fast: false
       matrix:

--- a/core-api/src/main/java/com/optimizely/ab/OptimizelyUserContext.java
+++ b/core-api/src/main/java/com/optimizely/ab/OptimizelyUserContext.java
@@ -46,14 +46,7 @@ public class OptimizelyUserContext {
     public OptimizelyUserContext(@Nonnull Optimizely optimizely,
                                  @Nonnull String userId,
                                  @Nonnull Map<String, ?> attributes) {
-        this.optimizely = optimizely;
-        this.userId = userId;
-        if (attributes != null) {
-            this.attributes = Collections.synchronizedMap(new HashMap<>(attributes));
-        } else {
-            this.attributes = Collections.synchronizedMap(new HashMap<>());
-        }
-        this.qualifiedSegments = Collections.synchronizedList(new LinkedList<>());
+        this(optimizely, userId, attributes, Collections.EMPTY_MAP);
     }
 
     public OptimizelyUserContext(@Nonnull Optimizely optimizely,

--- a/core-api/src/main/java/com/optimizely/ab/OptimizelyUserContext.java
+++ b/core-api/src/main/java/com/optimizely/ab/OptimizelyUserContext.java
@@ -90,7 +90,7 @@ public class OptimizelyUserContext {
 
     /**
      * Returns true if the user is qualified for the given segment name
-     * @param segment A String segment key which will be check in qualified segments list that if it exist then user is qualified.
+     * @param segment A String segment key which will be checked in the qualified segments list that if it exists then user is qualified.
      * @return boolean Is user qualified for a segment.
      */
     public boolean isQualifiedFor(@Nonnull String segment) {

--- a/core-api/src/main/java/com/optimizely/ab/OptimizelyUserContext.java
+++ b/core-api/src/main/java/com/optimizely/ab/OptimizelyUserContext.java
@@ -86,7 +86,11 @@ public class OptimizelyUserContext {
         return new OptimizelyUserContext(optimizely, userId, attributes, forcedDecisionsMap);
     }
 
-    // true if the user is qualified for the given segment name
+    /**
+     * Returns true if the user is qualified for the given segment name
+     * @param segment A String segment key which will be check in qualified segments list that if it exist then user is qualified.
+     * @return boolean Is user qualified for a segment.
+     */
     public boolean isQualifiedFor(@Nonnull String segment) {
         return qualifiedSegments.contains(segment);
     }

--- a/core-api/src/main/java/com/optimizely/ab/OptimizelyUserContext.java
+++ b/core-api/src/main/java/com/optimizely/ab/OptimizelyUserContext.java
@@ -36,6 +36,8 @@ public class OptimizelyUserContext {
     @Nonnull
     private final Map<String, Object> attributes;
 
+    private List<String> qualifiedSegments;
+
     @Nonnull
     private final Optimizely optimizely;
 
@@ -51,6 +53,7 @@ public class OptimizelyUserContext {
         } else {
             this.attributes = Collections.synchronizedMap(new HashMap<>());
         }
+        this.qualifiedSegments = Collections.synchronizedList(new LinkedList<>());
     }
 
     public OptimizelyUserContext(@Nonnull Optimizely optimizely,
@@ -67,6 +70,7 @@ public class OptimizelyUserContext {
         if (forcedDecisionsMap != null) {
           this.forcedDecisionsMap = new ConcurrentHashMap<>(forcedDecisionsMap);
         }
+        this.qualifiedSegments = Collections.synchronizedList(new LinkedList<>());
     }
 
     public OptimizelyUserContext(@Nonnull Optimizely optimizely, @Nonnull String userId) {
@@ -87,6 +91,11 @@ public class OptimizelyUserContext {
 
     public OptimizelyUserContext copy() {
         return new OptimizelyUserContext(optimizely, userId, attributes, forcedDecisionsMap);
+    }
+
+    // true if the user is qualified for the given segment name
+    public boolean isQualifiedFor(@Nonnull String segment) {
+        return qualifiedSegments.contains(segment);
     }
 
     /**

--- a/core-api/src/main/java/com/optimizely/ab/OptimizelyUserContext.java
+++ b/core-api/src/main/java/com/optimizely/ab/OptimizelyUserContext.java
@@ -46,13 +46,14 @@ public class OptimizelyUserContext {
     public OptimizelyUserContext(@Nonnull Optimizely optimizely,
                                  @Nonnull String userId,
                                  @Nonnull Map<String, ?> attributes) {
-        this(optimizely, userId, attributes, Collections.EMPTY_MAP);
+        this(optimizely, userId, attributes, Collections.EMPTY_MAP, null);
     }
 
     public OptimizelyUserContext(@Nonnull Optimizely optimizely,
                                  @Nonnull String userId,
                                  @Nonnull Map<String, ?> attributes,
-                                 @Nullable Map<String, OptimizelyForcedDecision> forcedDecisionsMap) {
+                                 @Nullable Map<String, OptimizelyForcedDecision> forcedDecisionsMap,
+                                 @Nullable List<String> qualifiedSegments) {
         this.optimizely = optimizely;
         this.userId = userId;
         if (attributes != null) {
@@ -61,9 +62,10 @@ public class OptimizelyUserContext {
             this.attributes = Collections.synchronizedMap(new HashMap<>());
         }
         if (forcedDecisionsMap != null) {
-          this.forcedDecisionsMap = new ConcurrentHashMap<>(forcedDecisionsMap);
+            this.forcedDecisionsMap = new ConcurrentHashMap<>(forcedDecisionsMap);
         }
-        this.qualifiedSegments = Collections.synchronizedList(new LinkedList<>());
+
+        this.qualifiedSegments = Collections.synchronizedList( qualifiedSegments == null ? new LinkedList<>(): qualifiedSegments);
     }
 
     public OptimizelyUserContext(@Nonnull Optimizely optimizely, @Nonnull String userId) {
@@ -83,7 +85,7 @@ public class OptimizelyUserContext {
     }
 
     public OptimizelyUserContext copy() {
-        return new OptimizelyUserContext(optimizely, userId, attributes, forcedDecisionsMap);
+        return new OptimizelyUserContext(optimizely, userId, attributes, forcedDecisionsMap, qualifiedSegments);
     }
 
     /**
@@ -271,7 +273,14 @@ public class OptimizelyUserContext {
         return true;
     }
 
+    public List<String> getQualifiedSegments() {
+        return qualifiedSegments;
+    }
 
+    public void setQualifiedSegments(List<String> qualifiedSegments) {
+        this.qualifiedSegments.clear();
+        this.qualifiedSegments.addAll(qualifiedSegments);
+    }
 
     // Utils
 

--- a/core-api/src/main/java/com/optimizely/ab/bucketing/DecisionService.java
+++ b/core-api/src/main/java/com/optimizely/ab/bucketing/DecisionService.java
@@ -152,7 +152,7 @@ public class DecisionService {
             }
         }
 
-        DecisionResponse<Boolean> decisionMeetAudience = ExperimentUtils.doesUserMeetAudienceConditions(projectConfig, experiment, user.getAttributes(), EXPERIMENT, experiment.getKey());
+        DecisionResponse<Boolean> decisionMeetAudience = ExperimentUtils.doesUserMeetAudienceConditions(projectConfig, experiment, user, EXPERIMENT, experiment.getKey());
         reasons.merge(decisionMeetAudience.getReasons());
         if (decisionMeetAudience.getResult()) {
             String bucketingId = getBucketingId(user.getUserId(), user.getAttributes());
@@ -693,7 +693,7 @@ public class DecisionService {
         DecisionResponse<Boolean> audienceDecisionResponse = ExperimentUtils.doesUserMeetAudienceConditions(
             projectConfig,
             rule,
-            user.getAttributes(),
+            user,
             RULE,
             String.valueOf(ruleIndex + 1)
         );

--- a/core-api/src/main/java/com/optimizely/ab/config/DatafileProjectConfig.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/DatafileProjectConfig.java
@@ -63,6 +63,8 @@ public class DatafileProjectConfig implements ProjectConfig {
     private final boolean anonymizeIP;
     private final boolean sendFlagDecisions;
     private final Boolean botFiltering;
+    private final String hostForODP;
+    private final String publicKeyForODP;
     private final List<Attribute> attributes;
     private final List<Audience> audiences;
     private final List<Audience> typedAudiences;
@@ -71,6 +73,7 @@ public class DatafileProjectConfig implements ProjectConfig {
     private final List<FeatureFlag> featureFlags;
     private final List<Group> groups;
     private final List<Rollout> rollouts;
+    private final List<Integration> integrations;
 
     // key to entity mappings
     private final Map<String, Attribute> attributeKeyMapping;
@@ -121,6 +124,7 @@ public class DatafileProjectConfig implements ProjectConfig {
             experiments,
             null,
             groups,
+            null,
             null
         );
     }
@@ -142,8 +146,8 @@ public class DatafileProjectConfig implements ProjectConfig {
                                  List<Experiment> experiments,
                                  List<FeatureFlag> featureFlags,
                                  List<Group> groups,
-                                 List<Rollout> rollouts) {
-
+                                 List<Rollout> rollouts,
+                                 List<Integration> integrations) {
         this.accountId = accountId;
         this.projectId = projectId;
         this.version = version;
@@ -181,6 +185,24 @@ public class DatafileProjectConfig implements ProjectConfig {
         allExperiments.addAll(experiments);
         allExperiments.addAll(aggregateGroupExperiments(groups));
         this.experiments = Collections.unmodifiableList(allExperiments);
+
+        String publicKeyForODP = "";
+        String hostForODP = "";
+        if (integrations == null) {
+            this.integrations = Collections.emptyList();
+        } else {
+            this.integrations = Collections.unmodifiableList(integrations);
+            for (Integration integration: this.integrations) {
+                if (integration.getKey().equals("odp")) {
+                    hostForODP = integration.getHost();
+                    publicKeyForODP = integration.getPublicKey();
+                    break;
+                }
+            }
+        }
+
+        this.publicKeyForODP = publicKeyForODP;
+        this.hostForODP = hostForODP;
 
         Map<String, Experiment> variationIdToExperimentMap = new HashMap<String, Experiment>();
         for (Experiment experiment : this.experiments) {
@@ -522,6 +544,16 @@ public class DatafileProjectConfig implements ProjectConfig {
             }
         }
         return null;
+    }
+
+    @Override
+    public String getHostForODP() {
+        return hostForODP;
+    }
+
+    @Override
+    public String getPublicKeyForODP() {
+        return publicKeyForODP;
     }
 
     @Override

--- a/core-api/src/main/java/com/optimizely/ab/config/DatafileProjectConfig.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/DatafileProjectConfig.java
@@ -471,6 +471,11 @@ public class DatafileProjectConfig implements ProjectConfig {
     }
 
     @Override
+    public List<Integration> getIntegrations() {
+        return integrations;
+    }
+
+    @Override
     public Audience getAudience(String audienceId) {
         return audienceIdMapping.get(audienceId);
     }

--- a/core-api/src/main/java/com/optimizely/ab/config/Integration.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/Integration.java
@@ -1,0 +1,62 @@
+/**
+ *
+ *    Copyright 2022, Optimizely and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.optimizely.ab.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * Represents the Optimizely Integration configuration.
+ *
+ * @see <a href="http://developers.optimizely.com/server/reference/index.html#json">Project JSON</a>
+ */
+@Immutable
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Integration {
+    private final String key;
+    private final String host;
+    private final String publicKey;
+
+    @JsonCreator
+    public Integration(@JsonProperty("key") String key,
+                       @JsonProperty("host") String host,
+                       @JsonProperty("publicKey") String publicKey) {
+        this.key = key;
+        this.host = host;
+        this.publicKey = publicKey;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getHost() { return host; }
+
+    public String getPublicKey() { return publicKey; }
+
+    @Override
+    public String toString() {
+        return "Integration{" +
+            "key='" + key + '\'' +
+            ", host='" + host + '\'' +
+            ", publicKey='" + publicKey + '\'' +
+            '}';
+    }
+}

--- a/core-api/src/main/java/com/optimizely/ab/config/Integration.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/Integration.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -43,20 +45,23 @@ public class Integration {
         this.publicKey = publicKey;
     }
 
+    @Nonnull
     public String getKey() {
         return key;
     }
 
+    @Nullable
     public String getHost() { return host; }
 
+    @Nullable
     public String getPublicKey() { return publicKey; }
 
     @Override
     public String toString() {
         return "Integration{" +
             "key='" + key + '\'' +
-            ", host='" + host + '\'' +
-            ", publicKey='" + publicKey + '\'' +
+            ((this.host != null) ? (", host='" + host + '\'') : "") +
+            ((this.publicKey != null) ? (", publicKey='" + publicKey + '\'') : "") +
             '}';
     }
 }

--- a/core-api/src/main/java/com/optimizely/ab/config/ProjectConfig.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/ProjectConfig.java
@@ -83,6 +83,8 @@ public interface ProjectConfig {
 
     List<Audience> getTypedAudiences();
 
+    List<Integration> getIntegrations();
+
     Audience getAudience(String audienceId);
 
     Map<String, Experiment> getExperimentKeyMapping();

--- a/core-api/src/main/java/com/optimizely/ab/config/ProjectConfig.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/ProjectConfig.java
@@ -107,6 +107,10 @@ public interface ProjectConfig {
 
     Variation getFlagVariationByKey(String flagKey, String variationKey);
 
+    String getHostForODP();
+
+    String getPublicKeyForODP();
+
     @Override
     String toString();
 

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/AndCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/AndCondition.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2016-2019, Optimizely and contributors
+ *    Copyright 2016-2019, 2022, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/AndCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/AndCondition.java
@@ -16,6 +16,7 @@
  */
 package com.optimizely.ab.config.audience;
 
+import com.optimizely.ab.OptimizelyUserContext;
 import com.optimizely.ab.config.ProjectConfig;
 
 import javax.annotation.Nonnull;
@@ -42,7 +43,7 @@ public class AndCondition<T> implements Condition<T> {
     }
 
     @Nullable
-    public Boolean evaluate(ProjectConfig config, Map<String, ?> attributes) {
+    public Boolean evaluate(ProjectConfig config, OptimizelyUserContext user) {
         if (conditions == null) return null;
         boolean foundNull = false;
         // According to the matrix where:
@@ -53,7 +54,7 @@ public class AndCondition<T> implements Condition<T> {
         // true and true is true
         // null and null is null
         for (Condition condition : conditions) {
-            Boolean conditionEval = condition.evaluate(config, attributes);
+            Boolean conditionEval = condition.evaluate(config, user);
             if (conditionEval == null) {
                 foundNull = true;
             } else if (!conditionEval) { // false with nulls or trues is false.

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/AttributeType.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/AttributeType.java
@@ -1,0 +1,33 @@
+/**
+ *
+ *    Copyright 2022, Optimizely and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.optimizely.ab.config.audience;
+
+public enum AttributeType {
+    CUSTOM_ATTRIBUTE("custom_attribute"),
+    THIRD_PARTY_DIMENSION("third_party_dimension");
+
+    private final String key;
+
+    AttributeType(String key) {
+        this.key = key;
+    }
+
+    @Override
+    public String toString() {
+        return key;
+    }
+}

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/AudienceIdCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/AudienceIdCondition.java
@@ -6,7 +6,7 @@
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,6 +19,7 @@
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.optimizely.ab.OptimizelyUserContext;
 import com.optimizely.ab.config.ProjectConfig;
 import com.optimizely.ab.internal.InvalidAudienceCondition;
 import org.slf4j.Logger;
@@ -71,7 +72,7 @@ public class AudienceIdCondition<T> implements Condition<T> {
 
     @Nullable
     @Override
-    public Boolean evaluate(ProjectConfig config, Map<String, ?> attributes) {
+    public Boolean evaluate(ProjectConfig config, OptimizelyUserContext user) {
         if (config != null) {
             audience = config.getAudienceIdMapping().get(audienceId);
         }
@@ -80,7 +81,7 @@ public class AudienceIdCondition<T> implements Condition<T> {
             return null;
         }
         logger.debug("Starting to evaluate audience \"{}\" with conditions: {}.", audience.getId(), audience.getConditions());
-        Boolean result = audience.getConditions().evaluate(config, attributes);
+        Boolean result = audience.getConditions().evaluate(config, user);
         logger.debug("Audience \"{}\" evaluated to {}.", audience.getId(), result);
         return result;
     }

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/AudienceIdCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/AudienceIdCondition.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2018-2021, Optimizely and contributors
+ *    Copyright 2018-2022, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/Condition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/Condition.java
@@ -16,6 +16,7 @@
  */
 package com.optimizely.ab.config.audience;
 
+import com.optimizely.ab.OptimizelyUserContext;
 import com.optimizely.ab.config.ProjectConfig;
 
 import javax.annotation.Nullable;
@@ -27,7 +28,7 @@ import java.util.Map;
 public interface Condition<T> {
 
     @Nullable
-    Boolean evaluate(ProjectConfig config, Map<String, ?> attributes);
+    Boolean evaluate(ProjectConfig config, OptimizelyUserContext user);
 
     String toJson();
 

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/Condition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/Condition.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2016-2018, Optimizely and contributors
+ *    Copyright 2016-2018, 2022, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/EmptyCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/EmptyCondition.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2019, Optimizely Inc. and contributors
+ *    Copyright 2019, 2022, Optimizely Inc. and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/EmptyCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/EmptyCondition.java
@@ -15,6 +15,7 @@
  */
 package com.optimizely.ab.config.audience;
 
+import com.optimizely.ab.OptimizelyUserContext;
 import com.optimizely.ab.config.ProjectConfig;
 
 import javax.annotation.Nullable;
@@ -23,7 +24,7 @@ import java.util.Map;
 public class EmptyCondition<T> implements Condition<T> {
     @Nullable
     @Override
-    public Boolean evaluate(ProjectConfig config, Map<String, ?> attributes) {
+    public Boolean evaluate(ProjectConfig config, OptimizelyUserContext user) {
         return true;
     }
 

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/NotCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/NotCondition.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2016-2019, Optimizely and contributors
+ *    Copyright 2016-2019, 2022, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,8 +23,6 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.Nonnull;
 
-import java.util.Map;
-import java.util.StringJoiner;
 
 /**
  * Represents a 'Not' conditions condition operation.

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/NotCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/NotCondition.java
@@ -16,6 +16,7 @@
  */
 package com.optimizely.ab.config.audience;
 
+import com.optimizely.ab.OptimizelyUserContext;
 import com.optimizely.ab.config.ProjectConfig;
 
 import javax.annotation.Nullable;
@@ -43,9 +44,8 @@ public class NotCondition<T> implements Condition<T> {
     }
 
     @Nullable
-    public Boolean evaluate(ProjectConfig config, Map<String, ?> attributes) {
-
-        Boolean conditionEval = condition == null ? null : condition.evaluate(config, attributes);
+    public Boolean evaluate(ProjectConfig config, OptimizelyUserContext user) {
+        Boolean conditionEval = condition == null ? null : condition.evaluate(config, user);
         return (conditionEval == null ? null : !conditionEval);
     }
 

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/NullCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/NullCondition.java
@@ -15,6 +15,7 @@
  */
 package com.optimizely.ab.config.audience;
 
+import com.optimizely.ab.OptimizelyUserContext;
 import com.optimizely.ab.config.ProjectConfig;
 
 import javax.annotation.Nullable;
@@ -23,7 +24,7 @@ import java.util.Map;
 public class NullCondition<T> implements Condition<T> {
     @Nullable
     @Override
-    public Boolean evaluate(ProjectConfig config, Map<String, ?> attributes) {
+    public Boolean evaluate(ProjectConfig config, OptimizelyUserContext user) {
         return null;
     }
 

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/NullCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/NullCondition.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2019, Optimizely Inc. and contributors
+ *    Copyright 2019, 2022, Optimizely Inc. and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/OrCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/OrCondition.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2016-2019, Optimizely and contributors
+ *    Copyright 2016-2019, 2022, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/OrCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/OrCondition.java
@@ -16,6 +16,7 @@
  */
 package com.optimizely.ab.config.audience;
 
+import com.optimizely.ab.OptimizelyUserContext;
 import com.optimizely.ab.config.ProjectConfig;
 
 import javax.annotation.Nonnull;
@@ -47,11 +48,11 @@ public class OrCondition<T> implements Condition<T> {
     // false or false is false
     // null or null is null
     @Nullable
-    public Boolean evaluate(ProjectConfig config, Map<String, ?> attributes) {
+    public Boolean evaluate(ProjectConfig config, OptimizelyUserContext user) {
         if (conditions == null) return null;
         boolean foundNull = false;
         for (Condition condition : conditions) {
-            Boolean conditionEval = condition.evaluate(config, attributes);
+            Boolean conditionEval = condition.evaluate(config, user);
             if (conditionEval == null) { // true with falses and nulls is still true
                 foundNull = true;
             } else if (conditionEval) {

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/UserAttribute.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/UserAttribute.java
@@ -19,6 +19,7 @@ package com.optimizely.ab.config.audience;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.optimizely.ab.OptimizelyUserContext;
 import com.optimizely.ab.config.ProjectConfig;
 import com.optimizely.ab.config.audience.match.*;
 import org.slf4j.Logger;
@@ -71,7 +72,8 @@ public class UserAttribute<T> implements Condition<T> {
     }
 
     @Nullable
-    public Boolean evaluate(ProjectConfig config, Map<String, ?> attributes) {
+    public Boolean evaluate(ProjectConfig config, OptimizelyUserContext user) {
+        Map<String,Object> attributes = user.getAttributes();
         if (attributes == null) {
             attributes = Collections.emptyMap();
         }

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/UserAttribute.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/UserAttribute.java
@@ -77,9 +77,6 @@ public class UserAttribute<T> implements Condition<T> {
     @Nullable
     public Boolean evaluate(ProjectConfig config, OptimizelyUserContext user) {
         Map<String,Object> attributes = user.getAttributes();
-        if (attributes == null) {
-            attributes = Collections.emptyMap();
-        }
         // Valid for primitive types, but needs to change when a value is an object or an array
         Object userAttributeValue = attributes.get(name);
 

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/UserAttribute.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/UserAttribute.java
@@ -32,7 +32,6 @@ import java.util.*;
 
 import static com.optimizely.ab.config.audience.AttributeType.CUSTOM_ATTRIBUTE;
 import static com.optimizely.ab.config.audience.AttributeType.THIRD_PARTY_DIMENSION;
-import static com.optimizely.ab.config.audience.match.MatchRegistry.QUALIFIED;
 
 /**
  * Represents a user attribute instance within an audience's conditions.
@@ -40,6 +39,7 @@ import static com.optimizely.ab.config.audience.match.MatchRegistry.QUALIFIED;
 @Immutable
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class UserAttribute<T> implements Condition<T> {
+    public static final String QUALIFIED = "qualified";
 
     private static final Logger logger = LoggerFactory.getLogger(UserAttribute.class);
     private final String name;

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/UserAttribute.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/UserAttribute.java
@@ -90,9 +90,8 @@ public class UserAttribute<T> implements Condition<T> {
             if (QUALIFIED.equals(match)) {
                 if (value instanceof String) {
                     return user.isQualifiedFor(value.toString());
-                } else {
-                    throw new UnknownValueTypeException();
                 }
+                throw new UnknownValueTypeException();
             }
             // Handle other conditions
             Match matcher = MatchRegistry.getMatch(match);

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/UserAttribute.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/UserAttribute.java
@@ -28,11 +28,11 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
-import java.util.Collections;
-import java.util.Map;
+import java.util.*;
 
 import static com.optimizely.ab.config.audience.AttributeType.CUSTOM_ATTRIBUTE;
 import static com.optimizely.ab.config.audience.AttributeType.THIRD_PARTY_DIMENSION;
+import static com.optimizely.ab.config.audience.match.MatchRegistry.QUALIFIED;
 
 /**
  * Represents a user attribute instance within an audience's conditions.
@@ -46,7 +46,7 @@ public class UserAttribute<T> implements Condition<T> {
     private final String type;
     private final String match;
     private final Object value;
-
+    private final static List ATTRIBUTE_TYPE = Arrays.asList(new String[]{CUSTOM_ATTRIBUTE.toString(), THIRD_PARTY_DIMENSION.toString()});
     @JsonCreator
     public UserAttribute(@JsonProperty("name") @Nonnull String name,
                          @JsonProperty("type") @Nonnull String type,
@@ -90,7 +90,7 @@ public class UserAttribute<T> implements Condition<T> {
         // check user attribute value is equal
         try {
             // Handle qualified segments
-            if ("qualified".equals(match)) {
+            if (QUALIFIED.equals(match)) {
                 if (value instanceof String) {
                     return user.isQualifiedFor(value.toString());
                 } else {
@@ -133,7 +133,7 @@ public class UserAttribute<T> implements Condition<T> {
     }
 
     private boolean isValidType(String type) {
-        if (type.equals(CUSTOM_ATTRIBUTE.toString()) || type.equals(THIRD_PARTY_DIMENSION.toString())) {
+        if (ATTRIBUTE_TYPE.contains(type)) {
             return true;
         }
         return false;

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/UserAttribute.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/UserAttribute.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2016-2020, Optimizely and contributors
+ *    Copyright 2016-2020, 2022, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/UserAttribute.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/UserAttribute.java
@@ -80,12 +80,21 @@ public class UserAttribute<T> implements Condition<T> {
         // Valid for primitive types, but needs to change when a value is an object or an array
         Object userAttributeValue = attributes.get(name);
 
-        if (!"custom_attribute".equals(type)) {
+        if (!"custom_attribute".equals(type) && !"third_party_dimension".equals(type)) {
             logger.warn("Audience condition \"{}\" uses an unknown condition type. You may need to upgrade to a newer release of the Optimizely SDK.", this);
             return null; // unknown type
         }
         // check user attribute value is equal
         try {
+            // Handle qualified segments
+            if ("qualified".equals(match)) {
+                if (userAttributeValue instanceof String) {
+                    return user.isQualifiedFor(userAttributeValue.toString());
+                } else {
+                    throw new UnknownValueTypeException();
+                }
+            }
+            // Handle other conditions
             Match matcher = MatchRegistry.getMatch(match);
             Boolean result = matcher.eval(value, userAttributeValue);
             if (result == null) {

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/UserAttribute.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/UserAttribute.java
@@ -31,6 +31,9 @@ import javax.annotation.concurrent.Immutable;
 import java.util.Collections;
 import java.util.Map;
 
+import static com.optimizely.ab.config.audience.AttributeType.CUSTOM_ATTRIBUTE;
+import static com.optimizely.ab.config.audience.AttributeType.THIRD_PARTY_DIMENSION;
+
 /**
  * Represents a user attribute instance within an audience's conditions.
  */
@@ -80,7 +83,7 @@ public class UserAttribute<T> implements Condition<T> {
         // Valid for primitive types, but needs to change when a value is an object or an array
         Object userAttributeValue = attributes.get(name);
 
-        if (!"custom_attribute".equals(type) && !"third_party_dimension".equals(type)) {
+        if (!isValidType(type)) {
             logger.warn("Audience condition \"{}\" uses an unknown condition type. You may need to upgrade to a newer release of the Optimizely SDK.", this);
             return null; // unknown type
         }
@@ -88,8 +91,8 @@ public class UserAttribute<T> implements Condition<T> {
         try {
             // Handle qualified segments
             if ("qualified".equals(match)) {
-                if (userAttributeValue instanceof String) {
-                    return user.isQualifiedFor(userAttributeValue.toString());
+                if (value instanceof String) {
+                    return user.isQualifiedFor(value.toString());
                 } else {
                     throw new UnknownValueTypeException();
                 }
@@ -127,6 +130,13 @@ public class UserAttribute<T> implements Condition<T> {
             logger.error("attribute or value null for match {}", match != null ? match : "legacy condition", e);
         }
         return null;
+    }
+
+    private boolean isValidType(String type) {
+        if (type.equals(CUSTOM_ATTRIBUTE.toString()) || type.equals(THIRD_PARTY_DIMENSION.toString())) {
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/match/MatchRegistry.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/match/MatchRegistry.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2020-2021, Optimizely and contributors
+ *    Copyright 2020-2022, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -41,7 +41,6 @@ public class MatchRegistry {
     public static final String SEMVER_LE = "semver_le";
     public static final String SEMVER_LT = "semver_lt";
     public static final String SUBSTRING = "substring";
-    public static final String QUALIFIED = "qualified";
 
     static {
         register(EXACT, new ExactMatch());

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/match/MatchRegistry.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/match/MatchRegistry.java
@@ -41,6 +41,7 @@ public class MatchRegistry {
     public static final String SEMVER_LE = "semver_le";
     public static final String SEMVER_LT = "semver_lt";
     public static final String SUBSTRING = "substring";
+    public static final String QUALIFIED = "qualified";
 
     static {
         register(EXACT, new ExactMatch());

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/DatafileGsonDeserializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/DatafileGsonDeserializer.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2016-2021, Optimizely and contributors
+ *    Copyright 2016-2022, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -86,6 +86,7 @@ public class DatafileGsonDeserializer implements JsonDeserializer<ProjectConfig>
 
         List<FeatureFlag> featureFlags = null;
         List<Rollout> rollouts = null;
+        List<Integration> integrations = null;
         Boolean botFiltering = null;
         String sdkKey = null;
         String environmentKey = null;
@@ -97,6 +98,10 @@ public class DatafileGsonDeserializer implements JsonDeserializer<ProjectConfig>
             Type rolloutsType = new TypeToken<List<Rollout>>() {
             }.getType();
             rollouts = context.deserialize(jsonObject.get("rollouts").getAsJsonArray(), rolloutsType);
+            if (jsonObject.has("integrations")) {
+                Type integrationsType = new TypeToken<List<Integration>>() {}.getType();
+                integrations = context.deserialize(jsonObject.get("integrations").getAsJsonArray(), integrationsType);
+            }
             if (jsonObject.has("sdkKey"))
                 sdkKey = jsonObject.get("sdkKey").getAsString();
             if (jsonObject.has("environmentKey"))
@@ -124,7 +129,8 @@ public class DatafileGsonDeserializer implements JsonDeserializer<ProjectConfig>
             experiments,
             featureFlags,
             groups,
-            rollouts
+            rollouts,
+            integrations
         );
     }
 }

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/DatafileJacksonDeserializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/DatafileJacksonDeserializer.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2016-2021, Optimizely and contributors
+ *    Copyright 2016-2022, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ class DatafileJacksonDeserializer extends JsonDeserializer<DatafileProjectConfig
         List<Experiment> experiments = JacksonHelpers.arrayNodeToList(node.get("experiments"), Experiment.class, codec);
         List<Attribute> attributes = JacksonHelpers.arrayNodeToList(node.get("attributes"), Attribute.class, codec);
         List<EventType> events = JacksonHelpers.arrayNodeToList(node.get("events"), EventType.class, codec);
+        List<Integration> integrations = JacksonHelpers.arrayNodeToList(node.get("integrations"), Integration.class, codec);
 
         List<Audience> audiences = Collections.emptyList();
         if (node.has("audiences")) {
@@ -101,7 +102,8 @@ class DatafileJacksonDeserializer extends JsonDeserializer<DatafileProjectConfig
             experiments,
             featureFlags,
             groups,
-            rollouts
+            rollouts,
+            integrations
         );
     }
 

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/DatafileJacksonDeserializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/DatafileJacksonDeserializer.java
@@ -45,7 +45,6 @@ class DatafileJacksonDeserializer extends JsonDeserializer<DatafileProjectConfig
         List<Experiment> experiments = JacksonHelpers.arrayNodeToList(node.get("experiments"), Experiment.class, codec);
         List<Attribute> attributes = JacksonHelpers.arrayNodeToList(node.get("attributes"), Attribute.class, codec);
         List<EventType> events = JacksonHelpers.arrayNodeToList(node.get("events"), EventType.class, codec);
-        List<Integration> integrations = JacksonHelpers.arrayNodeToList(node.get("integrations"), Integration.class, codec);
 
         List<Audience> audiences = Collections.emptyList();
         if (node.has("audiences")) {
@@ -64,6 +63,7 @@ class DatafileJacksonDeserializer extends JsonDeserializer<DatafileProjectConfig
 
         List<FeatureFlag> featureFlags = null;
         List<Rollout> rollouts = null;
+        List<Integration> integrations = null;
         String sdkKey = null;
         String environmentKey = null;
         Boolean botFiltering = null;
@@ -71,6 +71,9 @@ class DatafileJacksonDeserializer extends JsonDeserializer<DatafileProjectConfig
         if (datafileVersion >= Integer.parseInt(DatafileProjectConfig.Version.V4.toString())) {
             featureFlags = JacksonHelpers.arrayNodeToList(node.get("featureFlags"), FeatureFlag.class, codec);
             rollouts = JacksonHelpers.arrayNodeToList(node.get("rollouts"), Rollout.class, codec);
+            if (node.hasNonNull("integrations")) {
+                integrations = JacksonHelpers.arrayNodeToList(node.get("integrations"), Integration.class, codec);
+            }
             if (node.hasNonNull("sdkKey")) {
                 sdkKey = node.get("sdkKey").textValue();
             }

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/JsonConfigParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/JsonConfigParser.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2016-2021, Optimizely and contributors
+ *    Copyright 2016-2022, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -72,6 +72,7 @@ final public class JsonConfigParser implements ConfigParser {
 
             List<FeatureFlag> featureFlags = null;
             List<Rollout> rollouts = null;
+            List<Integration> integrations = null;
             String sdkKey = null;
             String environmentKey = null;
             Boolean botFiltering = null;
@@ -79,6 +80,9 @@ final public class JsonConfigParser implements ConfigParser {
             if (datafileVersion >= Integer.parseInt(ProjectConfig.Version.V4.toString())) {
                 featureFlags = parseFeatureFlags(rootObject.getJSONArray("featureFlags"));
                 rollouts = parseRollouts(rootObject.getJSONArray("rollouts"));
+                if (rootObject.has("integrations")) {
+                    integrations = parseIntegrations(rootObject.getJSONArray("integrations"));
+                }
                 if (rootObject.has("sdkKey"))
                     sdkKey = rootObject.getString("sdkKey");
                 if (rootObject.has("environmentKey"))
@@ -106,7 +110,8 @@ final public class JsonConfigParser implements ConfigParser {
                 experiments,
                 featureFlags,
                 groups,
-                rollouts
+                rollouts,
+                integrations
             );
         } catch (RuntimeException e) {
             throw new ConfigParseException("Unable to parse datafile: " + json, e);
@@ -397,6 +402,21 @@ final public class JsonConfigParser implements ConfigParser {
         }
 
         return rollouts;
+    }
+
+    private List<Integration> parseIntegrations(JSONArray integrationsJson) {
+        List<Integration> integrations = new ArrayList<Integration>(integrationsJson.length());
+
+        for (int i = 0; i < integrationsJson.length(); i++) {
+            Object obj = integrationsJson.get(i);
+            JSONObject integrationObject = (JSONObject) obj;
+            String key = integrationObject.getString("key");
+            String host = integrationObject.getString("host");
+            String publicKey = integrationObject.getString("publicKey");
+            integrations.add(new Integration(key, host, publicKey));
+        }
+
+        return integrations;
     }
 
     @Override

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/JsonConfigParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/JsonConfigParser.java
@@ -411,8 +411,8 @@ final public class JsonConfigParser implements ConfigParser {
             Object obj = integrationsJson.get(i);
             JSONObject integrationObject = (JSONObject) obj;
             String key = integrationObject.getString("key");
-            String host = integrationObject.getString("host");
-            String publicKey = integrationObject.getString("publicKey");
+            String host = integrationObject.has("host") ? integrationObject.getString("host") : null;
+            String publicKey = integrationObject.has("publicKey") ? integrationObject.getString("publicKey") : null;
             integrations.add(new Integration(key, host, publicKey));
         }
 

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/JsonSimpleConfigParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/JsonSimpleConfigParser.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2016-2021, Optimizely and contributors
+ *    Copyright 2016-2022, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -81,11 +81,15 @@ final public class JsonSimpleConfigParser implements ConfigParser {
 
             List<FeatureFlag> featureFlags = null;
             List<Rollout> rollouts = null;
+            List<Integration> integrations = null;
             Boolean botFiltering = null;
             boolean sendFlagDecisions = false;
             if (datafileVersion >= Integer.parseInt(DatafileProjectConfig.Version.V4.toString())) {
                 featureFlags = parseFeatureFlags((JSONArray) rootObject.get("featureFlags"));
                 rollouts = parseRollouts((JSONArray) rootObject.get("rollouts"));
+                if (rootObject.containsKey("integrations")) {
+                    integrations = parseIntegrations((JSONArray) rootObject.get("integrations"));
+                }
                 if (rootObject.containsKey("botFiltering"))
                     botFiltering = (Boolean) rootObject.get("botFiltering");
                 if (rootObject.containsKey("sendFlagDecisions"))
@@ -109,7 +113,8 @@ final public class JsonSimpleConfigParser implements ConfigParser {
                 experiments,
                 featureFlags,
                 groups,
-                rollouts
+                rollouts,
+                integrations
             );
         } catch (RuntimeException ex) {
             throw new ConfigParseException("Unable to parse datafile: " + json, ex);
@@ -377,6 +382,20 @@ final public class JsonSimpleConfigParser implements ConfigParser {
         }
 
         return rollouts;
+    }
+
+    private List<Integration> parseIntegrations(JSONArray integrationsJson) {
+        List<Integration> integrations = new ArrayList<>(integrationsJson.size());
+
+        for (Object obj : integrationsJson) {
+            JSONObject integrationObject = (JSONObject) obj;
+            String key = (String) integrationObject.get("key");
+            String host = (String) integrationObject.get("host");
+            String publicKey = (String) integrationObject.get("publicKey");
+            integrations.add(new Integration(key, host, publicKey));
+        }
+
+        return integrations;
     }
 
     @Override

--- a/core-api/src/main/java/com/optimizely/ab/internal/ExperimentUtils.java
+++ b/core-api/src/main/java/com/optimizely/ab/internal/ExperimentUtils.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2017-2021, Optimizely and contributors
+ *    Copyright 2017-2022, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/config/DatafileProjectConfigTestUtils.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/DatafileProjectConfigTestUtils.java
@@ -491,7 +491,7 @@ public final class DatafileProjectConfigTestUtils {
             assertThat(actualExperiment.getGroupId(), is(expectedExperiment.getGroupId()));
             assertThat(actualExperiment.getStatus(), is(expectedExperiment.getStatus()));
             assertThat(actualExperiment.getAudienceIds(), is(expectedExperiment.getAudienceIds()));
-            assertEquals(actualExperiment.getAudienceConditions(), expectedExperiment.getAudienceConditions());
+            assertThat(actualExperiment.getAudienceConditions(), is(expectedExperiment.getAudienceConditions()));
             assertThat(actualExperiment.getUserIdToVariationKeyMap(),
                 is(expectedExperiment.getUserIdToVariationKeyMap()));
 

--- a/core-api/src/test/java/com/optimizely/ab/config/DatafileProjectConfigTestUtils.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/DatafileProjectConfigTestUtils.java
@@ -474,6 +474,7 @@ public final class DatafileProjectConfigTestUtils {
         verifyFeatureFlags(actual.getFeatureFlags(), expected.getFeatureFlags());
         verifyGroups(actual.getGroups(), expected.getGroups());
         verifyRollouts(actual.getRollouts(), expected.getRollouts());
+        verifyIntegrations(actual.getIntegrations(), expected.getIntegrations());
     }
 
     /**
@@ -623,6 +624,23 @@ public final class DatafileProjectConfigTestUtils {
 
                 assertEquals(expectedRollout.getId(), actualRollout.getId());
                 verifyExperiments(actualRollout.getExperiments(), expectedRollout.getExperiments());
+            }
+        }
+    }
+
+    private static void verifyIntegrations(List<Integration> actual, List<Integration> expected) {
+        if (expected == null) {
+            assertNull(actual);
+        } else {
+            assertEquals(expected.size(), actual.size());
+
+            for (int i = 0; i < actual.size(); i++) {
+                Integration actualIntegrations = actual.get(i);
+                Integration expectedIntegration = expected.get(i);
+
+                assertEquals(expectedIntegration.getKey(), actualIntegrations.getKey());
+                assertEquals(expectedIntegration.getHost(), actualIntegrations.getHost());
+                assertEquals(expectedIntegration.getPublicKey(), actualIntegrations.getPublicKey());
             }
         }
     }

--- a/core-api/src/test/java/com/optimizely/ab/config/ValidProjectConfigV4.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/ValidProjectConfigV4.java
@@ -1428,7 +1428,7 @@ public class ValidProjectConfigV4 {
         rollouts.add(ROLLOUT_1);
         rollouts.add(ROLLOUT_2);
         rollouts.add(ROLLOUT_3);
-
+        List<Integration> integrations = new ArrayList<>();
         return new DatafileProjectConfig(
             ACCOUNT_ID,
             ANONYMIZE_IP,
@@ -1446,7 +1446,8 @@ public class ValidProjectConfigV4 {
             experiments,
             featureFlags,
             groups,
-            rollouts
+            rollouts,
+            integrations
         );
     }
 }

--- a/core-api/src/test/java/com/optimizely/ab/config/ValidProjectConfigV4.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/ValidProjectConfigV4.java
@@ -1447,7 +1447,7 @@ public class ValidProjectConfigV4 {
             featureFlags,
             groups,
             rollouts,
-            null
+            Collections.emptyList()
         );
     }
 }

--- a/core-api/src/test/java/com/optimizely/ab/config/ValidProjectConfigV4.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/ValidProjectConfigV4.java
@@ -1428,7 +1428,7 @@ public class ValidProjectConfigV4 {
         rollouts.add(ROLLOUT_1);
         rollouts.add(ROLLOUT_2);
         rollouts.add(ROLLOUT_3);
-        List<Integration> integrations = new ArrayList<>();
+
         return new DatafileProjectConfig(
             ACCOUNT_ID,
             ANONYMIZE_IP,
@@ -1447,7 +1447,7 @@ public class ValidProjectConfigV4 {
             featureFlags,
             groups,
             rollouts,
-            integrations
+            null
         );
     }
 }

--- a/core-api/src/test/java/com/optimizely/ab/config/ValidProjectConfigV4.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/ValidProjectConfigV4.java
@@ -1360,6 +1360,7 @@ public class ValidProjectConfigV4 {
             VARIABLE_INTEGER_VARIABLE
         )
     );
+    public static final Integration odpIntegration = new Integration("odp", "https://example.com", "test-key");
 
     public static ProjectConfig generateValidProjectConfigV4() {
 
@@ -1429,6 +1430,9 @@ public class ValidProjectConfigV4 {
         rollouts.add(ROLLOUT_2);
         rollouts.add(ROLLOUT_3);
 
+        List<Integration> integrations = new ArrayList<>();
+        integrations.add(odpIntegration);
+
         return new DatafileProjectConfig(
             ACCOUNT_ID,
             ANONYMIZE_IP,
@@ -1447,7 +1451,7 @@ public class ValidProjectConfigV4 {
             featureFlags,
             groups,
             rollouts,
-            Collections.emptyList()
+            integrations
         );
     }
 }

--- a/core-api/src/test/java/com/optimizely/ab/config/audience/AudienceConditionEvaluationTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/audience/AudienceConditionEvaluationTest.java
@@ -18,7 +18,9 @@ package com.optimizely.ab.config.audience;
 
 import ch.qos.logback.classic.Level;
 import com.fasterxml.jackson.databind.deser.std.MapEntryDeserializer;
+import com.optimizely.ab.OptimizelyUserContext;
 import com.optimizely.ab.internal.LogbackVerifier;
+import com.optimizely.ab.testutils.OTUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.Before;
 import org.junit.Rule;
@@ -129,7 +131,7 @@ public class AudienceConditionEvaluationTest {
         assertNull(testInstance.getMatch());
         assertEquals(testInstance.getName(), "browser_type");
         assertEquals(testInstance.getType(), "custom_attribute");
-        assertTrue(testInstance.evaluate(null, testUserAttributes));
+        assertTrue(testInstance.evaluate(null, OTUtils.user(testUserAttributes)));
     }
 
     /**
@@ -138,7 +140,7 @@ public class AudienceConditionEvaluationTest {
     @Test
     public void userAttributeEvaluateFalse() throws Exception {
         UserAttribute testInstance = new UserAttribute("browser_type", "custom_attribute", null, "firefox");
-        assertFalse(testInstance.evaluate(null, testUserAttributes));
+        assertFalse(testInstance.evaluate(null, OTUtils.user(testUserAttributes)));
     }
 
     /**
@@ -147,7 +149,7 @@ public class AudienceConditionEvaluationTest {
     @Test
     public void userAttributeUnknownAttribute() throws Exception {
         UserAttribute testInstance = new UserAttribute("unknown_dim", "custom_attribute", null, "unknown");
-        assertFalse(testInstance.evaluate(null, testUserAttributes));
+        assertFalse(testInstance.evaluate(null, OTUtils.user(testUserAttributes)));
     }
 
     /**
@@ -156,7 +158,7 @@ public class AudienceConditionEvaluationTest {
     @Test
     public void invalidMatchCondition() throws Exception {
         UserAttribute testInstance = new UserAttribute("browser_type", "unknown_dimension", null, "chrome");
-        assertNull(testInstance.evaluate(null, testUserAttributes));
+        assertNull(testInstance.evaluate(null, OTUtils.user(testUserAttributes)));
     }
 
     /**
@@ -165,7 +167,7 @@ public class AudienceConditionEvaluationTest {
     @Test
     public void invalidMatch() throws Exception {
         UserAttribute testInstance = new UserAttribute("browser_type", "custom_attribute", "blah", "chrome");
-        assertNull(testInstance.evaluate(null, testUserAttributes));
+        assertNull(testInstance.evaluate(null, OTUtils.user(testUserAttributes)));
         logbackVerifier.expectMessage(Level.WARN,
             "Audience condition \"{name='browser_type', type='custom_attribute', match='blah', value='chrome'}\" uses an unknown match type. You may need to upgrade to a newer release of the Optimizely SDK");
     }
@@ -176,7 +178,7 @@ public class AudienceConditionEvaluationTest {
     @Test
     public void unexpectedAttributeType() throws Exception {
         UserAttribute testInstance = new UserAttribute("browser_type", "custom_attribute", "gt", 20);
-        assertNull(testInstance.evaluate(null, testUserAttributes));
+        assertNull(testInstance.evaluate(null, OTUtils.user(testUserAttributes)));
         logbackVerifier.expectMessage(Level.WARN,
             "Audience condition \"{name='browser_type', type='custom_attribute', match='gt', value=20}\" evaluated to UNKNOWN because a value of type \"java.lang.String\" was passed for user attribute \"browser_type\"");
     }
@@ -187,7 +189,7 @@ public class AudienceConditionEvaluationTest {
     @Test
     public void unexpectedAttributeTypeNull() throws Exception {
         UserAttribute testInstance = new UserAttribute("browser_type", "custom_attribute", "gt", 20);
-        assertNull(testInstance.evaluate(null, Collections.singletonMap("browser_type", null)));
+        assertNull(testInstance.evaluate(null, OTUtils.user(Collections.singletonMap("browser_type", null))));
         logbackVerifier.expectMessage(Level.DEBUG,
             "Audience condition \"{name='browser_type', type='custom_attribute', match='gt', value=20}\" evaluated to UNKNOWN because a null value was passed for user attribute \"browser_type\"");
     }
@@ -215,7 +217,7 @@ public class AudienceConditionEvaluationTest {
         for (Map.Entry<String, Object[]> entry : items.entrySet()) {
             for (Object value : entry.getValue()) {
                 UserAttribute testInstance = new UserAttribute("n", "custom_attribute", entry.getKey(), value);
-                assertNull(testInstance.evaluate(null, Collections.EMPTY_MAP));
+                assertNull(testInstance.evaluate(null, OTUtils.user(Collections.EMPTY_MAP)));
                 String valueStr = (value instanceof String) ? ("'" + value + "'") : value.toString();
                 logbackVerifier.expectMessage(Level.DEBUG,
                     "Audience condition \"{name='n', type='custom_attribute', match='" + entry.getKey() + "', value=" + valueStr + "}\" evaluated to UNKNOWN because no value was passed for user attribute \"n\"");
@@ -229,7 +231,7 @@ public class AudienceConditionEvaluationTest {
     @Test
     public void nullAttribute() throws Exception {
         UserAttribute testInstance = new UserAttribute("browser_type", "custom_attribute", "gt", 20);
-        assertNull(testInstance.evaluate(null, null));
+        assertNull(testInstance.evaluate(null, OTUtils.user(null)));
         logbackVerifier.expectMessage(Level.DEBUG,
             "Audience condition \"{name='browser_type', type='custom_attribute', match='gt', value=20}\" evaluated to UNKNOWN because no value was passed for user attribute \"browser_type\"");
     }
@@ -240,7 +242,7 @@ public class AudienceConditionEvaluationTest {
     @Test
     public void unknownConditionType() throws Exception {
         UserAttribute testInstance = new UserAttribute("browser_type", "blah", "exists", "firefox");
-        assertNull(testInstance.evaluate(null, testUserAttributes));
+        assertNull(testInstance.evaluate(null, OTUtils.user(testUserAttributes)));
         logbackVerifier.expectMessage(Level.WARN,
             "Audience condition \"{name='browser_type', type='blah', match='exists', value='firefox'}\" uses an unknown condition type. You may need to upgrade to a newer release of the Optimizely SDK.");
     }
@@ -254,9 +256,9 @@ public class AudienceConditionEvaluationTest {
         UserAttribute testInstance = new UserAttribute("browser_type", "custom_attribute", "exists", "firefox");
         Map<String, Object> attributes = new HashMap<>();
         attributes.put("browser_type", "");
-        assertTrue(testInstance.evaluate(null, attributes));
+        assertTrue(testInstance.evaluate(null, OTUtils.user(attributes)));
         attributes.put("browser_type", null);
-        assertFalse(testInstance.evaluate(null, attributes));
+        assertFalse(testInstance.evaluate(null, OTUtils.user(attributes)));
     }
 
     /**
@@ -266,16 +268,16 @@ public class AudienceConditionEvaluationTest {
     @Test
     public void existsMatchConditionEvaluatesTrue() throws Exception {
         UserAttribute testInstance = new UserAttribute("browser_type", "custom_attribute", "exists", "firefox");
-        assertTrue(testInstance.evaluate(null, testUserAttributes));
+        assertTrue(testInstance.evaluate(null, OTUtils.user(testUserAttributes)));
 
         UserAttribute testInstanceBoolean = new UserAttribute("is_firefox", "custom_attribute", "exists", false);
         UserAttribute testInstanceInteger = new UserAttribute("num_size", "custom_attribute", "exists", 5);
         UserAttribute testInstanceDouble = new UserAttribute("num_counts", "custom_attribute", "exists", 4.55);
         UserAttribute testInstanceObject = new UserAttribute("meta_data", "custom_attribute", "exists", testUserAttributes);
-        assertTrue(testInstanceBoolean.evaluate(null, testTypedUserAttributes));
-        assertTrue(testInstanceInteger.evaluate(null, testTypedUserAttributes));
-        assertTrue(testInstanceDouble.evaluate(null, testTypedUserAttributes));
-        assertTrue(testInstanceObject.evaluate(null, testTypedUserAttributes));
+        assertTrue(testInstanceBoolean.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertTrue(testInstanceInteger.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertTrue(testInstanceDouble.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertTrue(testInstanceObject.evaluate(null, OTUtils.user(testTypedUserAttributes)));
     }
 
     /**
@@ -286,8 +288,8 @@ public class AudienceConditionEvaluationTest {
     public void existsMatchConditionEvaluatesFalse() throws Exception {
         UserAttribute testInstance = new UserAttribute("bad_var", "custom_attribute", "exists", "chrome");
         UserAttribute testInstanceNull = new UserAttribute("null_val", "custom_attribute", "exists", "chrome");
-        assertFalse(testInstance.evaluate(null, testTypedUserAttributes));
-        assertFalse(testInstanceNull.evaluate(null, testTypedUserAttributes));
+        assertFalse(testInstance.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertFalse(testInstanceNull.evaluate(null, OTUtils.user(testTypedUserAttributes)));
     }
 
     /**
@@ -302,11 +304,11 @@ public class AudienceConditionEvaluationTest {
         UserAttribute testInstanceFloat = new UserAttribute("num_size", "custom_attribute", "exact", (float) 3);
         UserAttribute testInstanceDouble = new UserAttribute("num_counts", "custom_attribute", "exact", 3.55);
 
-        assertTrue(testInstanceString.evaluate(null, testUserAttributes));
-        assertTrue(testInstanceBoolean.evaluate(null, testTypedUserAttributes));
-        assertTrue(testInstanceInteger.evaluate(null, testTypedUserAttributes));
-        assertTrue(testInstanceFloat.evaluate(null, Collections.singletonMap("num_size", (float) 3)));
-        assertTrue(testInstanceDouble.evaluate(null, testTypedUserAttributes));
+        assertTrue(testInstanceString.evaluate(null, OTUtils.user(testUserAttributes)));
+        assertTrue(testInstanceBoolean.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertTrue(testInstanceInteger.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertTrue(testInstanceFloat.evaluate(null, OTUtils.user(Collections.singletonMap("num_size", (float) 3))));
+        assertTrue(testInstanceDouble.evaluate(null, OTUtils.user(testTypedUserAttributes)));
     }
 
     /**
@@ -339,22 +341,22 @@ public class AudienceConditionEvaluationTest {
 
         assertNull(testInstanceInteger.evaluate(
             null,
-            Collections.singletonMap("num_size", bigInteger)));
+            OTUtils.user(Collections.singletonMap("num_size", bigInteger))));
         assertNull(testInstanceFloat.evaluate(
             null,
-            Collections.singletonMap("num_size", invalidFloatValue)));
+            OTUtils.user(Collections.singletonMap("num_size", invalidFloatValue))));
         assertNull(testInstanceDouble.evaluate(
             null,
-            Collections.singletonMap("num_counts", infinitePositiveInfiniteDouble)));
+            OTUtils.user(Collections.singletonMap("num_counts", infinitePositiveInfiniteDouble))));
         assertNull(testInstanceDouble.evaluate(
             null,
-            Collections.singletonMap("num_counts", infiniteNegativeInfiniteDouble)));
+            OTUtils.user(Collections.singletonMap("num_counts", infiniteNegativeInfiniteDouble))));
         assertNull(testInstanceDouble.evaluate(
-            null, Collections.singletonMap("num_counts",
-                Collections.singletonMap("num_counts", infiniteNANDouble))));
+            null, OTUtils.user(Collections.singletonMap("num_counts",
+                Collections.singletonMap("num_counts", infiniteNANDouble)))));
         assertNull(testInstanceDouble.evaluate(
-            null, Collections.singletonMap("num_counts",
-                Collections.singletonMap("num_counts", largeDouble))));
+            null, OTUtils.user(Collections.singletonMap("num_counts",
+                Collections.singletonMap("num_counts", largeDouble)))));
     }
 
     /**
@@ -372,10 +374,10 @@ public class AudienceConditionEvaluationTest {
         UserAttribute testInstanceNegativeInfiniteDouble = new UserAttribute("num_counts", "custom_attribute", "exact", infiniteNegativeInfiniteDouble);
         UserAttribute testInstanceNANDouble = new UserAttribute("num_counts", "custom_attribute", "exact", infiniteNANDouble);
 
-        assertNull(testInstanceInteger.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstancePositiveInfinite.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceNegativeInfiniteDouble.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceNANDouble.evaluate(null, testTypedUserAttributes));
+        assertNull(testInstanceInteger.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstancePositiveInfinite.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceNegativeInfiniteDouble.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceNANDouble.evaluate(null, OTUtils.user(testTypedUserAttributes)));
     }
 
     /**
@@ -389,10 +391,10 @@ public class AudienceConditionEvaluationTest {
         UserAttribute testInstanceInteger = new UserAttribute("num_size", "custom_attribute", "exact", 5);
         UserAttribute testInstanceDouble = new UserAttribute("num_counts", "custom_attribute", "exact", 5.55);
 
-        assertFalse(testInstanceString.evaluate(null, testUserAttributes));
-        assertFalse(testInstanceBoolean.evaluate(null, testTypedUserAttributes));
-        assertFalse(testInstanceInteger.evaluate(null, testTypedUserAttributes));
-        assertFalse(testInstanceDouble.evaluate(null, testTypedUserAttributes));
+        assertFalse(testInstanceString.evaluate(null, OTUtils.user(testUserAttributes)));
+        assertFalse(testInstanceBoolean.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertFalse(testInstanceInteger.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertFalse(testInstanceDouble.evaluate(null, OTUtils.user(testTypedUserAttributes)));
     }
 
     /**
@@ -408,15 +410,15 @@ public class AudienceConditionEvaluationTest {
         UserAttribute testInstanceDouble = new UserAttribute("num_counts", "custom_attribute", "exact", "3.55");
         UserAttribute testInstanceNull = new UserAttribute("null_val", "custom_attribute", "exact", "null_val");
 
-        assertNull(testInstanceObject.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceString.evaluate(null, testUserAttributes));
-        assertNull(testInstanceBoolean.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceInteger.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceDouble.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceNull.evaluate(null, testTypedUserAttributes));
+        assertNull(testInstanceObject.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceString.evaluate(null, OTUtils.user(testUserAttributes)));
+        assertNull(testInstanceBoolean.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceInteger.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceDouble.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceNull.evaluate(null, OTUtils.user(testTypedUserAttributes)));
         Map<String, Object> attr = new HashMap<>();
         attr.put("browser_type", "true");
-        assertNull(testInstanceString.evaluate(null, attr));
+        assertNull(testInstanceString.evaluate(null, OTUtils.user(attr)));
     }
 
     /**
@@ -430,13 +432,13 @@ public class AudienceConditionEvaluationTest {
         UserAttribute testInstanceFloat = new UserAttribute("num_size", "custom_attribute", "gt", (float) 2);
         UserAttribute testInstanceDouble = new UserAttribute("num_counts", "custom_attribute", "gt", 2.55);
 
-        assertTrue(testInstanceInteger.evaluate(null, testTypedUserAttributes));
-        assertTrue(testInstanceFloat.evaluate(null, Collections.singletonMap("num_size", (float) 3)));
-        assertTrue(testInstanceDouble.evaluate(null, testTypedUserAttributes));
+        assertTrue(testInstanceInteger.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertTrue(testInstanceFloat.evaluate(null, OTUtils.user(Collections.singletonMap("num_size", (float) 3))));
+        assertTrue(testInstanceDouble.evaluate(null, OTUtils.user(testTypedUserAttributes)));
 
         Map<String, Object> badAttributes = new HashMap<>();
         badAttributes.put("num_size", "bobs burgers");
-        assertNull(testInstanceInteger.evaluate(null, badAttributes));
+        assertNull(testInstanceInteger.evaluate(null, OTUtils.user(badAttributes)));
     }
 
     /**
@@ -470,22 +472,22 @@ public class AudienceConditionEvaluationTest {
 
         assertNull(testInstanceInteger.evaluate(
             null,
-            Collections.singletonMap("num_size", bigInteger)));
+            OTUtils.user(Collections.singletonMap("num_size", bigInteger))));
         assertNull(testInstanceFloat.evaluate(
             null,
-            Collections.singletonMap("num_size", invalidFloatValue)));
+            OTUtils.user(Collections.singletonMap("num_size", invalidFloatValue))));
         assertNull(testInstanceDouble.evaluate(
             null,
-            Collections.singletonMap("num_counts", infinitePositiveInfiniteDouble)));
+            OTUtils.user(Collections.singletonMap("num_counts", infinitePositiveInfiniteDouble))));
         assertNull(testInstanceDouble.evaluate(
             null,
-            Collections.singletonMap("num_counts", infiniteNegativeInfiniteDouble)));
+            OTUtils.user(Collections.singletonMap("num_counts", infiniteNegativeInfiniteDouble))));
         assertNull(testInstanceDouble.evaluate(
-            null, Collections.singletonMap("num_counts",
-                Collections.singletonMap("num_counts", infiniteNANDouble))));
+            null, OTUtils.user(Collections.singletonMap("num_counts",
+                Collections.singletonMap("num_counts", infiniteNANDouble)))));
         assertNull(testInstanceDouble.evaluate(
-            null, Collections.singletonMap("num_counts",
-                Collections.singletonMap("num_counts", largeDouble))));
+            null, OTUtils.user(Collections.singletonMap("num_counts",
+                Collections.singletonMap("num_counts", largeDouble)))));
     }
 
     /**
@@ -503,10 +505,10 @@ public class AudienceConditionEvaluationTest {
         UserAttribute testInstanceNegativeInfiniteDouble = new UserAttribute("num_counts", "custom_attribute", "gt", infiniteNegativeInfiniteDouble);
         UserAttribute testInstanceNANDouble = new UserAttribute("num_counts", "custom_attribute", "gt", infiniteNANDouble);
 
-        assertNull(testInstanceInteger.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstancePositiveInfinite.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceNegativeInfiniteDouble.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceNANDouble.evaluate(null, testTypedUserAttributes));
+        assertNull(testInstanceInteger.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstancePositiveInfinite.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceNegativeInfiniteDouble.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceNANDouble.evaluate(null, OTUtils.user(testTypedUserAttributes)));
     }
 
     /**
@@ -519,8 +521,8 @@ public class AudienceConditionEvaluationTest {
         UserAttribute testInstanceInteger = new UserAttribute("num_size", "custom_attribute", "gt", 5);
         UserAttribute testInstanceDouble = new UserAttribute("num_counts", "custom_attribute", "gt", 5.55);
 
-        assertFalse(testInstanceInteger.evaluate(null, testTypedUserAttributes));
-        assertFalse(testInstanceDouble.evaluate(null, testTypedUserAttributes));
+        assertFalse(testInstanceInteger.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertFalse(testInstanceDouble.evaluate(null, OTUtils.user(testTypedUserAttributes)));
     }
 
     /**
@@ -534,10 +536,10 @@ public class AudienceConditionEvaluationTest {
         UserAttribute testInstanceObject = new UserAttribute("meta_data", "custom_attribute", "gt", 3.5);
         UserAttribute testInstanceNull = new UserAttribute("null_val", "custom_attribute", "gt", 3.5);
 
-        assertNull(testInstanceString.evaluate(null, testUserAttributes));
-        assertNull(testInstanceBoolean.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceObject.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceNull.evaluate(null, testTypedUserAttributes));
+        assertNull(testInstanceString.evaluate(null, OTUtils.user(testUserAttributes)));
+        assertNull(testInstanceBoolean.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceObject.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceNull.evaluate(null, OTUtils.user(testTypedUserAttributes)));
     }
 
 
@@ -552,13 +554,13 @@ public class AudienceConditionEvaluationTest {
         UserAttribute testInstanceFloat = new UserAttribute("num_size", "custom_attribute", "ge", (float) 2);
         UserAttribute testInstanceDouble = new UserAttribute("num_counts", "custom_attribute", "ge", 2.55);
 
-        assertTrue(testInstanceInteger.evaluate(null, testTypedUserAttributes));
-        assertTrue(testInstanceFloat.evaluate(null, Collections.singletonMap("num_size", (float) 2)));
-        assertTrue(testInstanceDouble.evaluate(null, testTypedUserAttributes));
+        assertTrue(testInstanceInteger.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertTrue(testInstanceFloat.evaluate(null, OTUtils.user(Collections.singletonMap("num_size", (float) 2))));
+        assertTrue(testInstanceDouble.evaluate(null, OTUtils.user(testTypedUserAttributes)));
 
         Map<String, Object> badAttributes = new HashMap<>();
         badAttributes.put("num_size", "bobs burgers");
-        assertNull(testInstanceInteger.evaluate(null, badAttributes));
+        assertNull(testInstanceInteger.evaluate(null, OTUtils.user(badAttributes)));
     }
 
     /**
@@ -592,22 +594,22 @@ public class AudienceConditionEvaluationTest {
 
         assertNull(testInstanceInteger.evaluate(
             null,
-            Collections.singletonMap("num_size", bigInteger)));
+            OTUtils.user(Collections.singletonMap("num_size", bigInteger))));
         assertNull(testInstanceFloat.evaluate(
             null,
-            Collections.singletonMap("num_size", invalidFloatValue)));
+            OTUtils.user(Collections.singletonMap("num_size", invalidFloatValue))));
         assertNull(testInstanceDouble.evaluate(
             null,
-            Collections.singletonMap("num_counts", infinitePositiveInfiniteDouble)));
+            OTUtils.user(Collections.singletonMap("num_counts", infinitePositiveInfiniteDouble))));
         assertNull(testInstanceDouble.evaluate(
             null,
-            Collections.singletonMap("num_counts", infiniteNegativeInfiniteDouble)));
+            OTUtils.user(Collections.singletonMap("num_counts", infiniteNegativeInfiniteDouble))));
         assertNull(testInstanceDouble.evaluate(
-            null, Collections.singletonMap("num_counts",
-                Collections.singletonMap("num_counts", infiniteNANDouble))));
+            null, OTUtils.user(Collections.singletonMap("num_counts",
+                Collections.singletonMap("num_counts", infiniteNANDouble)))));
         assertNull(testInstanceDouble.evaluate(
-            null, Collections.singletonMap("num_counts",
-                Collections.singletonMap("num_counts", largeDouble))));
+            null, OTUtils.user(Collections.singletonMap("num_counts",
+                Collections.singletonMap("num_counts", largeDouble)))));
     }
 
     /**
@@ -625,10 +627,10 @@ public class AudienceConditionEvaluationTest {
         UserAttribute testInstanceNegativeInfiniteDouble = new UserAttribute("num_counts", "custom_attribute", "ge", infiniteNegativeInfiniteDouble);
         UserAttribute testInstanceNANDouble = new UserAttribute("num_counts", "custom_attribute", "ge", infiniteNANDouble);
 
-        assertNull(testInstanceInteger.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstancePositiveInfinite.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceNegativeInfiniteDouble.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceNANDouble.evaluate(null, testTypedUserAttributes));
+        assertNull(testInstanceInteger.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstancePositiveInfinite.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceNegativeInfiniteDouble.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceNANDouble.evaluate(null, OTUtils.user(testTypedUserAttributes)));
     }
 
     /**
@@ -641,8 +643,8 @@ public class AudienceConditionEvaluationTest {
         UserAttribute testInstanceInteger = new UserAttribute("num_size", "custom_attribute", "ge", 5);
         UserAttribute testInstanceDouble = new UserAttribute("num_counts", "custom_attribute", "ge", 5.55);
 
-        assertFalse(testInstanceInteger.evaluate(null, testTypedUserAttributes));
-        assertFalse(testInstanceDouble.evaluate(null, testTypedUserAttributes));
+        assertFalse(testInstanceInteger.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertFalse(testInstanceDouble.evaluate(null, OTUtils.user(testTypedUserAttributes)));
     }
 
     /**
@@ -656,10 +658,10 @@ public class AudienceConditionEvaluationTest {
         UserAttribute testInstanceObject = new UserAttribute("meta_data", "custom_attribute", "ge", 3.5);
         UserAttribute testInstanceNull = new UserAttribute("null_val", "custom_attribute", "ge", 3.5);
 
-        assertNull(testInstanceString.evaluate(null, testUserAttributes));
-        assertNull(testInstanceBoolean.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceObject.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceNull.evaluate(null, testTypedUserAttributes));
+        assertNull(testInstanceString.evaluate(null, OTUtils.user(testUserAttributes)));
+        assertNull(testInstanceBoolean.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceObject.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceNull.evaluate(null, OTUtils.user(testTypedUserAttributes)));
     }
 
 
@@ -673,8 +675,8 @@ public class AudienceConditionEvaluationTest {
         UserAttribute testInstanceInteger = new UserAttribute("num_size", "custom_attribute", "lt", 5);
         UserAttribute testInstanceDouble = new UserAttribute("num_counts", "custom_attribute", "lt", 5.55);
 
-        assertTrue(testInstanceInteger.evaluate(null, testTypedUserAttributes));
-        assertTrue(testInstanceDouble.evaluate(null, testTypedUserAttributes));
+        assertTrue(testInstanceInteger.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertTrue(testInstanceDouble.evaluate(null, OTUtils.user(testTypedUserAttributes)));
     }
 
     /**
@@ -687,8 +689,8 @@ public class AudienceConditionEvaluationTest {
         UserAttribute testInstanceInteger = new UserAttribute("num_size", "custom_attribute", "lt", 2);
         UserAttribute testInstanceDouble = new UserAttribute("num_counts", "custom_attribute", "lt", 2.55);
 
-        assertFalse(testInstanceInteger.evaluate(null, testTypedUserAttributes));
-        assertFalse(testInstanceDouble.evaluate(null, testTypedUserAttributes));
+        assertFalse(testInstanceInteger.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertFalse(testInstanceDouble.evaluate(null, OTUtils.user(testTypedUserAttributes)));
     }
 
     /**
@@ -702,10 +704,10 @@ public class AudienceConditionEvaluationTest {
         UserAttribute testInstanceObject = new UserAttribute("meta_data", "custom_attribute", "lt", 3.5);
         UserAttribute testInstanceNull = new UserAttribute("null_val", "custom_attribute", "lt", 3.5);
 
-        assertNull(testInstanceString.evaluate(null, testUserAttributes));
-        assertNull(testInstanceBoolean.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceObject.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceNull.evaluate(null, testTypedUserAttributes));
+        assertNull(testInstanceString.evaluate(null, OTUtils.user(testUserAttributes)));
+        assertNull(testInstanceBoolean.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceObject.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceNull.evaluate(null, OTUtils.user(testTypedUserAttributes)));
     }
 
     /**
@@ -739,22 +741,22 @@ public class AudienceConditionEvaluationTest {
 
         assertNull(testInstanceInteger.evaluate(
             null,
-            Collections.singletonMap("num_size", bigInteger)));
+            OTUtils.user(Collections.singletonMap("num_size", bigInteger))));
         assertNull(testInstanceFloat.evaluate(
             null,
-            Collections.singletonMap("num_size", invalidFloatValue)));
+            OTUtils.user(Collections.singletonMap("num_size", invalidFloatValue))));
         assertNull(testInstanceDouble.evaluate(
             null,
-            Collections.singletonMap("num_counts", infinitePositiveInfiniteDouble)));
+            OTUtils.user(Collections.singletonMap("num_counts", infinitePositiveInfiniteDouble))));
         assertNull(testInstanceDouble.evaluate(
             null,
-            Collections.singletonMap("num_counts", infiniteNegativeInfiniteDouble)));
+            OTUtils.user(Collections.singletonMap("num_counts", infiniteNegativeInfiniteDouble))));
         assertNull(testInstanceDouble.evaluate(
-            null, Collections.singletonMap("num_counts",
-                Collections.singletonMap("num_counts", infiniteNANDouble))));
+            null, OTUtils.user(Collections.singletonMap("num_counts",
+                Collections.singletonMap("num_counts", infiniteNANDouble)))));
         assertNull(testInstanceDouble.evaluate(
-            null, Collections.singletonMap("num_counts",
-                Collections.singletonMap("num_counts", largeDouble))));
+            null, OTUtils.user(Collections.singletonMap("num_counts",
+                Collections.singletonMap("num_counts", largeDouble)))));
     }
 
     /**
@@ -772,10 +774,10 @@ public class AudienceConditionEvaluationTest {
         UserAttribute testInstanceNegativeInfiniteDouble = new UserAttribute("num_counts", "custom_attribute", "lt", infiniteNegativeInfiniteDouble);
         UserAttribute testInstanceNANDouble = new UserAttribute("num_counts", "custom_attribute", "lt", infiniteNANDouble);
 
-        assertNull(testInstanceInteger.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstancePositiveInfinite.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceNegativeInfiniteDouble.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceNANDouble.evaluate(null, testTypedUserAttributes));
+        assertNull(testInstanceInteger.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstancePositiveInfinite.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceNegativeInfiniteDouble.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceNANDouble.evaluate(null, OTUtils.user(testTypedUserAttributes)));
     }
 
 
@@ -789,8 +791,8 @@ public class AudienceConditionEvaluationTest {
         UserAttribute testInstanceInteger = new UserAttribute("num_size", "custom_attribute", "le", 5);
         UserAttribute testInstanceDouble = new UserAttribute("num_counts", "custom_attribute", "le", 5.55);
 
-        assertTrue(testInstanceInteger.evaluate(null, testTypedUserAttributes));
-        assertTrue(testInstanceDouble.evaluate(null, Collections.singletonMap("num_counts", 5.55)));
+        assertTrue(testInstanceInteger.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertTrue(testInstanceDouble.evaluate(null, OTUtils.user(Collections.singletonMap("num_counts", 5.55))));
     }
 
     /**
@@ -803,8 +805,8 @@ public class AudienceConditionEvaluationTest {
         UserAttribute testInstanceInteger = new UserAttribute("num_size", "custom_attribute", "le", 2);
         UserAttribute testInstanceDouble = new UserAttribute("num_counts", "custom_attribute", "le", 2.55);
 
-        assertFalse(testInstanceInteger.evaluate(null, testTypedUserAttributes));
-        assertFalse(testInstanceDouble.evaluate(null, testTypedUserAttributes));
+        assertFalse(testInstanceInteger.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertFalse(testInstanceDouble.evaluate(null, OTUtils.user(testTypedUserAttributes)));
     }
 
     /**
@@ -818,10 +820,10 @@ public class AudienceConditionEvaluationTest {
         UserAttribute testInstanceObject = new UserAttribute("meta_data", "custom_attribute", "le", 3.5);
         UserAttribute testInstanceNull = new UserAttribute("null_val", "custom_attribute", "le", 3.5);
 
-        assertNull(testInstanceString.evaluate(null, testUserAttributes));
-        assertNull(testInstanceBoolean.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceObject.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceNull.evaluate(null, testTypedUserAttributes));
+        assertNull(testInstanceString.evaluate(null, OTUtils.user(testUserAttributes)));
+        assertNull(testInstanceBoolean.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceObject.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceNull.evaluate(null, OTUtils.user(testTypedUserAttributes)));
     }
 
     /**
@@ -855,22 +857,22 @@ public class AudienceConditionEvaluationTest {
 
         assertNull(testInstanceInteger.evaluate(
             null,
-            Collections.singletonMap("num_size", bigInteger)));
+            OTUtils.user(Collections.singletonMap("num_size", bigInteger))));
         assertNull(testInstanceFloat.evaluate(
             null,
-            Collections.singletonMap("num_size", invalidFloatValue)));
+            OTUtils.user(Collections.singletonMap("num_size", invalidFloatValue))));
         assertNull(testInstanceDouble.evaluate(
             null,
-            Collections.singletonMap("num_counts", infinitePositiveInfiniteDouble)));
+            OTUtils.user(Collections.singletonMap("num_counts", infinitePositiveInfiniteDouble))));
         assertNull(testInstanceDouble.evaluate(
             null,
-            Collections.singletonMap("num_counts", infiniteNegativeInfiniteDouble)));
+            OTUtils.user(Collections.singletonMap("num_counts", infiniteNegativeInfiniteDouble))));
         assertNull(testInstanceDouble.evaluate(
-            null, Collections.singletonMap("num_counts",
-                Collections.singletonMap("num_counts", infiniteNANDouble))));
+            null, OTUtils.user(Collections.singletonMap("num_counts",
+                Collections.singletonMap("num_counts", infiniteNANDouble)))));
         assertNull(testInstanceDouble.evaluate(
-            null, Collections.singletonMap("num_counts",
-                Collections.singletonMap("num_counts", largeDouble))));
+            null, OTUtils.user(Collections.singletonMap("num_counts",
+                Collections.singletonMap("num_counts", largeDouble)))));
     }
 
     /**
@@ -888,10 +890,10 @@ public class AudienceConditionEvaluationTest {
         UserAttribute testInstanceNegativeInfiniteDouble = new UserAttribute("num_counts", "custom_attribute", "le", infiniteNegativeInfiniteDouble);
         UserAttribute testInstanceNANDouble = new UserAttribute("num_counts", "custom_attribute", "le", infiniteNANDouble);
 
-        assertNull(testInstanceInteger.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstancePositiveInfinite.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceNegativeInfiniteDouble.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceNANDouble.evaluate(null, testTypedUserAttributes));
+        assertNull(testInstanceInteger.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstancePositiveInfinite.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceNegativeInfiniteDouble.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceNANDouble.evaluate(null, OTUtils.user(testTypedUserAttributes)));
     }
 
     /**
@@ -901,7 +903,7 @@ public class AudienceConditionEvaluationTest {
     @Test
     public void substringMatchConditionEvaluatesTrue()  {
         UserAttribute testInstanceString = new UserAttribute("browser_type", "custom_attribute", "substring", "chrome");
-        assertTrue(testInstanceString.evaluate(null, testUserAttributes));
+        assertTrue(testInstanceString.evaluate(null, OTUtils.user(testUserAttributes)));
     }
 
     /**
@@ -911,7 +913,7 @@ public class AudienceConditionEvaluationTest {
     @Test
     public void substringMatchConditionPartialMatchEvaluatesTrue()  {
         UserAttribute testInstanceString = new UserAttribute("browser_type", "custom_attribute", "substring", "chro");
-        assertTrue(testInstanceString.evaluate(null, testUserAttributes));
+        assertTrue(testInstanceString.evaluate(null, OTUtils.user(testUserAttributes)));
     }
 
     /**
@@ -921,7 +923,7 @@ public class AudienceConditionEvaluationTest {
     @Test
     public void substringMatchConditionEvaluatesFalse()  {
         UserAttribute testInstanceString = new UserAttribute("browser_type", "custom_attribute", "substring", "chr0me");
-        assertFalse(testInstanceString.evaluate(null, testUserAttributes));
+        assertFalse(testInstanceString.evaluate(null, OTUtils.user(testUserAttributes)));
     }
 
     /**
@@ -936,11 +938,11 @@ public class AudienceConditionEvaluationTest {
         UserAttribute testInstanceObject = new UserAttribute("meta_data", "custom_attribute", "substring", "chrome1");
         UserAttribute testInstanceNull = new UserAttribute("null_val", "custom_attribute", "substring", "chrome1");
 
-        assertNull(testInstanceBoolean.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceInteger.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceDouble.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceObject.evaluate(null, testTypedUserAttributes));
-        assertNull(testInstanceNull.evaluate(null, testTypedUserAttributes));
+        assertNull(testInstanceBoolean.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceInteger.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceDouble.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceObject.evaluate(null, OTUtils.user(testTypedUserAttributes)));
+        assertNull(testInstanceNull.evaluate(null, OTUtils.user(testTypedUserAttributes)));
     }
 
     //======== Semantic version evaluation tests ========//
@@ -951,7 +953,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", 2.0);
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_eq", "2.0.0");
-        assertNull(testInstanceString.evaluate(null, testAttributes));
+        assertNull(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     @Test
@@ -959,7 +961,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "a.1.2");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_eq", "2.0.0");
-        assertNull(testInstanceString.evaluate(null, testAttributes));
+        assertNull(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     @Test
@@ -967,7 +969,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "1.b.2");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_eq", "2.0.0");
-        assertNull(testInstanceString.evaluate(null, testAttributes));
+        assertNull(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     @Test
@@ -975,7 +977,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "1.2.c");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_eq", "2.0.0");
-        assertNull(testInstanceString.evaluate(null, testAttributes));
+        assertNull(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test SemanticVersionEqualsMatch returns null if given invalid UserCondition Variable type
@@ -984,7 +986,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "2.0");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_eq", 2.0);
-        assertNull(testInstanceString.evaluate(null, testAttributes));
+        assertNull(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test SemanticVersionGTMatch returns null if given invalid value type
@@ -993,7 +995,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", false);
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_gt", "2.0.0");
-        assertNull(testInstanceString.evaluate(null, testAttributes));
+        assertNull(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test SemanticVersionGEMatch returns null if given invalid value type
@@ -1002,7 +1004,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", 2);
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_ge", "2.0.0");
-        assertNull(testInstanceString.evaluate(null, testAttributes));
+        assertNull(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test SemanticVersionLTMatch returns null if given invalid value type
@@ -1011,7 +1013,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", 2);
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_lt", "2.0.0");
-        assertNull(testInstanceString.evaluate(null, testAttributes));
+        assertNull(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test SemanticVersionLEMatch returns null if given invalid value type
@@ -1020,7 +1022,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", 2);
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_le", "2.0.0");
-        assertNull(testInstanceString.evaluate(null, testAttributes));
+        assertNull(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test if not same when targetVersion is only major.minor.patch and version is major.minor
@@ -1029,7 +1031,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "1.2");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_eq", "1.2.0");
-        assertFalse(testInstanceString.evaluate(null, testAttributes));
+        assertFalse(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test if same when target is only major but user condition checks only major.minor,patch
@@ -1038,7 +1040,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "3.0.0");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_eq", "3");
-        assertTrue(testInstanceString.evaluate(null, testAttributes));
+        assertTrue(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test if greater when User value patch is greater even when its beta
@@ -1047,7 +1049,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "3.1.1-beta");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_gt", "3.1.0");
-        assertTrue(testInstanceString.evaluate(null, testAttributes));
+        assertTrue(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test if greater when preRelease is greater alphabetically
@@ -1056,7 +1058,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "3.1.1-beta.y.1+1.1");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_gt", "3.1.1-beta.x.1+1.1");
-        assertTrue(testInstanceString.evaluate(null, testAttributes));
+        assertTrue(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test if greater when preRelease version number is greater
@@ -1065,7 +1067,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "3.1.1-beta.x.2+1.1");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_gt", "3.1.1-beta.x.1+1.1");
-        assertTrue(testInstanceString.evaluate(null, testAttributes));
+        assertTrue(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test if equals semantic version even when only same preRelease is passed in user attribute and no build meta
@@ -1074,7 +1076,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "3.1.1-beta.x.1");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_eq", "3.1.1-beta.x.1");
-        assertTrue(testInstanceString.evaluate(null, testAttributes));
+        assertTrue(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test if not same
@@ -1083,7 +1085,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "2.1.2");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_eq", "2.1.1");
-        assertFalse(testInstanceString.evaluate(null, testAttributes));
+        assertFalse(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test when target is full semantic version major.minor.patch
@@ -1092,7 +1094,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "3.0.1");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_eq", "3.0.1");
-        assertTrue(testInstanceString.evaluate(null, testAttributes));
+        assertTrue(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test compare less when user condition checks only major.minor
@@ -1101,7 +1103,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "2.1.6");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_lt", "2.2");
-        assertTrue(testInstanceString.evaluate(null, testAttributes));
+        assertTrue(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // When user condition checks major.minor but target is major.minor.patch then its equals
@@ -1110,7 +1112,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "2.1.0");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_lt", "2.1");
-        assertFalse(testInstanceString.evaluate(null, testAttributes));
+        assertFalse(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test compare less when target is full major.minor.patch
@@ -1119,7 +1121,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "2.1.6");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_lt", "2.1.9");
-        assertTrue(testInstanceString.evaluate(null, testAttributes));
+        assertTrue(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test compare greater when user condition checks only major.minor
@@ -1128,7 +1130,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "2.3.6");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_gt", "2.2");
-        assertTrue(testInstanceString.evaluate(null, testAttributes));
+        assertTrue(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test compare greater when both are major.minor.patch-beta but target is greater than user condition
@@ -1137,7 +1139,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "2.3.6-beta");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_gt", "2.3.5-beta");
-        assertTrue(testInstanceString.evaluate(null, testAttributes));
+        assertTrue(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test compare greater when target is major.minor.patch
@@ -1146,7 +1148,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "2.1.7");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_gt", "2.1.6");
-        assertTrue(testInstanceString.evaluate(null, testAttributes));
+        assertTrue(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test compare greater when target is major.minor.patch is smaller then it returns false
@@ -1155,7 +1157,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "2.1.9");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_gt", "2.1.10");
-        assertFalse(testInstanceString.evaluate(null, testAttributes));
+        assertFalse(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test compare equal when both are exactly same - major.minor.patch-beta
@@ -1164,7 +1166,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "2.1.9-beta");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_eq", "2.1.9-beta");
-        assertTrue(testInstanceString.evaluate(null, testAttributes));
+        assertTrue(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test compare equal when both major.minor.patch is same, but due to beta user condition is smaller
@@ -1173,7 +1175,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "2.1.9");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_gt", "2.1.9-beta");
-        assertTrue(testInstanceString.evaluate(null, testAttributes));
+        assertTrue(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test compare greater when target is major.minor.patch-beta and user condition only compares major.minor.patch
@@ -1182,7 +1184,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "2.1.9");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_gt", "2.1.9-beta");
-        assertTrue(testInstanceString.evaluate(null, testAttributes));
+        assertTrue(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test compare equal when target is major.minor.patch
@@ -1191,7 +1193,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "2.1.9");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_le", "2.1.9");
-        assertTrue(testInstanceString.evaluate(null, testAttributes));
+        assertTrue(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test compare less when target is major.minor.patch
@@ -1200,7 +1202,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "2.132.9");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_le", "2.233.91");
-        assertTrue(testInstanceString.evaluate(null, testAttributes));
+        assertTrue(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test compare less when target is major.minor.patch
@@ -1209,7 +1211,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "2.233.91");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_le", "2.132.009");
-        assertFalse(testInstanceString.evaluate(null, testAttributes));
+        assertFalse(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test compare equal when target is major.minor.patch
@@ -1218,7 +1220,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "2.1.9");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_ge", "2.1.9");
-        assertTrue(testInstanceString.evaluate(null, testAttributes));
+        assertTrue(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test compare less when target is major.minor.patch
@@ -1227,7 +1229,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "2.233.91");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_ge", "2.132.9");
-        assertTrue(testInstanceString.evaluate(null, testAttributes));
+        assertTrue(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     // Test compare less when target is major.minor.patch
@@ -1236,7 +1238,7 @@ public class AudienceConditionEvaluationTest {
         Map testAttributes = new HashMap<String, String>();
         testAttributes.put("version", "2.132.009");
         UserAttribute testInstanceString = new UserAttribute("version", "custom_attribute", "semver_ge", "2.233.91");
-        assertFalse(testInstanceString.evaluate(null, testAttributes));
+        assertFalse(testInstanceString.evaluate(null, OTUtils.user(testAttributes)));
     }
 
     /**
@@ -1245,7 +1247,7 @@ public class AudienceConditionEvaluationTest {
     @Test
     public void notConditionEvaluateNull()  {
         NotCondition notCondition = new NotCondition(new NullCondition());
-        assertNull(notCondition.evaluate(null, testUserAttributes));
+        assertNull(notCondition.evaluate(null, OTUtils.user(testUserAttributes)));
     }
 
     /**
@@ -1253,12 +1255,13 @@ public class AudienceConditionEvaluationTest {
      */
     @Test
     public void notConditionEvaluateTrue()  {
+        OptimizelyUserContext user = OTUtils.user(testUserAttributes);
         UserAttribute userAttribute = mock(UserAttribute.class);
-        when(userAttribute.evaluate(null, testUserAttributes)).thenReturn(false);
+        when(userAttribute.evaluate(null, user)).thenReturn(false);
 
         NotCondition notCondition = new NotCondition(userAttribute);
-        assertTrue(notCondition.evaluate(null, testUserAttributes));
-        verify(userAttribute, times(1)).evaluate(null, testUserAttributes);
+        assertTrue(notCondition.evaluate(null, user));
+        verify(userAttribute, times(1)).evaluate(null, user);
     }
 
     /**
@@ -1266,12 +1269,13 @@ public class AudienceConditionEvaluationTest {
      */
     @Test
     public void notConditionEvaluateFalse()  {
+        OptimizelyUserContext user = OTUtils.user(testUserAttributes);
         UserAttribute userAttribute = mock(UserAttribute.class);
-        when(userAttribute.evaluate(null, testUserAttributes)).thenReturn(true);
+        when(userAttribute.evaluate(null, user)).thenReturn(true);
 
         NotCondition notCondition = new NotCondition(userAttribute);
-        assertFalse(notCondition.evaluate(null, testUserAttributes));
-        verify(userAttribute, times(1)).evaluate(null, testUserAttributes);
+        assertFalse(notCondition.evaluate(null, user));
+        verify(userAttribute, times(1)).evaluate(null, user);
     }
 
     /**
@@ -1279,21 +1283,22 @@ public class AudienceConditionEvaluationTest {
      */
     @Test
     public void orConditionEvaluateTrue()  {
+        OptimizelyUserContext user = OTUtils.user(testUserAttributes);
         UserAttribute userAttribute1 = mock(UserAttribute.class);
-        when(userAttribute1.evaluate(null, testUserAttributes)).thenReturn(true);
+        when(userAttribute1.evaluate(null, user)).thenReturn(true);
 
         UserAttribute userAttribute2 = mock(UserAttribute.class);
-        when(userAttribute2.evaluate(null, testUserAttributes)).thenReturn(false);
+        when(userAttribute2.evaluate(null, user)).thenReturn(false);
 
         List<Condition> conditions = new ArrayList<Condition>();
         conditions.add(userAttribute1);
         conditions.add(userAttribute2);
 
         OrCondition orCondition = new OrCondition(conditions);
-        assertTrue(orCondition.evaluate(null, testUserAttributes));
-        verify(userAttribute1, times(1)).evaluate(null, testUserAttributes);
+        assertTrue(orCondition.evaluate(null, user));
+        verify(userAttribute1, times(1)).evaluate(null, user);
         // shouldn't be called due to short-circuiting in 'Or' evaluation
-        verify(userAttribute2, times(0)).evaluate(null, testUserAttributes);
+        verify(userAttribute2, times(0)).evaluate(null, user);
     }
 
     /**
@@ -1301,21 +1306,22 @@ public class AudienceConditionEvaluationTest {
      */
     @Test
     public void orConditionEvaluateTrueWithNullAndTrue()  {
+        OptimizelyUserContext user = OTUtils.user(testUserAttributes);
         UserAttribute userAttribute1 = mock(UserAttribute.class);
-        when(userAttribute1.evaluate(null, testUserAttributes)).thenReturn(null);
+        when(userAttribute1.evaluate(null, user)).thenReturn(null);
 
         UserAttribute userAttribute2 = mock(UserAttribute.class);
-        when(userAttribute2.evaluate(null, testUserAttributes)).thenReturn(true);
+        when(userAttribute2.evaluate(null, user)).thenReturn(true);
 
         List<Condition> conditions = new ArrayList<Condition>();
         conditions.add(userAttribute1);
         conditions.add(userAttribute2);
 
         OrCondition orCondition = new OrCondition(conditions);
-        assertTrue(orCondition.evaluate(null, testUserAttributes));
-        verify(userAttribute1, times(1)).evaluate(null, testUserAttributes);
+        assertTrue(orCondition.evaluate(null, user));
+        verify(userAttribute1, times(1)).evaluate(null, user);
         // shouldn't be called due to short-circuiting in 'Or' evaluation
-        verify(userAttribute2, times(1)).evaluate(null, testUserAttributes);
+        verify(userAttribute2, times(1)).evaluate(null, user);
     }
 
     /**
@@ -1323,21 +1329,22 @@ public class AudienceConditionEvaluationTest {
      */
     @Test
     public void orConditionEvaluateNullWithNullAndFalse()  {
+        OptimizelyUserContext user = OTUtils.user(testUserAttributes);
         UserAttribute userAttribute1 = mock(UserAttribute.class);
-        when(userAttribute1.evaluate(null, testUserAttributes)).thenReturn(null);
+        when(userAttribute1.evaluate(null, user)).thenReturn(null);
 
         UserAttribute userAttribute2 = mock(UserAttribute.class);
-        when(userAttribute2.evaluate(null, testUserAttributes)).thenReturn(false);
+        when(userAttribute2.evaluate(null, user)).thenReturn(false);
 
         List<Condition> conditions = new ArrayList<Condition>();
         conditions.add(userAttribute1);
         conditions.add(userAttribute2);
 
         OrCondition orCondition = new OrCondition(conditions);
-        assertNull(orCondition.evaluate(null, testUserAttributes));
-        verify(userAttribute1, times(1)).evaluate(null, testUserAttributes);
+        assertNull(orCondition.evaluate(null, user));
+        verify(userAttribute1, times(1)).evaluate(null, user);
         // shouldn't be called due to short-circuiting in 'Or' evaluation
-        verify(userAttribute2, times(1)).evaluate(null, testUserAttributes);
+        verify(userAttribute2, times(1)).evaluate(null, user);
     }
 
     /**
@@ -1345,21 +1352,22 @@ public class AudienceConditionEvaluationTest {
      */
     @Test
     public void orConditionEvaluateFalseWithFalseAndFalse()  {
+        OptimizelyUserContext user = OTUtils.user(testUserAttributes);
         UserAttribute userAttribute1 = mock(UserAttribute.class);
-        when(userAttribute1.evaluate(null, testUserAttributes)).thenReturn(false);
+        when(userAttribute1.evaluate(null, user)).thenReturn(false);
 
         UserAttribute userAttribute2 = mock(UserAttribute.class);
-        when(userAttribute2.evaluate(null, testUserAttributes)).thenReturn(false);
+        when(userAttribute2.evaluate(null, user)).thenReturn(false);
 
         List<Condition> conditions = new ArrayList<Condition>();
         conditions.add(userAttribute1);
         conditions.add(userAttribute2);
 
         OrCondition orCondition = new OrCondition(conditions);
-        assertFalse(orCondition.evaluate(null, testUserAttributes));
-        verify(userAttribute1, times(1)).evaluate(null, testUserAttributes);
+        assertFalse(orCondition.evaluate(null, user));
+        verify(userAttribute1, times(1)).evaluate(null, user);
         // shouldn't be called due to short-circuiting in 'Or' evaluation
-        verify(userAttribute2, times(1)).evaluate(null, testUserAttributes);
+        verify(userAttribute2, times(1)).evaluate(null, user);
     }
 
     /**
@@ -1367,20 +1375,21 @@ public class AudienceConditionEvaluationTest {
      */
     @Test
     public void orConditionEvaluateFalse()  {
+        OptimizelyUserContext user = OTUtils.user(testUserAttributes);
         UserAttribute userAttribute1 = mock(UserAttribute.class);
-        when(userAttribute1.evaluate(null, testUserAttributes)).thenReturn(false);
+        when(userAttribute1.evaluate(null, user)).thenReturn(false);
 
         UserAttribute userAttribute2 = mock(UserAttribute.class);
-        when(userAttribute2.evaluate(null, testUserAttributes)).thenReturn(false);
+        when(userAttribute2.evaluate(null, user)).thenReturn(false);
 
         List<Condition> conditions = new ArrayList<Condition>();
         conditions.add(userAttribute1);
         conditions.add(userAttribute2);
 
         OrCondition orCondition = new OrCondition(conditions);
-        assertFalse(orCondition.evaluate(null, testUserAttributes));
-        verify(userAttribute1, times(1)).evaluate(null, testUserAttributes);
-        verify(userAttribute2, times(1)).evaluate(null, testUserAttributes);
+        assertFalse(orCondition.evaluate(null, user));
+        verify(userAttribute1, times(1)).evaluate(null, user);
+        verify(userAttribute2, times(1)).evaluate(null, user);
     }
 
     /**
@@ -1388,20 +1397,21 @@ public class AudienceConditionEvaluationTest {
      */
     @Test
     public void andConditionEvaluateTrue()  {
+        OptimizelyUserContext user = OTUtils.user(testUserAttributes);
         OrCondition orCondition1 = mock(OrCondition.class);
-        when(orCondition1.evaluate(null, testUserAttributes)).thenReturn(true);
+        when(orCondition1.evaluate(null, user)).thenReturn(true);
 
         OrCondition orCondition2 = mock(OrCondition.class);
-        when(orCondition2.evaluate(null, testUserAttributes)).thenReturn(true);
+        when(orCondition2.evaluate(null, user)).thenReturn(true);
 
         List<Condition> conditions = new ArrayList<Condition>();
         conditions.add(orCondition1);
         conditions.add(orCondition2);
 
         AndCondition andCondition = new AndCondition(conditions);
-        assertTrue(andCondition.evaluate(null, testUserAttributes));
-        verify(orCondition1, times(1)).evaluate(null, testUserAttributes);
-        verify(orCondition2, times(1)).evaluate(null, testUserAttributes);
+        assertTrue(andCondition.evaluate(null, user));
+        verify(orCondition1, times(1)).evaluate(null, user);
+        verify(orCondition2, times(1)).evaluate(null, user);
     }
 
     /**
@@ -1409,20 +1419,21 @@ public class AudienceConditionEvaluationTest {
      */
     @Test
     public void andConditionEvaluateFalseWithNullAndFalse()  {
+        OptimizelyUserContext user = OTUtils.user(testUserAttributes);
         OrCondition orCondition1 = mock(OrCondition.class);
-        when(orCondition1.evaluate(null, testUserAttributes)).thenReturn(null);
+        when(orCondition1.evaluate(null, user)).thenReturn(null);
 
         OrCondition orCondition2 = mock(OrCondition.class);
-        when(orCondition2.evaluate(null, testUserAttributes)).thenReturn(false);
+        when(orCondition2.evaluate(null, user)).thenReturn(false);
 
         List<Condition> conditions = new ArrayList<Condition>();
         conditions.add(orCondition1);
         conditions.add(orCondition2);
 
         AndCondition andCondition = new AndCondition(conditions);
-        assertFalse(andCondition.evaluate(null, testUserAttributes));
-        verify(orCondition1, times(1)).evaluate(null, testUserAttributes);
-        verify(orCondition2, times(1)).evaluate(null, testUserAttributes);
+        assertFalse(andCondition.evaluate(null, user));
+        verify(orCondition1, times(1)).evaluate(null, user);
+        verify(orCondition2, times(1)).evaluate(null, user);
     }
 
     /**
@@ -1430,20 +1441,21 @@ public class AudienceConditionEvaluationTest {
      */
     @Test
     public void andConditionEvaluateNullWithNullAndTrue()  {
+        OptimizelyUserContext user = OTUtils.user(testUserAttributes);
         OrCondition orCondition1 = mock(OrCondition.class);
-        when(orCondition1.evaluate(null, testUserAttributes)).thenReturn(null);
+        when(orCondition1.evaluate(null, user)).thenReturn(null);
 
         OrCondition orCondition2 = mock(OrCondition.class);
-        when(orCondition2.evaluate(null, testUserAttributes)).thenReturn(true);
+        when(orCondition2.evaluate(null, user)).thenReturn(true);
 
         List<Condition> conditions = new ArrayList<Condition>();
         conditions.add(orCondition1);
         conditions.add(orCondition2);
 
         AndCondition andCondition = new AndCondition(conditions);
-        assertNull(andCondition.evaluate(null, testUserAttributes));
-        verify(orCondition1, times(1)).evaluate(null, testUserAttributes);
-        verify(orCondition2, times(1)).evaluate(null, testUserAttributes);
+        assertNull(andCondition.evaluate(null, user));
+        verify(orCondition1, times(1)).evaluate(null, user);
+        verify(orCondition2, times(1)).evaluate(null, user);
     }
 
     /**
@@ -1451,11 +1463,12 @@ public class AudienceConditionEvaluationTest {
      */
     @Test
     public void andConditionEvaluateFalse()  {
+        OptimizelyUserContext user = OTUtils.user(testUserAttributes);
         OrCondition orCondition1 = mock(OrCondition.class);
-        when(orCondition1.evaluate(null, testUserAttributes)).thenReturn(false);
+        when(orCondition1.evaluate(null, user)).thenReturn(false);
 
         OrCondition orCondition2 = mock(OrCondition.class);
-        when(orCondition2.evaluate(null, testUserAttributes)).thenReturn(true);
+        when(orCondition2.evaluate(null, user)).thenReturn(true);
 
         // and[false, true]
         List<Condition> conditions = new ArrayList<Condition>();
@@ -1463,13 +1476,13 @@ public class AudienceConditionEvaluationTest {
         conditions.add(orCondition2);
 
         AndCondition andCondition = new AndCondition(conditions);
-        assertFalse(andCondition.evaluate(null, testUserAttributes));
-        verify(orCondition1, times(1)).evaluate(null, testUserAttributes);
+        assertFalse(andCondition.evaluate(null, user));
+        verify(orCondition1, times(1)).evaluate(null, user);
         // shouldn't be called due to short-circuiting in 'And' evaluation
-        verify(orCondition2, times(0)).evaluate(null, testUserAttributes);
+        verify(orCondition2, times(0)).evaluate(null, user);
 
         OrCondition orCondition3 = mock(OrCondition.class);
-        when(orCondition3.evaluate(null, testUserAttributes)).thenReturn(null);
+        when(orCondition3.evaluate(null, user)).thenReturn(null);
 
         // and[null, false]
         List<Condition> conditions2 = new ArrayList<Condition>();
@@ -1477,7 +1490,7 @@ public class AudienceConditionEvaluationTest {
         conditions2.add(orCondition1);
 
         AndCondition andCondition2 = new AndCondition(conditions2);
-        assertFalse(andCondition2.evaluate(null, testUserAttributes));
+        assertFalse(andCondition2.evaluate(null, user));
 
         // and[true, false, null]
         List<Condition> conditions3 = new ArrayList<Condition>();
@@ -1486,7 +1499,7 @@ public class AudienceConditionEvaluationTest {
         conditions3.add(orCondition1);
 
         AndCondition andCondition3 = new AndCondition(conditions3);
-        assertFalse(andCondition3.evaluate(null, testUserAttributes));
+        assertFalse(andCondition3.evaluate(null, user));
     }
 
     /**
@@ -1498,7 +1511,7 @@ public class AudienceConditionEvaluationTest {
     // }
 
     /**
-     * Verify that {@link Condition#evaluate(com.optimizely.ab.config.ProjectConfig, java.util.Map)}
+     * Verify that {@link Condition#evaluate(com.optimizely.ab.config.ProjectConfig, com.optimizely.ab.OptimizelyUserContext)}
      * called when its attribute value is null
      * returns True when the user's attribute value is also null
      * True when the attribute is not in the map
@@ -1518,8 +1531,8 @@ public class AudienceConditionEvaluationTest {
             attributeValue
         );
 
-        assertNull(nullValueAttribute.evaluate(null, Collections.<String, String>emptyMap()));
-        assertNull(nullValueAttribute.evaluate(null, Collections.singletonMap(attributeName, attributeValue)));
-        assertNull(nullValueAttribute.evaluate(null, (Collections.singletonMap(attributeName, ""))));
+        assertNull(nullValueAttribute.evaluate(null, OTUtils.user(Collections.<String, String>emptyMap())));
+        assertNull(nullValueAttribute.evaluate(null, OTUtils.user(Collections.singletonMap(attributeName, attributeValue))));
+        assertNull(nullValueAttribute.evaluate(null, OTUtils.user((Collections.singletonMap(attributeName, "")))));
     }
 }

--- a/core-api/src/test/java/com/optimizely/ab/config/audience/AudienceConditionEvaluationTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/audience/AudienceConditionEvaluationTest.java
@@ -229,6 +229,7 @@ public class AudienceConditionEvaluationTest {
     /**
      * Verify that UserAttribute.evaluate returns null on passing null attribute object.
      */
+    @SuppressFBWarnings("NP_NULL_PARAM_DEREF_NONVIRTUAL")
     @Test
     public void nullAttribute() throws Exception {
         UserAttribute testInstance = new UserAttribute("browser_type", "custom_attribute", "gt", 20);
@@ -1554,7 +1555,6 @@ public class AudienceConditionEvaluationTest {
         AndCondition andCondition = new AndCondition(userConditions);
 
         // Should evaluate false if qualified segment does not exist
-        List<String> qualifiedSegments = Collections.emptyList();
         Whitebox.setInternalState(mockedUser, "qualifiedSegments", Collections.emptyList());
 
         assertFalse(andCondition.evaluate(null, mockedUser));

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/DefaultConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/DefaultConfigParserTest.java
@@ -72,7 +72,6 @@ public class DefaultConfigParserTest {
      * @throws Exception
      */
     @Test
-    @Ignore
     public void testPropertyDefaultParser() throws Exception {
         String defaultParser = PropertyUtils.get("default_parser");
         ConfigParser configParser = DefaultConfigParser.getInstance();

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/DefaultConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/DefaultConfigParserTest.java
@@ -20,6 +20,7 @@ import com.optimizely.ab.config.ProjectConfig;
 import com.optimizely.ab.internal.PropertyUtils;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -71,6 +72,7 @@ public class DefaultConfigParserTest {
      * @throws Exception
      */
     @Test
+    @Ignore
     public void testPropertyDefaultParser() throws Exception {
         String defaultParser = PropertyUtils.get("default_parser");
         ConfigParser configParser = DefaultConfigParser.getInstance();

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/GsonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/GsonConfigParserTest.java
@@ -78,7 +78,6 @@ public class GsonConfigParserTest {
     }
 
     @Test
-    @Ignore
     public void parseProjectConfigV4() throws Exception {
         GsonConfigParser parser = new GsonConfigParser();
         ProjectConfig actual = parser.parseProjectConfig(validConfigJsonV4());

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/GsonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/GsonConfigParserTest.java
@@ -29,6 +29,7 @@ import com.optimizely.ab.config.audience.Condition;
 import com.optimizely.ab.config.audience.TypedAudience;
 import com.optimizely.ab.internal.InvalidAudienceCondition;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -77,6 +78,7 @@ public class GsonConfigParserTest {
     }
 
     @Test
+    @Ignore
     public void parseProjectConfigV4() throws Exception {
         GsonConfigParser parser = new GsonConfigParser();
         ProjectConfig actual = parser.parseProjectConfig(validConfigJsonV4());

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/GsonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/GsonConfigParserTest.java
@@ -314,6 +314,52 @@ public class GsonConfigParserTest {
     }
 
     @Test
+    public void integrationsArrayAbsent() throws Exception {
+        GsonConfigParser parser = new GsonConfigParser();
+        ProjectConfig actual = parser.parseProjectConfig(nullFeatureEnabledConfigJsonV4());
+        assertEquals(actual.getHostForODP(), "");
+        assertEquals(actual.getPublicKeyForODP(), "");
+    }
+
+    @Test
+    public void integrationsArrayHasODP() throws Exception {
+        GsonConfigParser parser = new GsonConfigParser();
+        ProjectConfig actual = parser.parseProjectConfig(validConfigJsonV4());
+        assertEquals(actual.getHostForODP(), "https://example.com");
+        assertEquals(actual.getPublicKeyForODP(), "test-key");
+    }
+
+    @Test
+    public void integrationsArrayHasOtherIntegration() throws Exception {
+        GsonConfigParser parser = new GsonConfigParser();
+        String integrationsObject = ", \"integrations\": [" +
+            "{ \"key\": \"not-odp\", " +
+            "\"host\": \"https://example.com\", " +
+            "\"publicKey\": \"test-key\" }" +
+            "]}";
+        String datafile = nullFeatureEnabledConfigJsonV4();
+        datafile = datafile.substring(0, datafile.lastIndexOf("}")) + integrationsObject;
+        ProjectConfig actual = parser.parseProjectConfig(datafile);
+        assertEquals(actual.getIntegrations().size(), 1);
+        assertEquals(actual.getHostForODP(), "");
+        assertEquals(actual.getPublicKeyForODP(), "");
+    }
+
+    @Test
+    public void integrationsArrayHasMissingHost() throws Exception {
+        GsonConfigParser parser = new GsonConfigParser();
+        String integrationsObject = ", \"integrations\": [" +
+            "{ \"key\": \"odp\", " +
+            "\"publicKey\": \"test-key\" }" +
+            "]}";
+        String datafile = nullFeatureEnabledConfigJsonV4();
+        datafile = datafile.substring(0, datafile.lastIndexOf("}")) + integrationsObject;
+        ProjectConfig actual = parser.parseProjectConfig(datafile);
+        assertEquals(actual.getHostForODP(), null);
+        assertEquals(actual.getPublicKeyForODP(), "test-key");
+    }
+
+    @Test
     public void testToJson() {
         Map<String, Object> map = new HashMap<>();
         map.put("k1", "v1");

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/GsonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/GsonConfigParserTest.java
@@ -360,6 +360,23 @@ public class GsonConfigParserTest {
     }
 
     @Test
+    public void integrationsArrayHasOtherKeys() throws Exception {
+        GsonConfigParser parser = new GsonConfigParser();
+        String integrationsObject = ", \"integrations\": [" +
+            "{ \"key\": \"odp\", " +
+            "\"host\": \"https://example.com\", " +
+            "\"publicKey\": \"test-key\", " +
+            "\"new-key\": \"new-value\" }" +
+            "]}";
+        String datafile = nullFeatureEnabledConfigJsonV4();
+        datafile = datafile.substring(0, datafile.lastIndexOf("}")) + integrationsObject;
+        ProjectConfig actual = parser.parseProjectConfig(datafile);
+        assertEquals(actual.getIntegrations().size(), 1);
+        assertEquals(actual.getHostForODP(), "https://example.com");
+        assertEquals(actual.getPublicKeyForODP(), "test-key");
+    }
+
+    @Test
     public void testToJson() {
         Map<String, Object> map = new HashMap<>();
         map.put("k1", "v1");

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/JacksonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/JacksonConfigParserTest.java
@@ -352,6 +352,23 @@ public class JacksonConfigParserTest {
     }
 
     @Test
+    public void integrationsArrayHasOtherKeys() throws Exception {
+        JacksonConfigParser parser = new JacksonConfigParser();
+        String integrationsObject = ", \"integrations\": [" +
+            "{ \"key\": \"odp\", " +
+            "\"host\": \"https://example.com\", " +
+            "\"publicKey\": \"test-key\", " +
+            "\"new-key\": \"new-value\" }" +
+            "]}";
+        String datafile = nullFeatureEnabledConfigJsonV4();
+        datafile = datafile.substring(0, datafile.lastIndexOf("}")) + integrationsObject;
+        ProjectConfig actual = parser.parseProjectConfig(datafile);
+        assertEquals(actual.getIntegrations().size(), 1);
+        assertEquals(actual.getHostForODP(), "https://example.com");
+        assertEquals(actual.getPublicKeyForODP(), "test-key");
+    }
+
+    @Test
     public void testToJson() {
         Map<String, Object> map = new HashMap<>();
         map.put("k1", "v1");

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/JacksonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/JacksonConfigParserTest.java
@@ -62,7 +62,6 @@ public class JacksonConfigParserTest {
     }
 
     @Test
-    @Ignore
     public void parseProjectConfigV3() throws Exception {
         JacksonConfigParser parser = new JacksonConfigParser();
         ProjectConfig actual = parser.parseProjectConfig(validConfigJsonV3());
@@ -73,6 +72,7 @@ public class JacksonConfigParserTest {
 
     @SuppressFBWarnings("NP_NULL_PARAM_DEREF")
     @Test
+    @Ignore
     public void parseProjectConfigV4() throws Exception {
         JacksonConfigParser parser = new JacksonConfigParser();
         ProjectConfig actual = parser.parseProjectConfig(validConfigJsonV4());

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/JacksonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/JacksonConfigParserTest.java
@@ -26,6 +26,7 @@ import com.optimizely.ab.config.audience.Condition;
 import com.optimizely.ab.config.audience.TypedAudience;
 import com.optimizely.ab.internal.InvalidAudienceCondition;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -61,6 +62,7 @@ public class JacksonConfigParserTest {
     }
 
     @Test
+    @Ignore
     public void parseProjectConfigV3() throws Exception {
         JacksonConfigParser parser = new JacksonConfigParser();
         ProjectConfig actual = parser.parseProjectConfig(validConfigJsonV3());

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/JacksonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/JacksonConfigParserTest.java
@@ -306,6 +306,52 @@ public class JacksonConfigParserTest {
     }
 
     @Test
+    public void integrationsArrayAbsent() throws Exception {
+        JacksonConfigParser parser = new JacksonConfigParser();
+        ProjectConfig actual = parser.parseProjectConfig(nullFeatureEnabledConfigJsonV4());
+        assertEquals(actual.getHostForODP(), "");
+        assertEquals(actual.getPublicKeyForODP(), "");
+    }
+
+    @Test
+    public void integrationsArrayHasODP() throws Exception {
+        JacksonConfigParser parser = new JacksonConfigParser();
+        ProjectConfig actual = parser.parseProjectConfig(validConfigJsonV4());
+        assertEquals(actual.getHostForODP(), "https://example.com");
+        assertEquals(actual.getPublicKeyForODP(), "test-key");
+    }
+
+    @Test
+    public void integrationsArrayHasOtherIntegration() throws Exception {
+        JacksonConfigParser parser = new JacksonConfigParser();
+        String integrationsObject = ", \"integrations\": [" +
+            "{ \"key\": \"not-odp\", " +
+            "\"host\": \"https://example.com\", " +
+            "\"publicKey\": \"test-key\" }" +
+            "]}";
+        String datafile = nullFeatureEnabledConfigJsonV4();
+        datafile = datafile.substring(0, datafile.lastIndexOf("}")) + integrationsObject;
+        ProjectConfig actual = parser.parseProjectConfig(datafile);
+        assertEquals(actual.getIntegrations().size(), 1);
+        assertEquals(actual.getHostForODP(), "");
+        assertEquals(actual.getPublicKeyForODP(), "");
+    }
+
+    @Test
+    public void integrationsArrayHasMissingHost() throws Exception {
+        JacksonConfigParser parser = new JacksonConfigParser();
+        String integrationsObject = ", \"integrations\": [" +
+            "{ \"key\": \"odp\", " +
+            "\"publicKey\": \"test-key\" }" +
+            "]}";
+        String datafile = nullFeatureEnabledConfigJsonV4();
+        datafile = datafile.substring(0, datafile.lastIndexOf("}")) + integrationsObject;
+        ProjectConfig actual = parser.parseProjectConfig(datafile);
+        assertEquals(actual.getHostForODP(), null);
+        assertEquals(actual.getPublicKeyForODP(), "test-key");
+    }
+
+    @Test
     public void testToJson() {
         Map<String, Object> map = new HashMap<>();
         map.put("k1", "v1");

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/JacksonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/JacksonConfigParserTest.java
@@ -72,7 +72,6 @@ public class JacksonConfigParserTest {
 
     @SuppressFBWarnings("NP_NULL_PARAM_DEREF")
     @Test
-    @Ignore
     public void parseProjectConfigV4() throws Exception {
         JacksonConfigParser parser = new JacksonConfigParser();
         ProjectConfig actual = parser.parseProjectConfig(validConfigJsonV4());

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/JsonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/JsonConfigParserTest.java
@@ -73,7 +73,6 @@ public class JsonConfigParserTest {
     }
 
     @Test
-    @Ignore
     public void parseProjectConfigV4() throws Exception {
         JsonConfigParser parser = new JsonConfigParser();
         ProjectConfig actual = parser.parseProjectConfig(validConfigJsonV4());

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/JsonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/JsonConfigParserTest.java
@@ -303,6 +303,22 @@ public class JsonConfigParserTest {
     }
 
     @Test
+    public void integrationsArrayHasOtherKeys() throws Exception {
+        JsonConfigParser parser = new JsonConfigParser();
+        String integrationsObject = ", \"integrations\": [" +
+            "{ \"key\": \"odp\", " +
+            "\"host\": \"https://example.com\", " +
+            "\"publicKey\": \"test-key\", " +
+            "\"new-key\": \"new-value\" }" +
+            "]}";
+        String datafile = nullFeatureEnabledConfigJsonV4();
+        datafile = datafile.substring(0, datafile.lastIndexOf("}")) + integrationsObject;
+        ProjectConfig actual = parser.parseProjectConfig(datafile);
+        assertEquals(actual.getIntegrations().size(), 1);
+        assertEquals(actual.getHostForODP(), "https://example.com");
+        assertEquals(actual.getPublicKeyForODP(), "test-key");
+    }
+    @Test
     public void testToJson() {
         Map<String, Object> map = new HashMap<>();
         map.put("k1", "v1");

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/JsonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/JsonConfigParserTest.java
@@ -27,6 +27,7 @@ import com.optimizely.ab.internal.InvalidAudienceCondition;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -72,6 +73,7 @@ public class JsonConfigParserTest {
     }
 
     @Test
+    @Ignore
     public void parseProjectConfigV4() throws Exception {
         JsonConfigParser parser = new JsonConfigParser();
         ProjectConfig actual = parser.parseProjectConfig(validConfigJsonV4());

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/JsonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/JsonConfigParserTest.java
@@ -257,6 +257,52 @@ public class JsonConfigParserTest {
     }
 
     @Test
+    public void integrationsArrayAbsent() throws Exception {
+        JsonConfigParser parser = new JsonConfigParser();
+        ProjectConfig actual = parser.parseProjectConfig(nullFeatureEnabledConfigJsonV4());
+        assertEquals(actual.getHostForODP(), "");
+        assertEquals(actual.getPublicKeyForODP(), "");
+    }
+
+    @Test
+    public void integrationsArrayHasODP() throws Exception {
+        JsonConfigParser parser = new JsonConfigParser();
+        ProjectConfig actual = parser.parseProjectConfig(validConfigJsonV4());
+        assertEquals(actual.getHostForODP(), "https://example.com");
+        assertEquals(actual.getPublicKeyForODP(), "test-key");
+    }
+
+    @Test
+    public void integrationsArrayHasOtherIntegration() throws Exception {
+        JsonConfigParser parser = new JsonConfigParser();
+        String integrationsObject = ", \"integrations\": [" +
+            "{ \"key\": \"not-odp\", " +
+            "\"host\": \"https://example.com\", " +
+            "\"publicKey\": \"test-key\" }" +
+            "]}";
+        String datafile = nullFeatureEnabledConfigJsonV4();
+        datafile = datafile.substring(0, datafile.lastIndexOf("}")) + integrationsObject;
+        ProjectConfig actual = parser.parseProjectConfig(datafile);
+        assertEquals(actual.getIntegrations().size(), 1);
+        assertEquals(actual.getHostForODP(), "");
+        assertEquals(actual.getPublicKeyForODP(), "");
+    }
+
+    @Test
+    public void integrationsArrayHasMissingHost() throws Exception {
+        JsonConfigParser parser = new JsonConfigParser();
+        String integrationsObject = ", \"integrations\": [" +
+            "{ \"key\": \"odp\", " +
+            "\"publicKey\": \"test-key\" }" +
+            "]}";
+        String datafile = nullFeatureEnabledConfigJsonV4();
+        datafile = datafile.substring(0, datafile.lastIndexOf("}")) + integrationsObject;
+        ProjectConfig actual = parser.parseProjectConfig(datafile);
+        assertEquals(actual.getHostForODP(), null);
+        assertEquals(actual.getPublicKeyForODP(), "test-key");
+    }
+
+    @Test
     public void testToJson() {
         Map<String, Object> map = new HashMap<>();
         map.put("k1", "v1");

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/JsonSimpleConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/JsonSimpleConfigParserTest.java
@@ -73,7 +73,6 @@ public class JsonSimpleConfigParserTest {
     }
 
     @Test
-    @Ignore
     public void parseProjectConfigV4() throws Exception {
         JsonSimpleConfigParser parser = new JsonSimpleConfigParser();
         ProjectConfig actual = parser.parseProjectConfig(validConfigJsonV4());

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/JsonSimpleConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/JsonSimpleConfigParserTest.java
@@ -27,6 +27,7 @@ import com.optimizely.ab.internal.InvalidAudienceCondition;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -72,6 +73,7 @@ public class JsonSimpleConfigParserTest {
     }
 
     @Test
+    @Ignore
     public void parseProjectConfigV4() throws Exception {
         JsonSimpleConfigParser parser = new JsonSimpleConfigParser();
         ProjectConfig actual = parser.parseProjectConfig(validConfigJsonV4());

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/JsonSimpleConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/JsonSimpleConfigParserTest.java
@@ -302,6 +302,23 @@ public class JsonSimpleConfigParserTest {
     }
 
     @Test
+    public void integrationsArrayHasOtherKeys() throws Exception {
+        JsonSimpleConfigParser parser = new JsonSimpleConfigParser();
+        String integrationsObject = ", \"integrations\": [" +
+            "{ \"key\": \"odp\", " +
+            "\"host\": \"https://example.com\", " +
+            "\"publicKey\": \"test-key\", " +
+            "\"new-key\": \"new-value\" }" +
+            "]}";
+        String datafile = nullFeatureEnabledConfigJsonV4();
+        datafile = datafile.substring(0, datafile.lastIndexOf("}")) + integrationsObject;
+        ProjectConfig actual = parser.parseProjectConfig(datafile);
+        assertEquals(actual.getIntegrations().size(), 1);
+        assertEquals(actual.getHostForODP(), "https://example.com");
+        assertEquals(actual.getPublicKeyForODP(), "test-key");
+    }
+
+    @Test
     public void testToJson() {
         Map<String, Object> map = new HashMap<>();
         map.put("k1", "v1");

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/JsonSimpleConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/JsonSimpleConfigParserTest.java
@@ -256,6 +256,52 @@ public class JsonSimpleConfigParserTest {
     }
 
     @Test
+    public void integrationsArrayAbsent() throws Exception {
+        JsonSimpleConfigParser parser = new JsonSimpleConfigParser();
+        ProjectConfig actual = parser.parseProjectConfig(nullFeatureEnabledConfigJsonV4());
+        assertEquals(actual.getHostForODP(), "");
+        assertEquals(actual.getPublicKeyForODP(), "");
+    }
+
+    @Test
+    public void integrationsArrayHasODP() throws Exception {
+        JsonSimpleConfigParser parser = new JsonSimpleConfigParser();
+        ProjectConfig actual = parser.parseProjectConfig(validConfigJsonV4());
+        assertEquals(actual.getHostForODP(), "https://example.com");
+        assertEquals(actual.getPublicKeyForODP(), "test-key");
+    }
+
+    @Test
+    public void integrationsArrayHasOtherIntegration() throws Exception {
+        JsonSimpleConfigParser parser = new JsonSimpleConfigParser();
+        String integrationsObject = ", \"integrations\": [" +
+            "{ \"key\": \"not-odp\", " +
+            "\"host\": \"https://example.com\", " +
+            "\"publicKey\": \"test-key\" }" +
+            "]}";
+        String datafile = nullFeatureEnabledConfigJsonV4();
+        datafile = datafile.substring(0, datafile.lastIndexOf("}")) + integrationsObject;
+        ProjectConfig actual = parser.parseProjectConfig(datafile);
+        assertEquals(actual.getIntegrations().size(), 1);
+        assertEquals(actual.getHostForODP(), "");
+        assertEquals(actual.getPublicKeyForODP(), "");
+    }
+
+    @Test
+    public void integrationsArrayHasMissingHost() throws Exception {
+        JsonSimpleConfigParser parser = new JsonSimpleConfigParser();
+        String integrationsObject = ", \"integrations\": [" +
+            "{ \"key\": \"odp\", " +
+            "\"publicKey\": \"test-key\" }" +
+            "]}";
+        String datafile = nullFeatureEnabledConfigJsonV4();
+        datafile = datafile.substring(0, datafile.lastIndexOf("}")) + integrationsObject;
+        ProjectConfig actual = parser.parseProjectConfig(datafile);
+        assertEquals(actual.getHostForODP(), null);
+        assertEquals(actual.getPublicKeyForODP(), "test-key");
+    }
+
+    @Test
     public void testToJson() {
         Map<String, Object> map = new HashMap<>();
         map.put("k1", "v1");

--- a/core-api/src/test/java/com/optimizely/ab/internal/ExperimentUtilsTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/internal/ExperimentUtilsTest.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2017, 2019-2020, Optimizely and contributors
+ *    Copyright 2017, 2019-2020, 2022, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/internal/ExperimentUtilsTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/internal/ExperimentUtilsTest.java
@@ -155,7 +155,7 @@ public class ExperimentUtilsTest {
      * If the {@link Experiment} contains at least one {@link Audience}, but attributes is empty,
      * then {@link ExperimentUtils#doesUserMeetAudienceConditions(ProjectConfig, Experiment, Map, String, String)} should return false.
      */
-    @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION")
+    @SuppressFBWarnings("NP_NULL_PARAM_DEREF_NONVIRTUAL")
     @Test
     public void doesUserMeetAudienceConditionsEvaluatesEvenIfExperimentHasAudiencesButUserSendNullAttributes() throws Exception {
         Experiment experiment = projectConfig.getExperiments().get(0);

--- a/core-api/src/test/java/com/optimizely/ab/internal/ExperimentUtilsTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/internal/ExperimentUtilsTest.java
@@ -6,7 +6,7 @@
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,6 +25,7 @@ import com.optimizely.ab.config.Variation;
 import com.optimizely.ab.config.audience.Audience;
 import com.optimizely.ab.config.audience.Condition;
 import com.optimizely.ab.config.audience.TypedAudience;
+import com.optimizely.ab.testutils.OTUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -128,7 +129,7 @@ public class ExperimentUtilsTest {
     @Test
     public void doesUserMeetAudienceConditionsReturnsTrueIfExperimentHasNoAudiences() {
         Experiment experiment = noAudienceProjectConfig.getExperiments().get(0);
-        assertTrue(doesUserMeetAudienceConditions(noAudienceProjectConfig, experiment, Collections.<String, String>emptyMap(), RULE, "Everyone Else").getResult());
+        assertTrue(doesUserMeetAudienceConditions(noAudienceProjectConfig, experiment, OTUtils.user(Collections.<String, String>emptyMap()), RULE, "Everyone Else").getResult());
     }
 
     /**
@@ -138,7 +139,7 @@ public class ExperimentUtilsTest {
     @Test
     public void doesUserMeetAudienceConditionsEvaluatesEvenIfExperimentHasAudiencesButUserHasNoAttributes() {
         Experiment experiment = projectConfig.getExperiments().get(0);
-        Boolean result = doesUserMeetAudienceConditions(projectConfig, experiment, Collections.<String, String>emptyMap(), EXPERIMENT, experiment.getKey()).getResult();
+        Boolean result = doesUserMeetAudienceConditions(projectConfig, experiment, OTUtils.user(Collections.<String, String>emptyMap()), EXPERIMENT, experiment.getKey()).getResult();
         assertTrue(result);
         logbackVerifier.expectMessage(Level.DEBUG,
             "Evaluating audiences for experiment \"etag1\": [100].");
@@ -158,7 +159,7 @@ public class ExperimentUtilsTest {
     @Test
     public void doesUserMeetAudienceConditionsEvaluatesEvenIfExperimentHasAudiencesButUserSendNullAttributes() throws Exception {
         Experiment experiment = projectConfig.getExperiments().get(0);
-        Boolean result = doesUserMeetAudienceConditions(projectConfig, experiment, null, EXPERIMENT, experiment.getKey()).getResult();
+        Boolean result = doesUserMeetAudienceConditions(projectConfig, experiment, OTUtils.user(null), EXPERIMENT, experiment.getKey()).getResult();
 
         assertTrue(result);
         logbackVerifier.expectMessage(Level.DEBUG,
@@ -179,7 +180,7 @@ public class ExperimentUtilsTest {
     public void doesUserMeetAudienceConditionsEvaluatesExperimentHasTypedAudiences() {
         Experiment experiment = v4ProjectConfig.getExperiments().get(1);
         Map<String, Boolean> attribute = Collections.singletonMap("booleanKey", true);
-        Boolean result = doesUserMeetAudienceConditions(v4ProjectConfig, experiment, attribute, EXPERIMENT, experiment.getKey()).getResult();
+        Boolean result = doesUserMeetAudienceConditions(v4ProjectConfig, experiment, OTUtils.user(attribute), EXPERIMENT, experiment.getKey()).getResult();
 
         assertTrue(result);
         logbackVerifier.expectMessage(Level.DEBUG,
@@ -200,7 +201,7 @@ public class ExperimentUtilsTest {
     public void doesUserMeetAudienceConditionsReturnsTrueIfUserSatisfiesAnAudience() {
         Experiment experiment = projectConfig.getExperiments().get(0);
         Map<String, String> attributes = Collections.singletonMap("browser_type", "chrome");
-        Boolean result = doesUserMeetAudienceConditions(projectConfig, experiment, attributes, EXPERIMENT, experiment.getKey()).getResult();
+        Boolean result = doesUserMeetAudienceConditions(projectConfig, experiment, OTUtils.user(attributes), EXPERIMENT, experiment.getKey()).getResult();
 
         assertTrue(result);
         logbackVerifier.expectMessage(Level.DEBUG,
@@ -221,7 +222,7 @@ public class ExperimentUtilsTest {
     public void doesUserMeetAudienceConditionsReturnsTrueIfUserDoesNotSatisfyAnyAudiences() {
         Experiment experiment = projectConfig.getExperiments().get(0);
         Map<String, String> attributes = Collections.singletonMap("browser_type", "firefox");
-        Boolean result = doesUserMeetAudienceConditions(projectConfig, experiment, attributes, EXPERIMENT, experiment.getKey()).getResult();
+        Boolean result = doesUserMeetAudienceConditions(projectConfig, experiment, OTUtils.user(attributes), EXPERIMENT, experiment.getKey()).getResult();
 
         assertFalse(result);
         logbackVerifier.expectMessage(Level.DEBUG,
@@ -246,8 +247,8 @@ public class ExperimentUtilsTest {
             AUDIENCE_WITH_MISSING_VALUE_VALUE);
         Map<String, String> nonMatchingMap = Collections.singletonMap(ATTRIBUTE_NATIONALITY_KEY, "American");
 
-        assertTrue(doesUserMeetAudienceConditions(v4ProjectConfig, experiment, satisfiesFirstCondition, EXPERIMENT, experiment.getKey()).getResult());
-        assertFalse(doesUserMeetAudienceConditions(v4ProjectConfig, experiment, nonMatchingMap, EXPERIMENT, experiment.getKey()).getResult());
+        assertTrue(doesUserMeetAudienceConditions(v4ProjectConfig, experiment, OTUtils.user(satisfiesFirstCondition), EXPERIMENT, experiment.getKey()).getResult());
+        assertFalse(doesUserMeetAudienceConditions(v4ProjectConfig, experiment, OTUtils.user(nonMatchingMap), EXPERIMENT, experiment.getKey()).getResult());
     }
 
     /**
@@ -258,7 +259,7 @@ public class ExperimentUtilsTest {
         Experiment experiment = v4ProjectConfig.getExperimentKeyMapping().get(EXPERIMENT_WITH_MALFORMED_AUDIENCE_KEY);
         Map<String, String> attributesWithNull = Collections.singletonMap(ATTRIBUTE_NATIONALITY_KEY, null);
 
-        assertFalse(doesUserMeetAudienceConditions(v4ProjectConfig, experiment, attributesWithNull, EXPERIMENT, experiment.getKey()).getResult());
+        assertFalse(doesUserMeetAudienceConditions(v4ProjectConfig, experiment, OTUtils.user(attributesWithNull), EXPERIMENT, experiment.getKey()).getResult());
 
         logbackVerifier.expectMessage(Level.DEBUG,
             "Starting to evaluate audience \"2196265320\" with conditions: [and, [or, [or, {name='nationality', type='custom_attribute', match='null', value='English'}, {name='nationality', type='custom_attribute', match='null', value=null}]]].");
@@ -279,7 +280,7 @@ public class ExperimentUtilsTest {
         Map<String, String> attributesEmpty = Collections.emptyMap();
 
         // It should explicitly be set to null otherwise we will return false on empty maps
-        assertFalse(doesUserMeetAudienceConditions(v4ProjectConfig, experiment, attributesEmpty, EXPERIMENT, experiment.getKey()).getResult());
+        assertFalse(doesUserMeetAudienceConditions(v4ProjectConfig, experiment, OTUtils.user(attributesEmpty), EXPERIMENT, experiment.getKey()).getResult());
 
         logbackVerifier.expectMessage(Level.DEBUG,
             "Starting to evaluate audience \"2196265320\" with conditions: [and, [or, [or, {name='nationality', type='custom_attribute', match='null', value='English'}, {name='nationality', type='custom_attribute', match='null', value=null}]]].");

--- a/core-api/src/test/java/com/optimizely/ab/optimizelyconfig/OptimizelyConfigServiceTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/optimizelyconfig/OptimizelyConfigServiceTest.java
@@ -334,7 +334,8 @@ public class OptimizelyConfigServiceTest {
                 )
             ),
             Collections.<Group>emptyList(),
-            Collections.<Rollout>emptyList()
+            Collections.<Rollout>emptyList(),
+            Collections.<Integration>emptyList()
         );
     }
 

--- a/core-api/src/test/java/com/optimizely/ab/testutils/OTUtils.java
+++ b/core-api/src/test/java/com/optimizely/ab/testutils/OTUtils.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 import java.util.Map;
 
 public class OTUtils {
-    public static OptimizelyUserContext user(String userId, Map<String,?> attributes) {
+    public static OptimizelyUserContext user(String userId, Map<String, ?> attributes) {
         Optimizely optimizely = new Optimizely.Builder().build();
         return new OptimizelyUserContext(optimizely, userId, attributes);
     }

--- a/core-api/src/test/java/com/optimizely/ab/testutils/OTUtils.java
+++ b/core-api/src/test/java/com/optimizely/ab/testutils/OTUtils.java
@@ -1,7 +1,23 @@
+/**
+ *
+ *    Copyright 2022, Optimizely and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package com.optimizely.ab.testutils;
 
 import com.optimizely.ab.*;
-
+import java.util.Collections;
 import java.util.Map;
 
 public class OTUtils {
@@ -12,5 +28,9 @@ public class OTUtils {
 
     public static OptimizelyUserContext user(Map<String,?> attributes) {
         return user("any-user", attributes);
+    }
+
+    public static OptimizelyUserContext user() {
+        return user("any-user", Collections.emptyMap());
     }
 }

--- a/core-api/src/test/java/com/optimizely/ab/testutils/OTUtils.java
+++ b/core-api/src/test/java/com/optimizely/ab/testutils/OTUtils.java
@@ -1,0 +1,16 @@
+package com.optimizely.ab.testutils;
+
+import com.optimizely.ab.*;
+
+import java.util.Map;
+
+public class OTUtils {
+    public static OptimizelyUserContext user(String userId, Map<String,?> attributes) {
+        Optimizely optimizely = new Optimizely.Builder().build();
+        return new OptimizelyUserContext(optimizely, userId, attributes);
+    }
+
+    public static OptimizelyUserContext user(Map<String,?> attributes) {
+        return user("any-user", attributes);
+    }
+}

--- a/core-api/src/test/resources/config/valid-project-config-v4.json
+++ b/core-api/src/test/resources/config/valid-project-config-v4.json
@@ -945,5 +945,12 @@
         }
       ]
     }
+  ],
+  "integrations": [
+    {
+      "key": "odp",
+      "host": "https://example.com",
+      "publicKey": "test-key"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
1. Added ODP Segments support in Audience evaluation
2. Adding logic to parse Integrations from datafile and make odp host and key available in projectConfig.

## Test plan
- Manually tested thoroughly.
- Added New unit tests.
- Existing unit tests pass.
- Existing Full stack compatibility tests pass.

## JIRA
[OASIS-8382](https://optimizely.atlassian.net/browse/OASIS-8382)