### PR TITLE
fix: Made ODP Event Dispatcher thread a daemon

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
@@ -68,7 +68,13 @@ public class ODPEventManager {
             eventDispatcherThread = new EventDispatcherThread();
         }
         if (!isRunning) {
-            eventDispatcherThread.start();
+            final ThreadFactory threadFactory = Executors.defaultThreadFactory();
+            ExecutorService executor = Executors.newSingleThreadExecutor(runnable -> {
+                Thread thread = threadFactory.newThread(runnable);
+                thread.setDaemon(true);
+                return thread;
+            });
+            executor.submit(eventDispatcherThread);
         }
         isRunning = true;
     }
@@ -159,7 +165,7 @@ public class ODPEventManager {
                     if (currentBatch.size() > 0) {
                         nextEvent = eventQueue.poll(nextFlushTime - new Date().getTime(), TimeUnit.MILLISECONDS);
                     } else {
-                        nextEvent = eventQueue.poll();
+                        nextEvent = eventQueue.take();
                     }
 
                     if (nextEvent == null) {


### PR DESCRIPTION
## Summary
The ODP Event Dispatcher thread was not terminating with the application unless closed explicitly. Converted the thread to a daemon so that it stops when the main app exits.

## Test plan
- Manually tested thoroughly
- All existing tests pass

## Issues
[FSSDK-8727](https://jira.sso.episerver.net/browse/FSSDK-8727)