### PR TITLE
fix: Fixed ODP Event type and Json Parser log levels

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/internal/JsonParserProvider.java
+++ b/core-api/src/main/java/com/optimizely/ab/internal/JsonParserProvider.java
@@ -64,7 +64,7 @@ public enum JsonParserProvider {
                 continue;
             }
 
-            logger.info("using json parser: {}", parser.className);
+            logger.debug("using json parser: {}", parser.className);
             return parser;
         }
 

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
@@ -91,7 +91,7 @@ public class ODPEventManager {
         if (userId != null) {
             identifiers.put(ODPUserKey.FS_USER_ID.getKeyString(), userId);
         }
-        ODPEvent event = new ODPEvent("fullstack", "client_initialized", identifiers, null);
+        ODPEvent event = new ODPEvent("fullstack", "identified", identifiers, null);
         sendEvent(event);
     }
 

--- a/core-api/src/main/java/com/optimizely/ab/odp/parser/ResponseJsonParserFactory.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/parser/ResponseJsonParserFactory.java
@@ -43,7 +43,7 @@ public class ResponseJsonParserFactory {
                 jsonParser = new JsonSimpleParser();
                 break;
         }
-        logger.info("Using " + parserProvider.toString() + " parser");
+        logger.debug("Using " + parserProvider.toString() + " parser");
         return jsonParser;
     }
 }

--- a/core-api/src/test/java/com/optimizely/ab/odp/ODPEventManagerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/odp/ODPEventManagerTest.java
@@ -204,7 +204,7 @@ public class ODPEventManagerTest {
         for (int i = 0; i < events.length(); i++) {
             JSONObject event = events.getJSONObject(i);
             assertEquals("fullstack", event.getString("type"));
-            assertEquals("client_initialized", event.getString("action"));
+            assertEquals("identified", event.getString("action"));
             assertEquals("the-vuid-" + i, event.getJSONObject("identifiers").getString("vuid"));
             assertEquals("the-fs-user-id-" + i, event.getJSONObject("identifiers").getString("fs_user_id"));
             assertEquals("sdk", event.getJSONObject("data").getString("data_source_type"));


### PR DESCRIPTION
## Summary
1. Changed default event type from `client_initialized` to `identified`.
2. Changed Parser log levels from `info` to `debug`.

## Test plan
- Manually tested thoroughly.
- All existing unit tests and FSC test pass.

## Issues
https://jira.sso.episerver.net/browse/FSSDK-8725
https://jira.sso.episerver.net/browse/FSSDK-8726