### PR TITLE
chore: skip unit and fsc tests for snapshot and publish

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -30,12 +30,14 @@ jobs:
       run: find . -type f -name '*.md' -exec awesome_bot {} \;
   
   integration_tests:
+    if: ${{ startsWith(github.ref, 'refs/tags/') != true && github.event.inputs.SNAPSHOT != 'true' }}
     uses: optimizely/java-sdk/.github/workflows/integration_test.yml@mnoman/fsc-gitaction-test
     secrets:
       CI_USER_TOKEN: ${{ secrets.CI_USER_TOKEN }}
       TRAVIS_COM_TOKEN: ${{ secrets.TRAVIS_COM_TOKEN }}
       
   fullstack_production_suite:
+    if: ${{ startsWith(github.ref, 'refs/tags/') != true && github.event.inputs.SNAPSHOT != 'true' }}
     uses: optimizely/java-sdk/.github/workflows/integration_test.yml@master
     with:
       FULLSTACK_TEST_REPO: ProdTesting
@@ -44,7 +46,7 @@ jobs:
       TRAVIS_COM_TOKEN: ${{ secrets.TRAVIS_COM_TOKEN }}
   
   test:
-    if: startsWith(github.ref, 'refs/tags/') != true
+    if: ${{ startsWith(github.ref, 'refs/tags/') != true && github.event.inputs.SNAPSHOT != 'true' }}
     runs-on: macos-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
Fix github workflow to skip testing for SNAPSHOT and publish tasks.

## Issues
- FSSDK-0000