### PR TITLE
feat(ats): add support for android ODP events

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/OptimizelyUserContext.java
+++ b/core-api/src/main/java/com/optimizely/ab/OptimizelyUserContext.java
@@ -16,6 +16,7 @@
  */
 package com.optimizely.ab;
 
+import com.optimizely.ab.config.ProjectConfig;
 import com.optimizely.ab.odp.ODPManager;
 import com.optimizely.ab.odp.ODPSegmentCallback;
 import com.optimizely.ab.odp.ODPSegmentOption;
@@ -313,6 +314,8 @@ public class OptimizelyUserContext {
      * Fetch all qualified segments for the user context.
      * <p>
      * The segments fetched will be saved and can be accessed at any time by calling {@link #getQualifiedSegments()}.
+     *
+     * @return a boolean value for fetch success or failure.
      */
     public Boolean fetchQualifiedSegments() {
         return fetchQualifiedSegments(Collections.emptyList());
@@ -324,6 +327,7 @@ public class OptimizelyUserContext {
      * The segments fetched will be saved and can be accessed at any time by calling {@link #getQualifiedSegments()}.
      *
      * @param segmentOptions A set of options for fetching qualified segments.
+     * @return a boolean value for fetch success or failure.
      */
     public Boolean fetchQualifiedSegments(@Nonnull List<ODPSegmentOption> segmentOptions) {
         List<String> segments = optimizely.fetchQualifiedSegments(userId, segmentOptions);

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPEvent.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPEvent.java
@@ -26,7 +26,7 @@ public class ODPEvent {
 
     private String type;
     private String action;
-    private Map<String, String > identifiers;
+    private Map<String, String> identifiers;
     private Map<String, Object> data;
 
     public ODPEvent(@Nullable String type, @Nonnull String action, @Nullable Map<String, String> identifiers, @Nullable Map<String, Object> data) {

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPEvent.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPEvent.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2022, Optimizely Inc. and contributors
+ *    Copyright 2022-2023, Optimizely Inc. and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
@@ -67,13 +67,13 @@ public class ODPEventManager {
     }
 
     // these user-provided common data are included in all ODP events in addition to the SDK-generated common data.
-    public void setUserCommonData(@Nonnull Map<String, Object> commonData) {
-        this.userCommonData = commonData;
+    public void setUserCommonData(@Nullable Map<String, Object> commonData) {
+        if (commonData != null) this.userCommonData = commonData;
     }
 
     // these user-provided common identifiers are included in all ODP events in addition to the SDK-generated identifiers.
-    public void setUserCommonIdentifiers(@Nonnull Map<String, String> commonIdentifiers) {
-        this.userCommonIdentifiers = commonIdentifiers;
+    public void setUserCommonIdentifiers(@Nullable Map<String, String> commonIdentifiers) {
+        if (commonIdentifiers != null) this.userCommonIdentifiers = commonIdentifiers;
     }
 
     public void start() {

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
@@ -67,13 +67,13 @@ public class ODPEventManager {
     }
 
     // these user-provided common data are included in all ODP events in addition to the SDK-generated common data.
-    public void setUserCommonData(@Nullable Map<String, Object> commonData) {
-        if (commonData != null) this.userCommonData = commonData;
+    public void setUserCommonData(@Nonnull Map<String, Object> commonData) {
+        this.userCommonData = commonData;
     }
 
     // these user-provided common identifiers are included in all ODP events in addition to the SDK-generated identifiers.
-    public void setUserCommonIdentifiers(@Nullable Map<String, String> commonIdentifiers) {
-        if (commonIdentifiers != null) this.userCommonIdentifiers = commonIdentifiers;
+    public void setUserCommonIdentifiers(@Nonnull Map<String, String> commonIdentifiers) {
+        this.userCommonIdentifiers = commonIdentifiers;
     }
 
     public void start() {

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPManager.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class ODPManager implements AutoCloseable {
@@ -77,6 +78,8 @@ public class ODPManager implements AutoCloseable {
         private Integer cacheSize;
         private Integer cacheTimeoutSeconds;
         private Cache<List<String>> cacheImpl;
+        private Map<String, Object> userCommonData;
+        private Map<String, String> userCommonIdentifiers;
 
         /**
          * Provide a custom {@link ODPManager} instance which makes http calls to fetch segments and send events.
@@ -156,6 +159,32 @@ public class ODPManager implements AutoCloseable {
             return this;
         }
 
+        /**
+         * Provide an optional group of user data that should be included in all ODP events.
+         *
+         * Note that this is in addition to the default data that is automatically included in all ODP events by this SDK (sdk-name, sdk-version, etc).
+         *
+         * @param commonData A key-value set of common user data.
+         * @return ODPManager builder
+         */
+        public Builder withUserCommonData(@Nonnull Map<String, Object> commonData) {
+            this.userCommonData = commonData;
+            return this;
+        }
+
+        /**
+         * Provide an optional group of identifiers that should be included in all ODP events.
+         *
+         * Note that this is in addition to the identifiers that is automatically included in all ODP events by this SDK.
+         *
+         * @param commonData A key-value set of common identifiers.
+         * @return ODPManager builder
+         */
+        public Builder withUserCommonIdentifiers(@Nonnull Map<String, String> commonIdentifiers) {
+            this.userCommonIdentifiers = commonIdentifiers;
+            return this;
+        }
+
         public ODPManager build() {
             if ((segmentManager == null || eventManager == null) && apiManager == null) {
                 logger.warn("ApiManager instance is needed when using default EventManager or SegmentManager");
@@ -182,6 +211,8 @@ public class ODPManager implements AutoCloseable {
             if (eventManager == null) {
                 eventManager = new ODPEventManager(apiManager);
             }
+            eventManager.setUserCommonData(userCommonData);
+            eventManager.setUserCommonIdentifiers(userCommonIdentifiers);
 
             return new ODPManager(segmentManager, eventManager);
         }

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPManager.java
@@ -212,8 +212,8 @@ public class ODPManager implements AutoCloseable {
             if (eventManager == null) {
                 eventManager = new ODPEventManager(apiManager);
             }
-            eventManager.setUserCommonData(userCommonData != null ?  userCommonData : Collections.emptyMap());
-            eventManager.setUserCommonIdentifiers(userCommonIdentifiers != null ? userCommonIdentifiers : Collections.emptyMap());
+            eventManager.setUserCommonData(userCommonData);
+            eventManager.setUserCommonIdentifiers(userCommonIdentifiers);
 
             return new ODPManager(segmentManager, eventManager);
         }

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPManager.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -211,8 +212,8 @@ public class ODPManager implements AutoCloseable {
             if (eventManager == null) {
                 eventManager = new ODPEventManager(apiManager);
             }
-            eventManager.setUserCommonData(userCommonData);
-            eventManager.setUserCommonIdentifiers(userCommonIdentifiers);
+            eventManager.setUserCommonData(userCommonData != null ?  userCommonData : Collections.emptyMap());
+            eventManager.setUserCommonIdentifiers(userCommonIdentifiers != null ? userCommonIdentifiers : Collections.emptyMap());
 
             return new ODPManager(segmentManager, eventManager);
         }

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPManager.java
@@ -164,7 +164,7 @@ public class ODPManager implements AutoCloseable {
          *
          * Note that this is in addition to the default data that is automatically included in all ODP events by this SDK (sdk-name, sdk-version, etc).
          *
-         * @param commonData A key-value set of common user data.
+         * @param commonData A key-value map of common user data.
          * @return ODPManager builder
          */
         public Builder withUserCommonData(@Nonnull Map<String, Object> commonData) {
@@ -177,7 +177,7 @@ public class ODPManager implements AutoCloseable {
          *
          * Note that this is in addition to the identifiers that is automatically included in all ODP events by this SDK.
          *
-         * @param commonData A key-value set of common identifiers.
+         * @param commonIdentifiers A key-value map of common identifiers.
          * @return ODPManager builder
          */
         public Builder withUserCommonIdentifiers(@Nonnull Map<String, String> commonIdentifiers) {

--- a/core-api/src/main/java/com/optimizely/ab/optimizelyconfig/OptimizelyFeature.java
+++ b/core-api/src/main/java/com/optimizely/ab/optimizelyconfig/OptimizelyFeature.java
@@ -63,6 +63,8 @@ public class OptimizelyFeature implements IdKeyMapped {
 
     /**
      * @deprecated use {@link #getExperimentRules()} and {@link #getDeliveryRules()} instead
+     *
+     * @return a map of ExperimentKey to OptimizelyExperiment
      */
     @Deprecated
     public Map<String, OptimizelyExperiment> getExperimentsMap() {

--- a/core-api/src/main/java/com/optimizely/ab/optimizelyconfig/OptimizelyFeature.java
+++ b/core-api/src/main/java/com/optimizely/ab/optimizelyconfig/OptimizelyFeature.java
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2020-2021, Optimizely, Inc. and contributors                        *
+ * Copyright 2020-2021, 2023, Optimizely, Inc. and contributors             *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyBuilderTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyBuilderTest.java
@@ -23,6 +23,8 @@ import com.optimizely.ab.error.NoOpErrorHandler;
 import com.optimizely.ab.event.EventHandler;
 import com.optimizely.ab.event.LogEvent;
 import com.optimizely.ab.event.internal.BuildVersionInfo;
+import com.optimizely.ab.event.internal.ClientEngineInfo;
+import com.optimizely.ab.event.internal.payload.Event;
 import com.optimizely.ab.event.internal.payload.EventBatch;
 import com.optimizely.ab.odp.ODPEventManager;
 import com.optimizely.ab.odp.ODPManager;
@@ -241,6 +243,10 @@ public class OptimizelyBuilderTest {
         verify(eventHandler, timeout(5000)).dispatchEvent(argument.capture());
         assertEquals(argument.getValue().getEventBatch().getClientName(), "android-sdk");
         assertEquals(argument.getValue().getEventBatch().getClientVersion(), "1.2.3");
+
+        // restore the default values for other tests
+        ClientEngineInfo.setClientEngine(ClientEngineInfo.DEFAULT);
+        BuildVersionInfo.setClientVersion(BuildVersionInfo.VERSION);
     }
 
     @Test

--- a/core-api/src/test/java/com/optimizely/ab/odp/ODPEventManagerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/odp/ODPEventManagerTest.java
@@ -284,8 +284,9 @@ public class ODPEventManagerTest {
         assertEquals(merged.get("data_source_version"), "1.2.3");
         assertEquals(merged.size(), 5);
 
-        // restore the default value for other tests
+        // restore the default values for other tests
         ClientEngineInfo.setClientEngine(ClientEngineInfo.DEFAULT);
+        BuildVersionInfo.setClientVersion(BuildVersionInfo.VERSION);
     }
 
     @Test

--- a/core-api/src/test/java/com/optimizely/ab/odp/ODPEventManagerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/odp/ODPEventManagerTest.java
@@ -271,8 +271,8 @@ public class ODPEventManagerTest {
         assertTrue(merged.get("data_source_version").toString().length() > 0);
         assertEquals(merged.size(), 5);
 
-        // when clientInfo is overriden (android-sdk):
-        
+        // when clientInfo is overridden (android-sdk):
+
         ClientEngineInfo.setClientEngine(EventBatch.ClientEngine.ANDROID_SDK);
         BuildVersionInfo.setClientVersion("1.2.3");
         merged = eventManager.augmentCommonData(sourceData);
@@ -283,6 +283,9 @@ public class ODPEventManagerTest {
         assertEquals(merged.get("data_source"), "android-sdk");
         assertEquals(merged.get("data_source_version"), "1.2.3");
         assertEquals(merged.size(), 5);
+
+        // restore the default value for other tests
+        ClientEngineInfo.setClientEngine(ClientEngineInfo.DEFAULT);
     }
 
     @Test

--- a/core-api/src/test/java/com/optimizely/ab/odp/ODPEventManagerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/odp/ODPEventManagerTest.java
@@ -255,6 +255,157 @@ public class ODPEventManagerTest {
         assertFalse(event.isDataValid());
     }
 
+    @Test
+    public void validateAugmentCommonData() {
+        Map<String, Object> sourceData = new HashMap<>();
+        sourceData.put("k1", "source-1");
+        sourceData.put("k2", "source-2");
+        Map<String, Object> userCommonData = new HashMap<>();
+        userCommonData.put("k3", "common-1");
+        userCommonData.put("k4", "common-2");
+
+        Mockito.reset(mockApiManager);
+        ODPEventManager eventManager = new ODPEventManager(mockApiManager);
+        eventManager.setUserCommonData(userCommonData);
+
+        Map<String, Object> merged = eventManager.augmentCommonData(sourceData);
+
+        // event-sourceData
+        assertEquals(merged.get("k1"), "source-1");
+        assertEquals(merged.get("k2"), "source-2");
+        // userCommonData
+        assertEquals(merged.get("k3"), "common-1");
+        assertEquals(merged.get("k4"), "common-2");
+        // sdk-generated common data
+        assertNotNull(merged.get("idempotence_id"));
+        assertEquals(merged.get("data_source_type"), "sdk");
+        assertNotNull(merged.get("data_source"));
+        assertNotNull(merged.get("data_source_version"));
+
+        assertEquals(merged.size(), 8);
+    }
+
+    @Test
+    public void validateAugmentCommonData_keyConflicts1() {
+        Map<String, Object> sourceData = new HashMap<>();
+        sourceData.put("k1", "source-1");
+        sourceData.put("k2", "source-2");
+        Map<String, Object> userCommonData = new HashMap<>();
+        userCommonData.put("k1", "common-1");
+        userCommonData.put("k2", "common-2");
+
+        Mockito.reset(mockApiManager);
+        ODPEventManager eventManager = new ODPEventManager(mockApiManager);
+        eventManager.setUserCommonData(userCommonData);
+
+        Map<String, Object> merged = eventManager.augmentCommonData(sourceData);
+
+        // event-sourceData overrides userCommonData
+        assertEquals(merged.get("k1"), "source-1");
+        assertEquals(merged.get("k2"), "source-2");
+        // sdk-generated common data
+        assertNotNull(merged.get("idempotence_id"));
+        assertEquals(merged.get("data_source_type"), "sdk");
+        assertNotNull(merged.get("data_source"));
+        assertNotNull(merged.get("data_source_version"));
+
+        assertEquals(merged.size(), 6);
+    }
+
+    @Test
+    public void validateAugmentCommonData_keyConflicts2() {
+        Map<String, Object> sourceData = new HashMap<>();
+        sourceData.put("data_source_type", "source-1");
+        Map<String, Object> userCommonData = new HashMap<>();
+        userCommonData.put("data_source_type", "common-1");
+
+        Mockito.reset(mockApiManager);
+        ODPEventManager eventManager = new ODPEventManager(mockApiManager);
+        eventManager.setUserCommonData(userCommonData);
+
+        Map<String, Object> merged = eventManager.augmentCommonData(sourceData);
+
+        // event-sourceData overrides userCommonData and sdk-generated common data
+        assertEquals(merged.get("data_source_type"), "source-1");
+        // sdk-generated common data
+        assertNotNull(merged.get("idempotence_id"));
+        assertNotNull(merged.get("data_source"));
+        assertNotNull(merged.get("data_source_version"));
+
+        assertEquals(merged.size(), 4);
+    }
+
+    @Test
+    public void validateAugmentCommonData_keyConflicts3() {
+        Map<String, Object> sourceData = new HashMap<>();
+        sourceData.put("k1", "source-1");
+        Map<String, Object> userCommonData = new HashMap<>();
+        userCommonData.put("data_source_type", "common-1");
+
+        Mockito.reset(mockApiManager);
+        ODPEventManager eventManager = new ODPEventManager(mockApiManager);
+        eventManager.setUserCommonData(userCommonData);
+
+        Map<String, Object> merged = eventManager.augmentCommonData(sourceData);
+
+        // userCommonData overrides sdk-generated common data
+        assertEquals(merged.get("data_source_type"), "common-1");
+        assertEquals(merged.get("k1"), "source-1");
+        // sdk-generated common data
+        assertNotNull(merged.get("idempotence_id"));
+        assertNotNull(merged.get("data_source"));
+        assertNotNull(merged.get("data_source_version"));
+
+        assertEquals(merged.size(), 5);
+    }
+
+    @Test
+    public void validateAugmentCommonIdentifiers() {
+        Map<String, String> sourceIdentifiers = new HashMap<>();
+        sourceIdentifiers.put("k1", "source-1");
+        sourceIdentifiers.put("k2", "source-2");
+        Map<String, String> userCommonIdentifiers = new HashMap<>();
+        userCommonIdentifiers.put("k3", "common-1");
+        userCommonIdentifiers.put("k4", "common-2");
+
+        Mockito.reset(mockApiManager);
+        ODPEventManager eventManager = new ODPEventManager(mockApiManager);
+        eventManager.setUserCommonIdentifiers(userCommonIdentifiers);
+
+        Map<String, String> merged = eventManager.augmentCommonIdentifiers(sourceIdentifiers);
+
+        // event-sourceIdentifiers
+        assertEquals(merged.get("k1"), "source-1");
+        assertEquals(merged.get("k2"), "source-2");
+        // userCommonIdentifiers
+        assertEquals(merged.get("k3"), "common-1");
+        assertEquals(merged.get("k4"), "common-2");
+
+        assertEquals(merged.size(), 4);
+    }
+
+    @Test
+    public void validateAugmentCommonIdentifiers_keyConflicts() {
+        Map<String, String> sourceIdentifiers = new HashMap<>();
+        sourceIdentifiers.put("k1", "source-1");
+        sourceIdentifiers.put("k2", "source-2");
+        Map<String, String> userCommonIdentifiers = new HashMap<>();
+        userCommonIdentifiers.put("k1", "common-1");
+        userCommonIdentifiers.put("k2", "common-2");
+
+        Mockito.reset(mockApiManager);
+        ODPEventManager eventManager = new ODPEventManager(mockApiManager);
+        eventManager.setUserCommonIdentifiers(userCommonIdentifiers);
+
+        Map<String, String> merged = eventManager.augmentCommonIdentifiers(sourceIdentifiers);
+
+        // event-sourceIdentifiers overrides userCommonIdentifiers
+        assertEquals(merged.get("k1"), "source-1");
+        assertEquals(merged.get("k2"), "source-2");
+
+        assertEquals(merged.size(), 2);
+    }
+
     private ODPEvent getEvent(int id) {
         Map<String, String> identifiers = new HashMap<>();
         identifiers.put("identifier1", "value1-" + id);

--- a/core-api/src/test/java/com/optimizely/ab/odp/ODPManagerBuilderTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/odp/ODPManagerBuilderTest.java
@@ -81,7 +81,7 @@ public class ODPManagerBuilderTest {
 
         ODPEventManager mockEventManager = mock(ODPEventManager.class);
         ODPSegmentManager mockSegmentManager = mock(ODPSegmentManager.class);
-        ODPManager odpManager = ODPManager.builder()
+        ODPManager.builder()
             .withUserCommonData(data)
             .withUserCommonIdentifiers(identifiers)
             .withEventManager(mockEventManager)

--- a/core-api/src/test/java/com/optimizely/ab/odp/ODPManagerBuilderTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/odp/ODPManagerBuilderTest.java
@@ -19,9 +19,7 @@ package com.optimizely.ab.odp;
 import com.optimizely.ab.internal.Cache;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
 
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
@@ -73,4 +71,25 @@ public class ODPManagerBuilderTest {
         odpManager.getSegmentManager().getQualifiedSegments("test-user");
         verify(mockCache).lookup("fs_user_id-$-test-user");
     }
+
+    @Test
+    public void withUserCommonDataAndCommonIdentifiers() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("k1", "v1");
+        Map<String, String> identifiers = new HashMap<>();
+        identifiers.put("k2", "v2");
+
+        ODPEventManager mockEventManager = mock(ODPEventManager.class);
+        ODPSegmentManager mockSegmentManager = mock(ODPSegmentManager.class);
+        ODPManager odpManager = ODPManager.builder()
+            .withUserCommonData(data)
+            .withUserCommonIdentifiers(identifiers)
+            .withEventManager(mockEventManager)
+            .withSegmentManager(mockSegmentManager)
+            .build();
+
+        verify(mockEventManager).setUserCommonData(eq(data));
+        verify(mockEventManager).setUserCommonIdentifiers(eq(identifiers));
+    }
+
 }

--- a/core-api/src/test/java/com/optimizely/ab/odp/ODPManagerBuilderTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/odp/ODPManagerBuilderTest.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2022, Optimizely
+ *    Copyright 2022-2023, Optimizely
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
Add support for Android-SDK ODP integration, which may not be implemented in the Android-SDK.

1. ODPManager.Builder.withExtraCommonData(commonData)
   - clients (android-sdk) will pass common data (client os, device type,...) which should be added into all ODPEvents.
2. ODPManager.Builder.withExtraCommonIdentifiers(commonIdentifiers)
   - clients (android-sdk) will pass common identifiers (vuid,...) which should be added into all ODPEvents.

## Test plan
Unit tests covering builder interface and generated events.

## Issues
- FSSDK-8768