### PR TITLE
feat: Added configurable timeouts for fetchSegments and dispatch events ODP calls

### DIFF
--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/HttpClientUtils.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/HttpClientUtils.java
@@ -23,9 +23,11 @@ import org.apache.http.client.config.RequestConfig;
  */
 public final class HttpClientUtils {
 
-    private static final int CONNECTION_TIMEOUT_MS = 10000;
-    private static final int CONNECTION_REQUEST_TIMEOUT_MS = 5000;
-    private static final int SOCKET_TIMEOUT_MS = 10000;
+    public static final int CONNECTION_TIMEOUT_MS = 10000;
+    public static final int CONNECTION_REQUEST_TIMEOUT_MS = 5000;
+    public static final int SOCKET_TIMEOUT_MS = 10000;
+
+    private static RequestConfig requestConfigWithTimeout;
 
     private HttpClientUtils() {
     }
@@ -35,6 +37,17 @@ public final class HttpClientUtils {
         .setConnectionRequestTimeout(CONNECTION_REQUEST_TIMEOUT_MS)
         .setSocketTimeout(SOCKET_TIMEOUT_MS)
         .build();
+
+    public static RequestConfig getDefaultRequestConfigWithTimeout(int timeoutMillis) {
+        if (requestConfigWithTimeout == null) {
+            requestConfigWithTimeout = RequestConfig.custom()
+                .setConnectTimeout(timeoutMillis)
+                .setConnectionRequestTimeout(CONNECTION_REQUEST_TIMEOUT_MS)
+                .setSocketTimeout(SOCKET_TIMEOUT_MS)
+                .build();
+        }
+        return  requestConfigWithTimeout;
+    }
 
     public static OptimizelyHttpClient getDefaultHttpClient() {
         return OptimizelyHttpClient.builder().build();

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyHttpClient.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyHttpClient.java
@@ -19,6 +19,7 @@ package com.optimizely.ab;
 import com.optimizely.ab.annotations.VisibleForTesting;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -78,6 +79,7 @@ public class OptimizelyHttpClient implements Closeable {
         // force-close the connection after this idle time (with 0, eviction is disabled by default)
         long evictConnectionIdleTimePeriod = 0;
         TimeUnit evictConnectionIdleTimeUnit = TimeUnit.MILLISECONDS;
+        private int timeoutMillis = HttpClientUtils.CONNECTION_TIMEOUT_MS;
 
         private Builder() {
 
@@ -103,6 +105,11 @@ public class OptimizelyHttpClient implements Closeable {
             this.evictConnectionIdleTimeUnit = maxIdleTimeUnit;
             return this;
         }
+        
+        public Builder setTimeoutMillis(int timeoutMillis) {
+            this.timeoutMillis = timeoutMillis;
+            return this;
+        }
 
         public OptimizelyHttpClient build() {
             PoolingHttpClientConnectionManager poolingHttpClientConnectionManager = new PoolingHttpClientConnectionManager();
@@ -111,7 +118,7 @@ public class OptimizelyHttpClient implements Closeable {
             poolingHttpClientConnectionManager.setValidateAfterInactivity(validateAfterInactivity);
 
             HttpClientBuilder builder = HttpClients.custom()
-                .setDefaultRequestConfig(HttpClientUtils.DEFAULT_REQUEST_CONFIG)
+                .setDefaultRequestConfig(HttpClientUtils.getDefaultRequestConfigWithTimeout(timeoutMillis))
                 .setConnectionManager(poolingHttpClientConnectionManager)
                 .disableCookieManagement()
                 .useSystemProperties();

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyHttpClient.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyHttpClient.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2019, Optimizely
+ *    Copyright 2019, 2022 Optimizely
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,13 +19,14 @@ package com.optimizely.ab;
 import com.optimizely.ab.annotations.VisibleForTesting;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.ResponseHandler;
-import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -38,6 +39,8 @@ import java.util.concurrent.TimeUnit;
  * TODO abstract out interface and move into core?
  */
 public class OptimizelyHttpClient implements Closeable {
+
+    private static final Logger logger = LoggerFactory.getLogger(OptimizelyHttpClient.class);
 
     private final CloseableHttpClient httpClient;
 
@@ -122,6 +125,8 @@ public class OptimizelyHttpClient implements Closeable {
                 .setConnectionManager(poolingHttpClientConnectionManager)
                 .disableCookieManagement()
                 .useSystemProperties();
+
+            logger.debug("Creating HttpClient with timeout: " + timeoutMillis);
 
             if (evictConnectionIdleTimePeriod > 0) {
                 builder.evictIdleConnections(evictConnectionIdleTimePeriod, evictConnectionIdleTimeUnit);

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/odp/DefaultODPApiManagerTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/odp/DefaultODPApiManagerTest.java
@@ -28,7 +28,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 
@@ -128,5 +127,21 @@ public class DefaultODPApiManagerTest {
         ODPApiManager apiManager = new DefaultODPApiManager(mockHttpClient);
         apiManager.sendEvents("testKey", "testEndpoint", "[]]");
         logbackVerifier.expectMessage(Level.ERROR, "ODP event send failed (Response code: 400, null)");
+    }
+
+    @Test
+    public void apiTimeouts() {
+        // Default timeout is 10 seconds
+        new DefaultODPApiManager();
+        logbackVerifier.expectMessage(Level.DEBUG, "Creating HttpClient with timeout: 10000", 1);
+
+        // Same timeouts result in single httpclient
+        new DefaultODPApiManager(2222, 2222);
+        logbackVerifier.expectMessage(Level.DEBUG, "Creating HttpClient with timeout: 2222", 1);
+
+        // Different timeouts result in different HttpClients
+        new DefaultODPApiManager(3333, 4444);
+        logbackVerifier.expectMessage(Level.DEBUG, "Creating HttpClient with timeout: 3333", 1);
+        logbackVerifier.expectMessage(Level.DEBUG, "Creating HttpClient with timeout: 4444", 1);
     }
 }


### PR DESCRIPTION
## Summary
Added configurable timeouts for fetchSegments and dispatch events ODP calls. The default timeout is 10s.

## Test plan
- Manually tested thoroughly
- All test pass

## Issues
[FSSDK-8689](https://jira.sso.episerver.net/browse/FSSDK-8689)