### PR TITLE
Fix: Added notificationRegistry to make sure that odpSettings updates

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -129,7 +129,7 @@ public class Optimizely implements AutoCloseable {
                 updateODPSettings();
             }
             if (projectConfigManager != null) {
-                NotificationRegistry.getNotificationCenter(projectConfigManager.getSDKKey()).
+                NotificationRegistry.getInternalNotificationCenter(projectConfigManager.getSDKKey()).
                     addNotificationHandler(UpdateConfigNotification.class,
                         configNotification -> { updateODPSettings(); });
             }

--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -125,10 +125,10 @@ public class Optimizely implements AutoCloseable {
 
         if (odpManager != null) {
             odpManager.getEventManager().start();
-            if (!(projectConfigManager instanceof PollingProjectConfigManager)) {
+            if (projectConfigManager.getCachedConfig() != null) {
                 updateODPSettings();
             }
-            if (projectConfigManager != null && projectConfigManager.getSDKKey() != null) {
+            if (projectConfigManager.getSDKKey() != null) {
                 NotificationRegistry.getInternalNotificationCenter(projectConfigManager.getSDKKey()).
                     addNotificationHandler(UpdateConfigNotification.class,
                         configNotification -> { updateODPSettings(); });
@@ -1485,8 +1485,8 @@ public class Optimizely implements AutoCloseable {
     }
 
     private void updateODPSettings() {
-        if (odpManager != null && getProjectConfig() != null) {
-            ProjectConfig projectConfig = getProjectConfig();
+        ProjectConfig projectConfig = projectConfigManager.getCachedConfig();
+        if (odpManager != null && projectConfig != null) {
             odpManager.updateSettings(projectConfig.getHostForODP(), projectConfig.getPublicKeyForODP(), projectConfig.getAllSegments());
         }
     }

--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -125,10 +125,10 @@ public class Optimizely implements AutoCloseable {
 
         if (odpManager != null) {
             odpManager.getEventManager().start();
-            if (getProjectConfig() != null) {
+            if (!(projectConfigManager instanceof PollingProjectConfigManager)) {
                 updateODPSettings();
             }
-            if (projectConfigManager != null) {
+            if (projectConfigManager != null && projectConfigManager.getSDKKey() != null) {
                 NotificationRegistry.getInternalNotificationCenter(projectConfigManager.getSDKKey()).
                     addNotificationHandler(UpdateConfigNotification.class,
                         configNotification -> { updateODPSettings(); });
@@ -159,7 +159,8 @@ public class Optimizely implements AutoCloseable {
         tryClose(eventProcessor);
         tryClose(eventHandler);
         tryClose(projectConfigManager);
-        NotificationRegistry.clearNotificationCenterRegistry();
+        notificationCenter.clearAllNotificationListeners();
+        NotificationRegistry.clearNotificationCenterRegistry(projectConfigManager.getSDKKey());
         if (odpManager != null) {
             tryClose(odpManager);
         }

--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -27,6 +27,7 @@ import com.optimizely.ab.error.NoOpErrorHandler;
 import com.optimizely.ab.event.*;
 import com.optimizely.ab.event.internal.*;
 import com.optimizely.ab.event.internal.payload.EventBatch;
+import com.optimizely.ab.internal.NotificationRegistry;
 import com.optimizely.ab.notification.*;
 import com.optimizely.ab.odp.*;
 import com.optimizely.ab.optimizelyconfig.OptimizelyConfig;
@@ -127,7 +128,12 @@ public class Optimizely implements AutoCloseable {
             if (getProjectConfig() != null) {
                 updateODPSettings();
             }
-            addUpdateConfigNotificationHandler(configNotification -> { updateODPSettings(); });
+            if (projectConfigManager != null) {
+                NotificationRegistry.getNotificationCenter(projectConfigManager.getSDKKey()).
+                    addNotificationHandler(UpdateConfigNotification.class,
+                        configNotification -> { updateODPSettings(); });
+            }
+
         }
     }
 
@@ -153,6 +159,7 @@ public class Optimizely implements AutoCloseable {
         tryClose(eventProcessor);
         tryClose(eventHandler);
         tryClose(projectConfigManager);
+        NotificationRegistry.clearNotificationCenterRegistry();
         if (odpManager != null) {
             tryClose(odpManager);
         }

--- a/core-api/src/main/java/com/optimizely/ab/config/AtomicProjectConfigManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/AtomicProjectConfigManager.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2019, Optimizely and contributors
+ *    Copyright 2019, 2023, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/AtomicProjectConfigManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/AtomicProjectConfigManager.java
@@ -27,6 +27,11 @@ public class AtomicProjectConfigManager implements ProjectConfigManager {
         return projectConfigReference.get();
     }
 
+    @Override
+    public String getSDKKey() {
+        return "";
+    }
+
     public void setConfig(ProjectConfig projectConfig) {
         projectConfigReference.set(projectConfig);
     }

--- a/core-api/src/main/java/com/optimizely/ab/config/AtomicProjectConfigManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/AtomicProjectConfigManager.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2019, Optimizely and contributors
+ *    Copyright 2019, 2023, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,6 +24,16 @@ public class AtomicProjectConfigManager implements ProjectConfigManager {
 
     @Override
     public ProjectConfig getConfig() {
+        return projectConfigReference.get();
+    }
+
+    /**
+     * Access to current cached project configuration.
+     *
+     * @return {@link ProjectConfig}
+     */
+    @Override
+    public ProjectConfig getCachedConfig() {
         return projectConfigReference.get();
     }
 

--- a/core-api/src/main/java/com/optimizely/ab/config/AtomicProjectConfigManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/AtomicProjectConfigManager.java
@@ -27,11 +27,6 @@ public class AtomicProjectConfigManager implements ProjectConfigManager {
         return projectConfigReference.get();
     }
 
-    @Override
-    public String getSDKKey() {
-        return "";
-    }
-
     public void setConfig(ProjectConfig projectConfig) {
         projectConfigReference.set(projectConfig);
     }

--- a/core-api/src/main/java/com/optimizely/ab/config/AtomicProjectConfigManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/AtomicProjectConfigManager.java
@@ -37,6 +37,11 @@ public class AtomicProjectConfigManager implements ProjectConfigManager {
         return projectConfigReference.get();
     }
 
+    @Override
+    public String getSDKKey() {
+        return null;
+    }
+
     public void setConfig(ProjectConfig projectConfig) {
         projectConfigReference.set(projectConfig);
     }

--- a/core-api/src/main/java/com/optimizely/ab/config/AtomicProjectConfigManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/AtomicProjectConfigManager.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2019, 2023, Optimizely and contributors
+ *    Copyright 2019, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java
@@ -86,6 +86,16 @@ public abstract class PollingProjectConfigManager implements ProjectConfigManage
     protected abstract ProjectConfig poll();
 
     /**
+     * Access to current cached project configuration, This is to make sure that config returns without any wait, even if it is null.
+     *
+     * @return {@link ProjectConfig}
+     */
+    @Override
+    public ProjectConfig getCachedConfig() {
+        return currentProjectConfig.get();
+    }
+
+    /**
      * Only allow the ProjectConfig to be set to a non-null value, if and only if the value has not already been set.
      * @param projectConfig
      */

--- a/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java
@@ -110,7 +110,9 @@ public abstract class PollingProjectConfigManager implements ProjectConfigManage
         currentProjectConfig.set(projectConfig);
         currentOptimizelyConfig.set(new OptimizelyConfigService(projectConfig).getConfig());
         countDownLatch.countDown();
-        NotificationRegistry.getInternalNotificationCenter(projectConfig.getSdkKey()).send(SIGNAL);
+        if (projectConfig.getSdkKey() != null) {
+            NotificationRegistry.getInternalNotificationCenter(projectConfig.getSdkKey()).send(SIGNAL);
+        }
         notificationCenter.send(SIGNAL);
     }
 

--- a/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java
@@ -57,6 +57,7 @@ public abstract class PollingProjectConfigManager implements ProjectConfigManage
 
     private final CountDownLatch countDownLatch = new CountDownLatch(1);
 
+    private volatile String sdkKey;
     private volatile boolean started;
     private ScheduledFuture<?> scheduledFuture;
 
@@ -120,8 +121,9 @@ public abstract class PollingProjectConfigManager implements ProjectConfigManage
         currentProjectConfig.set(projectConfig);
         currentOptimizelyConfig.set(new OptimizelyConfigService(projectConfig).getConfig());
         countDownLatch.countDown();
-        if (projectConfig.getSdkKey() != null) {
-            NotificationRegistry.getInternalNotificationCenter(projectConfig.getSdkKey()).send(SIGNAL);
+
+        if (sdkKey != null) {
+            NotificationRegistry.getInternalNotificationCenter(sdkKey).send(SIGNAL);
         }
         notificationCenter.send(SIGNAL);
     }
@@ -201,6 +203,10 @@ public abstract class PollingProjectConfigManager implements ProjectConfigManage
         stop();
         scheduledExecutorService.shutdownNow();
         started = false;
+    }
+
+    protected void setSdkKey(String sdkKey) {
+        this.sdkKey = sdkKey;
     }
 
     public boolean isRunning() {

--- a/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java
@@ -16,6 +16,7 @@
  */
 package com.optimizely.ab.config;
 
+import com.optimizely.ab.internal.NotificationRegistry;
 import com.optimizely.ab.notification.NotificationCenter;
 import com.optimizely.ab.notification.UpdateConfigNotification;
 import com.optimizely.ab.optimizelyconfig.OptimizelyConfig;
@@ -109,6 +110,7 @@ public abstract class PollingProjectConfigManager implements ProjectConfigManage
         currentProjectConfig.set(projectConfig);
         currentOptimizelyConfig.set(new OptimizelyConfigService(projectConfig).getConfig());
         countDownLatch.countDown();
+        NotificationRegistry.getNotificationCenter(projectConfig.getSdkKey()).send(SIGNAL);
         notificationCenter.send(SIGNAL);
     }
 

--- a/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2019-2020, Optimizely and contributors
+ *    Copyright 2019-2020, 2023, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java
@@ -122,6 +122,9 @@ public abstract class PollingProjectConfigManager implements ProjectConfigManage
         currentOptimizelyConfig.set(new OptimizelyConfigService(projectConfig).getConfig());
         countDownLatch.countDown();
 
+        if (sdkKey == null) {
+            sdkKey = projectConfig.getSdkKey();
+        }
         if (sdkKey != null) {
             NotificationRegistry.getInternalNotificationCenter(sdkKey).send(SIGNAL);
         }

--- a/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java
@@ -110,7 +110,7 @@ public abstract class PollingProjectConfigManager implements ProjectConfigManage
         currentProjectConfig.set(projectConfig);
         currentOptimizelyConfig.set(new OptimizelyConfigService(projectConfig).getConfig());
         countDownLatch.countDown();
-        NotificationRegistry.getNotificationCenter(projectConfig.getSdkKey()).send(SIGNAL);
+        NotificationRegistry.getInternalNotificationCenter(projectConfig.getSdkKey()).send(SIGNAL);
         notificationCenter.send(SIGNAL);
     }
 

--- a/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/PollingProjectConfigManager.java
@@ -169,6 +169,11 @@ public abstract class PollingProjectConfigManager implements ProjectConfigManage
         return currentOptimizelyConfig.get();
     }
 
+    @Override
+    public String getSDKKey() {
+        return this.sdkKey;
+    }
+
     public synchronized void start() {
         if (started) {
             logger.warn("Manager already started.");

--- a/core-api/src/main/java/com/optimizely/ab/config/ProjectConfigManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/ProjectConfigManager.java
@@ -24,6 +24,14 @@ public interface ProjectConfigManager {
      */
     ProjectConfig getConfig();
 
+    /**
+     * Implementations of this method should not block until a datafile is available, instead return current cached project configuration.
+     *
+     * NOTE: To use ODP segments, implementation of this function is required to return current project configuration.
+     * @return ProjectConfig
+     */
+    default ProjectConfig getCachedConfig() { return null; }
+
     default String getSDKKey() {
         return null;
     }

--- a/core-api/src/main/java/com/optimizely/ab/config/ProjectConfigManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/ProjectConfigManager.java
@@ -23,5 +23,7 @@ public interface ProjectConfigManager {
      * @return ProjectConfig
      */
     ProjectConfig getConfig();
+
+    String getSDKKey();
 }
 

--- a/core-api/src/main/java/com/optimizely/ab/config/ProjectConfigManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/ProjectConfigManager.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2019, Optimizely and contributors
+ *    Copyright 2019, 2023, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/config/ProjectConfigManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/ProjectConfigManager.java
@@ -16,6 +16,8 @@
  */
 package com.optimizely.ab.config;
 
+import javax.annotation.Nullable;
+
 public interface ProjectConfigManager {
     /**
      * Implementations of this method should block until a datafile is available.
@@ -26,10 +28,12 @@ public interface ProjectConfigManager {
 
     /**
      * Implementations of this method should not block until a datafile is available, instead return current cached project configuration.
+     * return null if ProjectConfig is not ready at the moment.
      *
      * NOTE: To use ODP segments, implementation of this function is required to return current project configuration.
      * @return ProjectConfig
      */
+    @Nullable
     ProjectConfig getCachedConfig();
 
     /**
@@ -38,6 +42,7 @@ public interface ProjectConfigManager {
      * NOTE: To update ODP segments configuration via polling, it is required to return sdkKey.
      * @return String
      */
+    @Nullable
     String getSDKKey();
 }
 

--- a/core-api/src/main/java/com/optimizely/ab/config/ProjectConfigManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/ProjectConfigManager.java
@@ -32,8 +32,12 @@ public interface ProjectConfigManager {
      */
     ProjectConfig getCachedConfig();
 
-    default String getSDKKey() {
-        return null;
-    }
+    /**
+     * Implementations of this method should return SDK key. If there is no SDKKey then it should return null.
+     *
+     * NOTE: To update ODP segments configuration via polling, it is required to return sdkKey.
+     * @return String
+     */
+    String getSDKKey();
 }
 

--- a/core-api/src/main/java/com/optimizely/ab/config/ProjectConfigManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/ProjectConfigManager.java
@@ -24,6 +24,8 @@ public interface ProjectConfigManager {
      */
     ProjectConfig getConfig();
 
-    String getSDKKey();
+    default String getSDKKey() {
+        return null;
+    }
 }
 

--- a/core-api/src/main/java/com/optimizely/ab/config/ProjectConfigManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/ProjectConfigManager.java
@@ -30,7 +30,7 @@ public interface ProjectConfigManager {
      * NOTE: To use ODP segments, implementation of this function is required to return current project configuration.
      * @return ProjectConfig
      */
-    default ProjectConfig getCachedConfig() { return null; }
+    ProjectConfig getCachedConfig();
 
     default String getSDKKey() {
         return null;

--- a/core-api/src/main/java/com/optimizely/ab/internal/NotificationRegistry.java
+++ b/core-api/src/main/java/com/optimizely/ab/internal/NotificationRegistry.java
@@ -1,0 +1,52 @@
+/**
+ *
+ *    Copyright 2023, Optimizely
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.optimizely.ab.internal;
+
+import com.optimizely.ab.notification.NotificationCenter;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class NotificationRegistry {
+    private final static Map<String, NotificationCenter> _notificationCenters = new ConcurrentHashMap<>();
+
+    private NotificationRegistry()
+    {
+    }
+
+    public static NotificationCenter getNotificationCenter(@Nonnull String sdkKey)
+    {
+        if (sdkKey == null) {
+            sdkKey = "";
+        }
+
+        NotificationCenter notificationCenter;
+        if (_notificationCenters.containsKey(sdkKey)) {
+            notificationCenter = _notificationCenters.get(sdkKey);
+        } else {
+            notificationCenter = new NotificationCenter();
+            _notificationCenters.put(sdkKey, notificationCenter);
+        }
+        return notificationCenter;
+    }
+
+    public static void clearNotificationCenterRegistry() {
+        _notificationCenters.clear();
+    }
+
+}

--- a/core-api/src/main/java/com/optimizely/ab/internal/NotificationRegistry.java
+++ b/core-api/src/main/java/com/optimizely/ab/internal/NotificationRegistry.java
@@ -29,7 +29,7 @@ public class NotificationRegistry {
     {
     }
 
-    public static NotificationCenter getNotificationCenter(@Nonnull String sdkKey)
+    public static NotificationCenter getInternalNotificationCenter(@Nonnull String sdkKey)
     {
         if (sdkKey == null) {
             sdkKey = "";

--- a/core-api/src/main/java/com/optimizely/ab/internal/NotificationRegistry.java
+++ b/core-api/src/main/java/com/optimizely/ab/internal/NotificationRegistry.java
@@ -31,22 +31,22 @@ public class NotificationRegistry {
 
     public static NotificationCenter getInternalNotificationCenter(@Nonnull String sdkKey)
     {
-        if (sdkKey == null) {
-            sdkKey = "";
-        }
-
-        NotificationCenter notificationCenter;
-        if (_notificationCenters.containsKey(sdkKey)) {
-            notificationCenter = _notificationCenters.get(sdkKey);
-        } else {
-            notificationCenter = new NotificationCenter();
-            _notificationCenters.put(sdkKey, notificationCenter);
+        NotificationCenter notificationCenter = null;
+        if (sdkKey != null) {
+            if (_notificationCenters.containsKey(sdkKey)) {
+                notificationCenter = _notificationCenters.get(sdkKey);
+            } else {
+                notificationCenter = new NotificationCenter();
+                _notificationCenters.put(sdkKey, notificationCenter);
+            }
         }
         return notificationCenter;
     }
 
-    public static void clearNotificationCenterRegistry() {
-        _notificationCenters.clear();
+    public static void clearNotificationCenterRegistry(@Nonnull String sdkKey) {
+        if (sdkKey != null) {
+            _notificationCenters.remove(sdkKey);
+        }
     }
 
 }

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2016-2022, Optimizely, Inc. and contributors                   *
+ * Copyright 2016-2023, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -129,6 +129,11 @@ public class OptimizelyTest {
         public ProjectConfig getCachedConfig() {
             return null;
         }
+
+        @Override
+        public String getSDKKey() {
+            return null;
+        }
     };
 
     @Rule

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2016-2023, Optimizely, Inc. and contributors                   *
+ * Copyright 2016-2022, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -4505,13 +4505,13 @@ public class OptimizelyTest {
 
     @Test
     public void testGetNotificationCenter() {
-        Optimizely optimizely = optimizelyBuilder.withConfigManager(new TestProjectConfigManager()).build();
+        Optimizely optimizely = optimizelyBuilder.withConfigManager(() -> null).build();
         assertEquals(optimizely.notificationCenter, optimizely.getNotificationCenter());
     }
 
     @Test
     public void testAddTrackNotificationHandler() {
-        Optimizely optimizely = optimizelyBuilder.withConfigManager(new TestProjectConfigManager()).build();
+        Optimizely optimizely = optimizelyBuilder.withConfigManager(() -> null).build();
         NotificationManager<TrackNotification> manager = optimizely.getNotificationCenter()
             .getNotificationManager(TrackNotification.class);
 
@@ -4521,7 +4521,7 @@ public class OptimizelyTest {
 
     @Test
     public void testAddDecisionNotificationHandler() {
-        Optimizely optimizely = optimizelyBuilder.withConfigManager(new TestProjectConfigManager()).build();
+        Optimizely optimizely = optimizelyBuilder.withConfigManager(() -> null).build();
         NotificationManager<DecisionNotification> manager = optimizely.getNotificationCenter()
             .getNotificationManager(DecisionNotification.class);
 
@@ -4531,7 +4531,7 @@ public class OptimizelyTest {
 
     @Test
     public void testAddUpdateConfigNotificationHandler() {
-        Optimizely optimizely = optimizelyBuilder.withConfigManager(new TestProjectConfigManager()).build();
+        Optimizely optimizely = optimizelyBuilder.withConfigManager(() -> null).build();
         NotificationManager<UpdateConfigNotification> manager = optimizely.getNotificationCenter()
             .getNotificationManager(UpdateConfigNotification.class);
 
@@ -4541,7 +4541,7 @@ public class OptimizelyTest {
 
     @Test
     public void testAddLogEventNotificationHandler() {
-        Optimizely optimizely = optimizelyBuilder.withConfigManager(new TestProjectConfigManager()).build();
+        Optimizely optimizely = optimizelyBuilder.withConfigManager(() -> null).build();
         NotificationManager<LogEvent> manager = optimizely.getNotificationCenter()
             .getNotificationManager(LogEvent.class);
 
@@ -4781,17 +4781,5 @@ public class OptimizelyTest {
         Mockito.verify(mockODPEventManager, times(1)).identifyUser("the-user");
     }
 
-    public static class TestProjectConfigManager implements ProjectConfigManager {
-
-        @Override
-        public ProjectConfig getConfig() {
-            return null;
-        }
-
-        @Override
-        public String getSDKKey() {
-            return null;
-        }
-    }
 }
 

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -119,6 +119,18 @@ public class OptimizelyTest {
     public OptimizelyRule optimizelyBuilder = new OptimizelyRule();
     public EventHandlerRule eventHandler = new EventHandlerRule();
 
+    public ProjectConfigManager projectConfigManagerReturningNull = new ProjectConfigManager() {
+        @Override
+        public ProjectConfig getConfig() {
+            return null;
+        }
+
+        @Override
+        public ProjectConfig getCachedConfig() {
+            return null;
+        }
+    };
+
     @Rule
     @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public RuleChain ruleChain = RuleChain.outerRule(thrown)
@@ -4505,13 +4517,13 @@ public class OptimizelyTest {
 
     @Test
     public void testGetNotificationCenter() {
-        Optimizely optimizely = optimizelyBuilder.withConfigManager(() -> null).build();
+        Optimizely optimizely = optimizelyBuilder.withConfigManager(projectConfigManagerReturningNull).build();
         assertEquals(optimizely.notificationCenter, optimizely.getNotificationCenter());
     }
 
     @Test
     public void testAddTrackNotificationHandler() {
-        Optimizely optimizely = optimizelyBuilder.withConfigManager(() -> null).build();
+        Optimizely optimizely = optimizelyBuilder.withConfigManager(projectConfigManagerReturningNull).build();
         NotificationManager<TrackNotification> manager = optimizely.getNotificationCenter()
             .getNotificationManager(TrackNotification.class);
 
@@ -4521,7 +4533,7 @@ public class OptimizelyTest {
 
     @Test
     public void testAddDecisionNotificationHandler() {
-        Optimizely optimizely = optimizelyBuilder.withConfigManager(() -> null).build();
+        Optimizely optimizely = optimizelyBuilder.withConfigManager(projectConfigManagerReturningNull).build();
         NotificationManager<DecisionNotification> manager = optimizely.getNotificationCenter()
             .getNotificationManager(DecisionNotification.class);
 
@@ -4531,7 +4543,7 @@ public class OptimizelyTest {
 
     @Test
     public void testAddUpdateConfigNotificationHandler() {
-        Optimizely optimizely = optimizelyBuilder.withConfigManager(() -> null).build();
+        Optimizely optimizely = optimizelyBuilder.withConfigManager(projectConfigManagerReturningNull).build();
         NotificationManager<UpdateConfigNotification> manager = optimizely.getNotificationCenter()
             .getNotificationManager(UpdateConfigNotification.class);
 
@@ -4541,7 +4553,7 @@ public class OptimizelyTest {
 
     @Test
     public void testAddLogEventNotificationHandler() {
-        Optimizely optimizely = optimizelyBuilder.withConfigManager(() -> null).build();
+        Optimizely optimizely = optimizelyBuilder.withConfigManager(projectConfigManagerReturningNull).build();
         NotificationManager<LogEvent> manager = optimizely.getNotificationCenter()
             .getNotificationManager(LogEvent.class);
 

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -4505,13 +4505,13 @@ public class OptimizelyTest {
 
     @Test
     public void testGetNotificationCenter() {
-        Optimizely optimizely = optimizelyBuilder.withConfigManager(() -> null).build();
+        Optimizely optimizely = optimizelyBuilder.withConfigManager(new TestProjectConfigManager()).build();
         assertEquals(optimizely.notificationCenter, optimizely.getNotificationCenter());
     }
 
     @Test
     public void testAddTrackNotificationHandler() {
-        Optimizely optimizely = optimizelyBuilder.withConfigManager(() -> null).build();
+        Optimizely optimizely = optimizelyBuilder.withConfigManager(new TestProjectConfigManager()).build();
         NotificationManager<TrackNotification> manager = optimizely.getNotificationCenter()
             .getNotificationManager(TrackNotification.class);
 
@@ -4521,7 +4521,7 @@ public class OptimizelyTest {
 
     @Test
     public void testAddDecisionNotificationHandler() {
-        Optimizely optimizely = optimizelyBuilder.withConfigManager(() -> null).build();
+        Optimizely optimizely = optimizelyBuilder.withConfigManager(new TestProjectConfigManager()).build();
         NotificationManager<DecisionNotification> manager = optimizely.getNotificationCenter()
             .getNotificationManager(DecisionNotification.class);
 
@@ -4531,7 +4531,7 @@ public class OptimizelyTest {
 
     @Test
     public void testAddUpdateConfigNotificationHandler() {
-        Optimizely optimizely = optimizelyBuilder.withConfigManager(() -> null).build();
+        Optimizely optimizely = optimizelyBuilder.withConfigManager(new TestProjectConfigManager()).build();
         NotificationManager<UpdateConfigNotification> manager = optimizely.getNotificationCenter()
             .getNotificationManager(UpdateConfigNotification.class);
 
@@ -4541,7 +4541,7 @@ public class OptimizelyTest {
 
     @Test
     public void testAddLogEventNotificationHandler() {
-        Optimizely optimizely = optimizelyBuilder.withConfigManager(() -> null).build();
+        Optimizely optimizely = optimizelyBuilder.withConfigManager(new TestProjectConfigManager()).build();
         NotificationManager<LogEvent> manager = optimizely.getNotificationCenter()
             .getNotificationManager(LogEvent.class);
 
@@ -4714,24 +4714,6 @@ public class OptimizelyTest {
     }
 
     @Test
-    public void updateODPManagerWhenConfigUpdates() throws IOException {
-        ODPEventManager mockODPEventManager = mock(ODPEventManager.class);
-        ODPManager mockODPManager = mock(ODPManager.class);
-        NotificationCenter mockNotificationCenter = mock(NotificationCenter.class);
-
-        Mockito.when(mockODPManager.getEventManager()).thenReturn(mockODPEventManager);
-        Optimizely.builder()
-            .withDatafile(validConfigJsonV4())
-            .withNotificationCenter(mockNotificationCenter)
-            .withODPManager(mockODPManager)
-            .build();
-
-        verify(mockODPManager, times(1)).updateSettings(any(), any(), any());
-
-        Mockito.verify(mockNotificationCenter, times(1)).addNotificationHandler(any(), any());
-    }
-
-    @Test
     public void sendODPEvent() {
         ProjectConfigManager mockProjectConfigManager = mock(ProjectConfigManager.class);
         ODPEventManager mockODPEventManager = mock(ODPEventManager.class);
@@ -4798,4 +4780,18 @@ public class OptimizelyTest {
         optimizely.identifyUser("the-user");
         Mockito.verify(mockODPEventManager, times(1)).identifyUser("the-user");
     }
+
+    public static class TestProjectConfigManager implements ProjectConfigManager {
+
+        @Override
+        public ProjectConfig getConfig() {
+            return null;
+        }
+
+        @Override
+        public String getSDKKey() {
+            return null;
+        }
+    }
 }
+

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2016-2022, Optimizely, Inc. and contributors                   *
+ * Copyright 2016-2023, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -4780,6 +4780,4 @@ public class OptimizelyTest {
         optimizely.identifyUser("the-user");
         Mockito.verify(mockODPEventManager, times(1)).identifyUser("the-user");
     }
-
 }
-

--- a/core-api/src/test/java/com/optimizely/ab/config/PollingProjectConfigManagerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/PollingProjectConfigManagerTest.java
@@ -215,14 +215,14 @@ public class PollingProjectConfigManagerTest {
     @Test
     public void testUpdateConfigNotificationGetsTriggered() throws InterruptedException {
         CountDownLatch countDownLatch = new CountDownLatch(2);
-        NotificationCenter registryDefaultNotificationCenter = NotificationRegistry.getNotificationCenter("ValidProjectConfigV4");
+        NotificationCenter registryDefaultNotificationCenter = NotificationRegistry.getInternalNotificationCenter("ValidProjectConfigV4");
         NotificationCenter userNotificationCenter = testProjectConfigManager.getNotificationCenter();
         assertNotEquals(registryDefaultNotificationCenter, userNotificationCenter);
         
         testProjectConfigManager.getNotificationCenter()
             .<UpdateConfigNotification>getNotificationManager(UpdateConfigNotification.class)
             .addHandler(message -> {countDownLatch.countDown();});
-        NotificationRegistry.getNotificationCenter("ValidProjectConfigV4")
+        NotificationRegistry.getInternalNotificationCenter("ValidProjectConfigV4")
             .<UpdateConfigNotification>getNotificationManager(UpdateConfigNotification.class)
             .addHandler(message -> {countDownLatch.countDown();});
         assertTrue(countDownLatch.await(500, TimeUnit.MILLISECONDS));
@@ -285,7 +285,7 @@ public class PollingProjectConfigManagerTest {
         @Override
         public String getSDKKey() {
             if (projectConfig == null) {
-                return "";
+                return null;
             }
             return projectConfig.getSdkKey();
         }

--- a/core-api/src/test/java/com/optimizely/ab/config/PollingProjectConfigManagerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/PollingProjectConfigManagerTest.java
@@ -271,5 +271,13 @@ public class PollingProjectConfigManagerTest {
         public void release() {
             countDownLatch.countDown();
         }
+
+        @Override
+        public String getSDKKey() {
+            if (projectConfig == null) {
+                return "";
+            }
+            return projectConfig.getSdkKey();
+        }
     }
 }

--- a/core-api/src/test/java/com/optimizely/ab/internal/NotificationRegistryTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/internal/NotificationRegistryTest.java
@@ -22,39 +22,38 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 
 public class NotificationRegistryTest {
 
     @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION")
     @Test
-    public void getSameNotificationcenterWhenSDKkeyIsNull() {
+    public void getNullNotificationCenterWhenSDKeyIsNull() {
         String sdkKey = null;
-        NotificationCenter notificationCenter1 = NotificationRegistry.getInternalNotificationCenter(sdkKey);
-        NotificationCenter notificationCenter2 = NotificationRegistry.getInternalNotificationCenter(sdkKey);
-        assertEquals(notificationCenter1, notificationCenter2);
+        NotificationCenter notificationCenter = NotificationRegistry.getInternalNotificationCenter(sdkKey);
+        assertNull(notificationCenter);
     }
 
     @Test
-    public void getSameNotificationcenterWhenSDKkeyIsSameButNotNull() {
+    public void getSameNotificationCenterWhenSDKKeyIsSameButNotNull() {
         String sdkKey = "testSDkKey";
         NotificationCenter notificationCenter1 = NotificationRegistry.getInternalNotificationCenter(sdkKey);
         NotificationCenter notificationCenter2 = NotificationRegistry.getInternalNotificationCenter(sdkKey);
         assertEquals(notificationCenter1, notificationCenter2);
     }
 
-    @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION")
     @Test
-    public void getSameNotificationcenterWhenSDKkeyIsNullAndAnotherIsEmpty() {
+    public void getSameNotificationCenterWhenSDKKeyIsEmpty() {
         String sdkKey1 = "";
-        String sdkKey2 = null;
+        String sdkKey2 = "";
         NotificationCenter notificationCenter1 = NotificationRegistry.getInternalNotificationCenter(sdkKey1);
         NotificationCenter notificationCenter2 = NotificationRegistry.getInternalNotificationCenter(sdkKey2);
         assertEquals(notificationCenter1, notificationCenter2);
     }
 
     @Test
-    public void getDifferentNotificationcenterWhenSDKkeyIsNotSame() {
+    public void getDifferentNotificationCenterWhenSDKKeyIsNotSame() {
         String sdkKey1 = "testSDkKey1";
         String sdkKey2 = "testSDkKey2";
         NotificationCenter notificationCenter1 = NotificationRegistry.getInternalNotificationCenter(sdkKey1);
@@ -63,12 +62,23 @@ public class NotificationRegistryTest {
     }
 
     @Test
-    public void clearRegistryNotificationcenterClearsOldNotificationCenter() {
+    public void clearRegistryNotificationCenterClearsOldNotificationCenter() {
         String sdkKey1 = "testSDkKey1";
         NotificationCenter notificationCenter1 = NotificationRegistry.getInternalNotificationCenter(sdkKey1);
-        NotificationRegistry.clearNotificationCenterRegistry();
+        NotificationRegistry.clearNotificationCenterRegistry(sdkKey1);
         NotificationCenter notificationCenter2 = NotificationRegistry.getInternalNotificationCenter(sdkKey1);
 
         Assert.assertNotEquals(notificationCenter1, notificationCenter2);
+    }
+
+    @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION")
+    @Test
+    public void clearRegistryNotificationCenterWillNotCauseExceptionIfPassedNullSDkKey() {
+        String sdkKey1 = "testSDkKey1";
+        NotificationCenter notificationCenter1 = NotificationRegistry.getInternalNotificationCenter(sdkKey1);
+        NotificationRegistry.clearNotificationCenterRegistry(null);
+        NotificationCenter notificationCenter2 = NotificationRegistry.getInternalNotificationCenter(sdkKey1);
+
+        Assert.assertEquals(notificationCenter1, notificationCenter2);
     }
 }

--- a/core-api/src/test/java/com/optimizely/ab/internal/NotificationRegistryTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/internal/NotificationRegistryTest.java
@@ -30,16 +30,16 @@ public class NotificationRegistryTest {
     @Test
     public void getSameNotificationcenterWhenSDKkeyIsNull() {
         String sdkKey = null;
-        NotificationCenter notificationCenter1 = NotificationRegistry.getNotificationCenter(sdkKey);
-        NotificationCenter notificationCenter2 = NotificationRegistry.getNotificationCenter(sdkKey);
+        NotificationCenter notificationCenter1 = NotificationRegistry.getInternalNotificationCenter(sdkKey);
+        NotificationCenter notificationCenter2 = NotificationRegistry.getInternalNotificationCenter(sdkKey);
         assertEquals(notificationCenter1, notificationCenter2);
     }
 
     @Test
     public void getSameNotificationcenterWhenSDKkeyIsSameButNotNull() {
         String sdkKey = "testSDkKey";
-        NotificationCenter notificationCenter1 = NotificationRegistry.getNotificationCenter(sdkKey);
-        NotificationCenter notificationCenter2 = NotificationRegistry.getNotificationCenter(sdkKey);
+        NotificationCenter notificationCenter1 = NotificationRegistry.getInternalNotificationCenter(sdkKey);
+        NotificationCenter notificationCenter2 = NotificationRegistry.getInternalNotificationCenter(sdkKey);
         assertEquals(notificationCenter1, notificationCenter2);
     }
 
@@ -48,8 +48,8 @@ public class NotificationRegistryTest {
     public void getSameNotificationcenterWhenSDKkeyIsNullAndAnotherIsEmpty() {
         String sdkKey1 = "";
         String sdkKey2 = null;
-        NotificationCenter notificationCenter1 = NotificationRegistry.getNotificationCenter(sdkKey1);
-        NotificationCenter notificationCenter2 = NotificationRegistry.getNotificationCenter(sdkKey2);
+        NotificationCenter notificationCenter1 = NotificationRegistry.getInternalNotificationCenter(sdkKey1);
+        NotificationCenter notificationCenter2 = NotificationRegistry.getInternalNotificationCenter(sdkKey2);
         assertEquals(notificationCenter1, notificationCenter2);
     }
 
@@ -57,17 +57,17 @@ public class NotificationRegistryTest {
     public void getDifferentNotificationcenterWhenSDKkeyIsNotSame() {
         String sdkKey1 = "testSDkKey1";
         String sdkKey2 = "testSDkKey2";
-        NotificationCenter notificationCenter1 = NotificationRegistry.getNotificationCenter(sdkKey1);
-        NotificationCenter notificationCenter2 = NotificationRegistry.getNotificationCenter(sdkKey2);
+        NotificationCenter notificationCenter1 = NotificationRegistry.getInternalNotificationCenter(sdkKey1);
+        NotificationCenter notificationCenter2 = NotificationRegistry.getInternalNotificationCenter(sdkKey2);
         Assert.assertNotEquals(notificationCenter1, notificationCenter2);
     }
 
     @Test
     public void clearRegistryNotificationcenterClearsOldNotificationCenter() {
         String sdkKey1 = "testSDkKey1";
-        NotificationCenter notificationCenter1 = NotificationRegistry.getNotificationCenter(sdkKey1);
+        NotificationCenter notificationCenter1 = NotificationRegistry.getInternalNotificationCenter(sdkKey1);
         NotificationRegistry.clearNotificationCenterRegistry();
-        NotificationCenter notificationCenter2 = NotificationRegistry.getNotificationCenter(sdkKey1);
+        NotificationCenter notificationCenter2 = NotificationRegistry.getInternalNotificationCenter(sdkKey1);
 
         Assert.assertNotEquals(notificationCenter1, notificationCenter2);
     }

--- a/core-api/src/test/java/com/optimizely/ab/internal/NotificationRegistryTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/internal/NotificationRegistryTest.java
@@ -17,6 +17,7 @@
 package com.optimizely.ab.internal;
 
 import com.optimizely.ab.notification.NotificationCenter;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -24,6 +25,8 @@ import static org.junit.Assert.assertEquals;
 
 
 public class NotificationRegistryTest {
+
+    @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION")
     @Test
     public void getSameNotificationcenterWhenSDKkeyIsNull() {
         String sdkKey = null;
@@ -40,6 +43,7 @@ public class NotificationRegistryTest {
         assertEquals(notificationCenter1, notificationCenter2);
     }
 
+    @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION")
     @Test
     public void getSameNotificationcenterWhenSDKkeyIsNullAndAnotherIsEmpty() {
         String sdkKey1 = "";

--- a/core-api/src/test/java/com/optimizely/ab/internal/NotificationRegistryTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/internal/NotificationRegistryTest.java
@@ -1,0 +1,70 @@
+/**
+ *
+ *    Copyright 2023, Optimizely
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.optimizely.ab.internal;
+
+import com.optimizely.ab.notification.NotificationCenter;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class NotificationRegistryTest {
+    @Test
+    public void getSameNotificationcenterWhenSDKkeyIsNull() {
+        String sdkKey = null;
+        NotificationCenter notificationCenter1 = NotificationRegistry.getNotificationCenter(sdkKey);
+        NotificationCenter notificationCenter2 = NotificationRegistry.getNotificationCenter(sdkKey);
+        assertEquals(notificationCenter1, notificationCenter2);
+    }
+
+    @Test
+    public void getSameNotificationcenterWhenSDKkeyIsSameButNotNull() {
+        String sdkKey = "testSDkKey";
+        NotificationCenter notificationCenter1 = NotificationRegistry.getNotificationCenter(sdkKey);
+        NotificationCenter notificationCenter2 = NotificationRegistry.getNotificationCenter(sdkKey);
+        assertEquals(notificationCenter1, notificationCenter2);
+    }
+
+    @Test
+    public void getSameNotificationcenterWhenSDKkeyIsNullAndAnotherIsEmpty() {
+        String sdkKey1 = "";
+        String sdkKey2 = null;
+        NotificationCenter notificationCenter1 = NotificationRegistry.getNotificationCenter(sdkKey1);
+        NotificationCenter notificationCenter2 = NotificationRegistry.getNotificationCenter(sdkKey2);
+        assertEquals(notificationCenter1, notificationCenter2);
+    }
+
+    @Test
+    public void getDifferentNotificationcenterWhenSDKkeyIsNotSame() {
+        String sdkKey1 = "testSDkKey1";
+        String sdkKey2 = "testSDkKey2";
+        NotificationCenter notificationCenter1 = NotificationRegistry.getNotificationCenter(sdkKey1);
+        NotificationCenter notificationCenter2 = NotificationRegistry.getNotificationCenter(sdkKey2);
+        Assert.assertNotEquals(notificationCenter1, notificationCenter2);
+    }
+
+    @Test
+    public void clearRegistryNotificationcenterClearsOldNotificationCenter() {
+        String sdkKey1 = "testSDkKey1";
+        NotificationCenter notificationCenter1 = NotificationRegistry.getNotificationCenter(sdkKey1);
+        NotificationRegistry.clearNotificationCenterRegistry();
+        NotificationCenter notificationCenter2 = NotificationRegistry.getNotificationCenter(sdkKey1);
+
+        Assert.assertNotEquals(notificationCenter1, notificationCenter2);
+    }
+}

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyFactory.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyFactory.java
@@ -17,7 +17,6 @@
 package com.optimizely.ab;
 
 import com.optimizely.ab.config.HttpProjectConfigManager;
-import com.optimizely.ab.config.ProjectConfig;
 import com.optimizely.ab.config.ProjectConfigManager;
 import com.optimizely.ab.event.AsyncEventHandler;
 import com.optimizely.ab.event.BatchEventProcessor;
@@ -223,17 +222,7 @@ public final class OptimizelyFactory {
     public static Optimizely newDefaultInstance(String sdkKey) {
         if (sdkKey == null) {
             logger.error("Must provide an sdkKey, returning non-op Optimizely client");
-            return newDefaultInstance(new ProjectConfigManager() {
-                @Override
-                public ProjectConfig getConfig() {
-                    return null;
-                }
-
-                @Override
-                public String getSDKKey() {
-                    return null;
-                }
-            });
+            return newDefaultInstance(() -> null);
         }
 
         return newDefaultInstance(sdkKey, null);

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyFactory.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyFactory.java
@@ -17,6 +17,7 @@
 package com.optimizely.ab;
 
 import com.optimizely.ab.config.HttpProjectConfigManager;
+import com.optimizely.ab.config.ProjectConfig;
 import com.optimizely.ab.config.ProjectConfigManager;
 import com.optimizely.ab.event.AsyncEventHandler;
 import com.optimizely.ab.event.BatchEventProcessor;
@@ -222,7 +223,17 @@ public final class OptimizelyFactory {
     public static Optimizely newDefaultInstance(String sdkKey) {
         if (sdkKey == null) {
             logger.error("Must provide an sdkKey, returning non-op Optimizely client");
-            return newDefaultInstance(() -> null);
+            return newDefaultInstance(new ProjectConfigManager() {
+                @Override
+                public ProjectConfig getConfig() {
+                    return null;
+                }
+
+                @Override
+                public String getSDKKey() {
+                    return null;
+                }
+            });
         }
 
         return newDefaultInstance(sdkKey, null);

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyFactory.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyFactory.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2019-2021, Optimizely
+ *    Copyright 2019-2021, 2023, Optimizely
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.optimizely.ab;
 
 import com.optimizely.ab.config.HttpProjectConfigManager;
+import com.optimizely.ab.config.ProjectConfig;
 import com.optimizely.ab.config.ProjectConfigManager;
 import com.optimizely.ab.event.AsyncEventHandler;
 import com.optimizely.ab.event.BatchEventProcessor;
@@ -222,7 +223,17 @@ public final class OptimizelyFactory {
     public static Optimizely newDefaultInstance(String sdkKey) {
         if (sdkKey == null) {
             logger.error("Must provide an sdkKey, returning non-op Optimizely client");
-            return newDefaultInstance(() -> null);
+            return newDefaultInstance(new ProjectConfigManager() {
+                @Override
+                public ProjectConfig getConfig() {
+                    return null;
+                }
+
+                @Override
+                public ProjectConfig getCachedConfig() {
+                    return null;
+                }
+            });
         }
 
         return newDefaultInstance(sdkKey, null);

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyFactory.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyFactory.java
@@ -233,6 +233,11 @@ public final class OptimizelyFactory {
                 public ProjectConfig getCachedConfig() {
                     return null;
                 }
+
+                @Override
+                public String getSDKKey() {
+                    return null;
+                }
             });
         }
 

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
@@ -65,7 +65,6 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
     private final URI uri;
     private final String datafileAccessToken;
     private String datafileLastModified;
-    private String sdkKey;
 
     private HttpProjectConfigManager(long period,
                                      TimeUnit timeUnit,
@@ -74,13 +73,11 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
                                      String datafileAccessToken,
                                      long blockingTimeoutPeriod,
                                      TimeUnit blockingTimeoutUnit,
-                                     NotificationCenter notificationCenter,
-                                     String sdkKey) {
+                                     NotificationCenter notificationCenter) {
         super(period, timeUnit, blockingTimeoutPeriod, blockingTimeoutUnit, notificationCenter);
         this.httpClient = httpClient;
         this.uri = URI.create(url);
         this.datafileAccessToken = datafileAccessToken;
-        this.sdkKey = sdkKey;
     }
 
     public URI getUri() {
@@ -168,11 +165,6 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
 
     public static Builder builder() {
         return new Builder();
-    }
-
-    @Override
-    public String getSDKKey() {
-        return this.sdkKey;
     }
 
     public static class Builder {
@@ -364,8 +356,7 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
                 datafileAccessToken,
                 blockingTimeoutPeriod,
                 blockingTimeoutUnit,
-                notificationCenter,
-                sdkKey);
+                notificationCenter);
             httpProjectManager.setSdkKey(sdkKey);
             if (datafile != null) {
                 try {

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
@@ -340,11 +340,10 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
                     .withEvictIdleConnections(evictConnectionIdleTimePeriod, evictConnectionIdleTimeUnit)
                     .build();
             }
-
+            if (sdkKey == null) {
+                throw new NullPointerException("sdkKey cannot be null");
+            }
             if (url == null) {
-                if (sdkKey == null) {
-                    throw new NullPointerException("sdkKey cannot be null");
-                }
 
                 if (datafileAccessToken == null) {
                     url = String.format(format, sdkKey);

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
@@ -65,6 +65,7 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
     private final URI uri;
     private final String datafileAccessToken;
     private String datafileLastModified;
+    private String sdkKey;
 
     private HttpProjectConfigManager(long period,
                                      TimeUnit timeUnit,
@@ -73,11 +74,13 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
                                      String datafileAccessToken,
                                      long blockingTimeoutPeriod,
                                      TimeUnit blockingTimeoutUnit,
-                                     NotificationCenter notificationCenter) {
+                                     NotificationCenter notificationCenter,
+                                     String sdkKey) {
         super(period, timeUnit, blockingTimeoutPeriod, blockingTimeoutUnit, notificationCenter);
         this.httpClient = httpClient;
         this.uri = URI.create(url);
         this.datafileAccessToken = datafileAccessToken;
+        this.sdkKey = sdkKey;
     }
 
     public URI getUri() {
@@ -165,6 +168,11 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
 
     public static Builder builder() {
         return new Builder();
+    }
+
+    @Override
+    public String getSDKKey() {
+        return this.sdkKey;
     }
 
     public static class Builder {
@@ -357,7 +365,8 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
                 datafileAccessToken,
                 blockingTimeoutPeriod,
                 blockingTimeoutUnit,
-                notificationCenter);
+                notificationCenter,
+                sdkKey);
 
             if (datafile != null) {
                 try {

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
@@ -179,7 +179,7 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
         private String datafile;
         private String url;
         private String datafileAccessToken = null;
-        private String format = "http://localhost:3001/datafiles/%s.json";
+        private String format = "https://cdn.optimizely.com/datafiles/%s.json";
         private String authFormat = "https://config.optimizely.com/datafiles/auth/%s.json";
         private OptimizelyHttpClient httpClient;
         private NotificationCenter notificationCenter;

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
@@ -179,7 +179,7 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
         private String datafile;
         private String url;
         private String datafileAccessToken = null;
-        private String format = "https://cdn.optimizely.com/datafiles/%s.json";
+        private String format = "http://localhost:3001/datafiles/%s.json";
         private String authFormat = "https://config.optimizely.com/datafiles/auth/%s.json";
         private OptimizelyHttpClient httpClient;
         private NotificationCenter notificationCenter;
@@ -366,7 +366,7 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
                 blockingTimeoutUnit,
                 notificationCenter,
                 sdkKey);
-
+            httpProjectManager.setSdkKey(sdkKey);
             if (datafile != null) {
                 try {
                     ProjectConfig projectConfig = HttpProjectConfigManager.parseProjectConfig(datafile);

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyFactoryTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyFactoryTest.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2019-2020, Optimizely
+ *    Copyright 2019-2020, 2023, Optimizely
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package com.optimizely.ab;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import com.optimizely.ab.config.HttpProjectConfigManager;
+import com.optimizely.ab.config.ProjectConfig;
+import com.optimizely.ab.config.ProjectConfigManager;
 import com.optimizely.ab.event.AsyncEventHandler;
 import com.optimizely.ab.event.BatchEventProcessor;
 import com.optimizely.ab.internal.PropertyUtils;
@@ -260,17 +262,28 @@ public class OptimizelyFactoryTest {
         optimizely = OptimizelyFactory.newDefaultInstance("sdk-key", datafileString, "auth-token", httpClient);
         assertTrue(optimizely.isValid());
     }
+    public ProjectConfigManager projectConfigManagerReturningNull = new ProjectConfigManager() {
+        @Override
+        public ProjectConfig getConfig() {
+            return null;
+        }
+
+        @Override
+        public ProjectConfig getCachedConfig() {
+            return null;
+        }
+    };
 
     @Test
     public void newDefaultInstanceWithProjectConfig() throws Exception {
-        optimizely = OptimizelyFactory.newDefaultInstance(() -> null);
+        optimizely = OptimizelyFactory.newDefaultInstance(projectConfigManagerReturningNull);
         assertFalse(optimizely.isValid());
     }
 
     @Test
     public void newDefaultInstanceWithProjectConfigAndNotificationCenter() throws Exception {
         NotificationCenter notificationCenter = new NotificationCenter();
-        optimizely = OptimizelyFactory.newDefaultInstance(() -> null, notificationCenter);
+        optimizely = OptimizelyFactory.newDefaultInstance(projectConfigManagerReturningNull, notificationCenter);
         assertFalse(optimizely.isValid());
         assertEquals(notificationCenter, optimizely.getNotificationCenter());
     }
@@ -278,7 +291,7 @@ public class OptimizelyFactoryTest {
     @Test
     public void newDefaultInstanceWithProjectConfigAndNotificationCenterAndEventHandler() {
         NotificationCenter notificationCenter = new NotificationCenter();
-        optimizely = OptimizelyFactory.newDefaultInstance(() -> null, notificationCenter, logEvent -> {});
+        optimizely = OptimizelyFactory.newDefaultInstance(projectConfigManagerReturningNull, notificationCenter, logEvent -> {});
         assertFalse(optimizely.isValid());
         assertEquals(notificationCenter, optimizely.getNotificationCenter());
     }

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyFactoryTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyFactoryTest.java
@@ -19,8 +19,6 @@ package com.optimizely.ab;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import com.optimizely.ab.config.HttpProjectConfigManager;
-import com.optimizely.ab.config.ProjectConfig;
-import com.optimizely.ab.config.ProjectConfigManager;
 import com.optimizely.ab.event.AsyncEventHandler;
 import com.optimizely.ab.event.BatchEventProcessor;
 import com.optimizely.ab.internal.PropertyUtils;
@@ -265,34 +263,14 @@ public class OptimizelyFactoryTest {
 
     @Test
     public void newDefaultInstanceWithProjectConfig() throws Exception {
-        optimizely = OptimizelyFactory.newDefaultInstance(new ProjectConfigManager() {
-            @Override
-            public ProjectConfig getConfig() {
-                return null;
-            }
-
-            @Override
-            public String getSDKKey() {
-                return null;
-            }
-        });
+        optimizely = OptimizelyFactory.newDefaultInstance(() -> null);
         assertFalse(optimizely.isValid());
     }
 
     @Test
     public void newDefaultInstanceWithProjectConfigAndNotificationCenter() throws Exception {
         NotificationCenter notificationCenter = new NotificationCenter();
-        optimizely = OptimizelyFactory.newDefaultInstance(new ProjectConfigManager() {
-            @Override
-            public ProjectConfig getConfig() {
-                return null;
-            }
-
-            @Override
-            public String getSDKKey() {
-                return null;
-            }
-        }, notificationCenter);
+        optimizely = OptimizelyFactory.newDefaultInstance(() -> null, notificationCenter);
         assertFalse(optimizely.isValid());
         assertEquals(notificationCenter, optimizely.getNotificationCenter());
     }
@@ -300,17 +278,7 @@ public class OptimizelyFactoryTest {
     @Test
     public void newDefaultInstanceWithProjectConfigAndNotificationCenterAndEventHandler() {
         NotificationCenter notificationCenter = new NotificationCenter();
-        optimizely = OptimizelyFactory.newDefaultInstance(new ProjectConfigManager() {
-            @Override
-            public ProjectConfig getConfig() {
-                return null;
-            }
-
-            @Override
-            public String getSDKKey() {
-                return null;
-            }
-        }, notificationCenter, logEvent -> {
+        optimizely = OptimizelyFactory.newDefaultInstance(() -> null, notificationCenter, logEvent -> {
         });
         assertFalse(optimizely.isValid());
         assertEquals(notificationCenter, optimizely.getNotificationCenter());

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyFactoryTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyFactoryTest.java
@@ -278,8 +278,7 @@ public class OptimizelyFactoryTest {
     @Test
     public void newDefaultInstanceWithProjectConfigAndNotificationCenterAndEventHandler() {
         NotificationCenter notificationCenter = new NotificationCenter();
-        optimizely = OptimizelyFactory.newDefaultInstance(() -> null, notificationCenter, logEvent -> {
-        });
+        optimizely = OptimizelyFactory.newDefaultInstance(() -> null, notificationCenter, logEvent -> {});
         assertFalse(optimizely.isValid());
         assertEquals(notificationCenter, optimizely.getNotificationCenter());
     }

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyFactoryTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyFactoryTest.java
@@ -19,6 +19,8 @@ package com.optimizely.ab;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import com.optimizely.ab.config.HttpProjectConfigManager;
+import com.optimizely.ab.config.ProjectConfig;
+import com.optimizely.ab.config.ProjectConfigManager;
 import com.optimizely.ab.event.AsyncEventHandler;
 import com.optimizely.ab.event.BatchEventProcessor;
 import com.optimizely.ab.internal.PropertyUtils;
@@ -263,14 +265,34 @@ public class OptimizelyFactoryTest {
 
     @Test
     public void newDefaultInstanceWithProjectConfig() throws Exception {
-        optimizely = OptimizelyFactory.newDefaultInstance(() -> null);
+        optimizely = OptimizelyFactory.newDefaultInstance(new ProjectConfigManager() {
+            @Override
+            public ProjectConfig getConfig() {
+                return null;
+            }
+
+            @Override
+            public String getSDKKey() {
+                return null;
+            }
+        });
         assertFalse(optimizely.isValid());
     }
 
     @Test
     public void newDefaultInstanceWithProjectConfigAndNotificationCenter() throws Exception {
         NotificationCenter notificationCenter = new NotificationCenter();
-        optimizely = OptimizelyFactory.newDefaultInstance(() -> null, notificationCenter);
+        optimizely = OptimizelyFactory.newDefaultInstance(new ProjectConfigManager() {
+            @Override
+            public ProjectConfig getConfig() {
+                return null;
+            }
+
+            @Override
+            public String getSDKKey() {
+                return null;
+            }
+        }, notificationCenter);
         assertFalse(optimizely.isValid());
         assertEquals(notificationCenter, optimizely.getNotificationCenter());
     }
@@ -278,7 +300,18 @@ public class OptimizelyFactoryTest {
     @Test
     public void newDefaultInstanceWithProjectConfigAndNotificationCenterAndEventHandler() {
         NotificationCenter notificationCenter = new NotificationCenter();
-        optimizely = OptimizelyFactory.newDefaultInstance(() -> null, notificationCenter, logEvent -> {});
+        optimizely = OptimizelyFactory.newDefaultInstance(new ProjectConfigManager() {
+            @Override
+            public ProjectConfig getConfig() {
+                return null;
+            }
+
+            @Override
+            public String getSDKKey() {
+                return null;
+            }
+        }, notificationCenter, logEvent -> {
+        });
         assertFalse(optimizely.isValid());
         assertEquals(notificationCenter, optimizely.getNotificationCenter());
     }

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyFactoryTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyFactoryTest.java
@@ -272,6 +272,11 @@ public class OptimizelyFactoryTest {
         public ProjectConfig getCachedConfig() {
             return null;
         }
+
+        @Override
+        public String getSDKKey() {
+            return null;
+        }
     };
 
     @Test

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/config/HttpProjectConfigManagerTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/config/HttpProjectConfigManagerTest.java
@@ -129,6 +129,7 @@ public class HttpProjectConfigManagerTest {
 
         projectConfigManager = builder()
             .withOptimizelyHttpClient(mockHttpClient)
+            .withSdkKey("custom-sdkKey")
             .withUrl(expected)
             .build();
 

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/config/HttpProjectConfigManagerTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/config/HttpProjectConfigManagerTest.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2019, Optimizely
+ *    Copyright 2019, 2023, Optimizely
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -207,6 +207,7 @@ public class HttpProjectConfigManagerTest {
             .withOptimizelyHttpClient(mockHttpClient)
             .withSdkKey("sdk-key")
             .build(true);
+        assertEquals("sdk-key", projectConfigManager.getSDKKey());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- NotificationRegistry is added to create default NotificationCenter for internal use for updating ODPConfigSetting. 
- This is to handle a corner case that if in any case user passes different notificationCenter to Optimizely and ProjectconfigManager then the Notification of UpdateProjectConfig will not trigger because its handler is getting added in the main NotificationCenter object. 
- This will make sure UpdateProjectConfig will update ODPConfigSetting everytime irrespective of different NotificationCenter passed by user.
- Added getCachedConfig method in ProjectconfigManager to return ProjectConfig without await. 

**NOTE: breaking change**
Anyone who is implementing custom ProjectConfigManager should now have to implement `getCachedConfig` and `getSdkKey `. 

## Test plan
- Added additional unit test to test NotificationRegistry 
- All tests should pass.

## Issue
[FSSDK-8769](https://jira.sso.episerver.net/browse/FSSDK-8769)