### PR TITLE
feat: Added support to get All segments used in the project

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/config/DatafileProjectConfig.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/DatafileProjectConfig.java
@@ -74,6 +74,7 @@ public class DatafileProjectConfig implements ProjectConfig {
     private final List<Group> groups;
     private final List<Rollout> rollouts;
     private final List<Integration> integrations;
+    private final Set<String> allSegments;
 
     // key to entity mappings
     private final Map<String, Attribute> attributeKeyMapping;
@@ -203,6 +204,15 @@ public class DatafileProjectConfig implements ProjectConfig {
 
         this.publicKeyForODP = publicKeyForODP;
         this.hostForODP = hostForODP;
+
+        Set<String> allSegments = new HashSet<>();
+        if (typedAudiences != null) {
+            for(Audience audience: typedAudiences) {
+                allSegments.addAll(audience.getSegments());
+            }
+        }
+
+        this.allSegments = allSegments;
 
         Map<String, Experiment> variationIdToExperimentMap = new HashMap<String, Experiment>();
         for (Experiment experiment : this.experiments) {

--- a/core-api/src/main/java/com/optimizely/ab/config/DatafileProjectConfig.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/DatafileProjectConfig.java
@@ -434,6 +434,10 @@ public class DatafileProjectConfig implements ProjectConfig {
         return experiments;
     }
 
+    public Set<String> getAllSegments() {
+        return this.allSegments;
+    }
+
     @Override
     public List<Experiment> getExperimentsForEventKey(String eventKey) {
         EventType event = eventNameMapping.get(eventKey);

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/AndCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/AndCondition.java
@@ -38,6 +38,7 @@ public class AndCondition<T> implements Condition<T> {
         this.conditions = conditions;
     }
 
+    @Override
     public List<Condition> getConditions() {
         return conditions;
     }

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/Audience.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/Audience.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2016-2017, 2019, Optimizely and contributors
+ *    Copyright 2016-2017, 2019, 2022, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/AudienceIdCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/AudienceIdCondition.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -95,6 +96,11 @@ public class AudienceIdCondition<T> implements Condition<T> {
             (audience.getId().equals(condition.audience != null ? condition.audience.getId() : null))) &&
             ((audienceId == null) ? (null == condition.audienceId) :
                 (audienceId.equals(condition.audienceId)));
+    }
+
+    @Override
+    public List<Condition> getConditions() {
+        return null;
     }
 
     @Override

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/Condition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/Condition.java
@@ -20,6 +20,7 @@ import com.optimizely.ab.OptimizelyUserContext;
 import com.optimizely.ab.config.ProjectConfig;
 
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -33,4 +34,6 @@ public interface Condition<T> {
     String toJson();
 
     String getOperandOrId();
+
+    List<Condition> getConditions();
 }

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/EmptyCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/EmptyCondition.java
@@ -21,7 +21,7 @@ import com.optimizely.ab.config.ProjectConfig;
 import javax.annotation.Nullable;
 import java.util.Map;
 
-public class EmptyCondition<T> implements Condition<T> {
+public class EmptyCondition<T> extends LeafCondition<T> {
     @Nullable
     @Override
     public Boolean evaluate(ProjectConfig config, OptimizelyUserContext user) {

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/LeafCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/LeafCondition.java
@@ -1,0 +1,11 @@
+package com.optimizely.ab.config.audience;
+
+import java.util.List;
+
+public abstract class LeafCondition<T> implements Condition<T> {
+
+    @Override
+    public List<Condition> getConditions() {
+        return null;
+    }
+}

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/LeafCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/LeafCondition.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2022, Optimizely Inc. and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package com.optimizely.ab.config.audience;
 
 import java.util.List;

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/NotCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/NotCondition.java
@@ -22,6 +22,8 @@ import com.optimizely.ab.config.ProjectConfig;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.List;
 
 
 /**
@@ -39,6 +41,11 @@ public class NotCondition<T> implements Condition<T> {
 
     public Condition getCondition() {
         return condition;
+    }
+
+    @Override
+    public List<Condition> getConditions() {
+        return Arrays.asList(condition);
     }
 
     @Nullable

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/NullCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/NullCondition.java
@@ -21,7 +21,7 @@ import com.optimizely.ab.config.ProjectConfig;
 import javax.annotation.Nullable;
 import java.util.Map;
 
-public class NullCondition<T> implements Condition<T> {
+public class NullCondition<T> extends LeafCondition<T> {
     @Nullable
     @Override
     public Boolean evaluate(ProjectConfig config, OptimizelyUserContext user) {

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/OrCondition.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/OrCondition.java
@@ -38,6 +38,7 @@ public class OrCondition<T> implements Condition<T> {
         this.conditions = conditions;
     }
 
+    @Override
     public List<Condition> getConditions() {
         return conditions;
     }

--- a/core-api/src/main/java/com/optimizely/ab/config/audience/UserAttribute.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/audience/UserAttribute.java
@@ -38,7 +38,7 @@ import static com.optimizely.ab.config.audience.AttributeType.THIRD_PARTY_DIMENS
  */
 @Immutable
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class UserAttribute<T> implements Condition<T> {
+public class UserAttribute<T> extends LeafCondition<T> {
     public static final String QUALIFIED = "qualified";
 
     private static final Logger logger = LoggerFactory.getLogger(UserAttribute.class);

--- a/core-api/src/test/java/com/optimizely/ab/config/audience/AudienceConditionEvaluationTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/audience/AudienceConditionEvaluationTest.java
@@ -1840,4 +1840,40 @@ public class AudienceConditionEvaluationTest {
         assertNull(nullValueAttribute.evaluate(null, OTUtils.user(Collections.singletonMap(attributeName, attributeValue))));
         assertNull(nullValueAttribute.evaluate(null, OTUtils.user((Collections.singletonMap(attributeName, "")))));
     }
+
+    @Test
+    public void getAllSegmentsFromAudience() {
+        Condition condition = createMultipleConditionAudienceAndOrODP();
+        Audience audience = new Audience("1", "testAudience", condition);
+        assertEquals(new HashSet<>(Arrays.asList("odp-segment-1", "odp-segment-2", "odp-segment-3", "odp-segment-4")), audience.getSegments());
+
+        // ["and", "1", "2"]
+        List<Condition> audience1And2 = new ArrayList<>();
+        audience1And2.add(new UserAttribute("odp.audiences", "third_party_dimension", "qualified", "odp-segment-1"));
+        audience1And2.add(new UserAttribute("odp.audiences", "third_party_dimension", "qualified", "odp-segment-2"));
+        AndCondition audienceCondition1 = new AndCondition(audience1And2);
+
+        // ["and", "3", "4"]
+        List<Condition> audience3And4 = new ArrayList<>();
+        audience3And4.add(new UserAttribute("odp.audiences", "third_party_dimension", "qualified", "odp-segment-3"));
+        audience3And4.add(new UserAttribute("odp.audiences", "third_party_dimension", "qualified", "odp-segment-4"));
+        AndCondition audienceCondition2 = new AndCondition(audience3And4);
+
+        // ["or", "5", "6"]
+        List<Condition> audience5And6 = new ArrayList<>();
+        audience5And6.add(new UserAttribute("odp.audiences", "third_party_dimension", "qualified", "odp-segment-5"));
+        audience5And6.add(new UserAttribute("odp.audiences", "third_party_dimension", "qualified", "odp-segment-6"));
+        OrCondition audienceCondition3 = new OrCondition(audience5And6);
+
+
+        //['or', '1', '2', '3']
+        List<Condition> conditions = new ArrayList<>();
+        conditions.add(audienceCondition1);
+        conditions.add(audienceCondition2);
+        conditions.add(audienceCondition3);
+
+        OrCondition implicitOr = new OrCondition(conditions);
+        audience = new Audience("1", "testAudience", implicitOr);
+        assertEquals(new HashSet<>(Arrays.asList("odp-segment-1", "odp-segment-2", "odp-segment-3", "odp-segment-4", "odp-segment-5", "odp-segment-6")), audience.getSegments());
+    }
 }


### PR DESCRIPTION
## Summary
ODP Server needs a subset of segments to look for in the API call. This PR adds functionality to get all segments used in the project inside `DatafileProjectConfig`.

## Test plan
- Manually tested thoroughly
- Added Unit tests

## Jira
[OASIS-8383](https://optimizely.atlassian.net/browse/OASIS-8383)