### PR TITLE
Refact: ODPAPIManager now returns fetchQualifiedSegments list instead of string

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPApiManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPApiManager.java
@@ -15,10 +15,11 @@
  */
 package com.optimizely.ab.odp;
 
+import java.util.List;
 import java.util.Set;
 
 public interface ODPApiManager {
-    String fetchQualifiedSegments(String apiKey, String apiEndpoint, String userKey, String userValue, Set<String> segmentsToCheck);
+    List<String> fetchQualifiedSegments(String apiKey, String apiEndpoint, String userKey, String userValue, Set<String> segmentsToCheck);
 
     Integer sendEvents(String apiKey, String apiEndpoint, String eventPayload);
 }

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPApiManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPApiManager.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2022, Optimizely Inc. and contributors
+ *    Copyright 2022-2023, Optimizely Inc. and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
@@ -107,7 +107,7 @@ public class ODPEventManager {
         if (vuid != null) {
             identifiers.put(ODPUserKey.VUID.getKeyString(), vuid);
         }
-        if (userId != null) {
+        if (userId != null && !isVuid(userId)) {
             identifiers.put(ODPUserKey.FS_USER_ID.getKeyString(), userId);
         }
         ODPEvent event = new ODPEvent("fullstack", "identified", identifiers, null);
@@ -147,6 +147,10 @@ public class ODPEventManager {
         identifiers.putAll(userCommonIdentifiers);
         identifiers.putAll(sourceIdentifiers);
         return identifiers;
+    }
+
+    private boolean isVuid(String userId) {
+        return userId.startsWith("vuid_");
     }
 
     private void processEvent(ODPEvent event) {

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
@@ -107,8 +107,12 @@ public class ODPEventManager {
         if (vuid != null) {
             identifiers.put(ODPUserKey.VUID.getKeyString(), vuid);
         }
-        if (userId != null && !isVuid(userId)) {
-            identifiers.put(ODPUserKey.FS_USER_ID.getKeyString(), userId);
+        if (userId != null) {
+            if (isVuid(userId)) {
+                        identifiers.put(ODPUserKey.VUID.getKeyString(), userId);
+            } else {
+                        identifiers.put(ODPUserKey.FS_USER_ID.getKeyString(), userId);
+            }
         }
         ODPEvent event = new ODPEvent("fullstack", "identified", identifiers, null);
         sendEvent(event);

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
@@ -125,7 +125,7 @@ public class ODPEventManager {
     }
 
     @VisibleForTesting
-    Map<String, Object> augmentCommonData(Map<String, Object> sourceData) {
+    protected Map<String, Object> augmentCommonData(Map<String, Object> sourceData) {
         // priority: sourceData > userCommonData > sdkCommonData
 
         Map<String, Object> data = new HashMap<>();
@@ -140,7 +140,7 @@ public class ODPEventManager {
     }
 
     @VisibleForTesting
-    Map<String, String> augmentCommonIdentifiers(Map<String, String> sourceIdentifiers) {
+    protected Map<String, String> augmentCommonIdentifiers(Map<String, String> sourceIdentifiers) {
         // priority: sourceIdentifiers > userCommonIdentifiers
 
         Map<String, String> identifiers = new HashMap<>();

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPSegmentManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPSegmentManager.java
@@ -89,16 +89,7 @@ public class ODPSegmentManager {
 
         logger.debug("ODP Cache Miss. Making a call to ODP Server.");
 
-        ResponseJsonParser parser = ResponseJsonParserFactory.getParser();
-        String qualifiedSegmentsResponse = apiManager.fetchQualifiedSegments(odpConfig.getApiKey(), odpConfig.getApiHost() + SEGMENT_URL_PATH, userKey.getKeyString(), userValue, odpConfig.getAllSegments());
-        try {
-            qualifiedSegments = parser.parseQualifiedSegments(qualifiedSegmentsResponse);
-        } catch (Exception e) {
-            logger.error("Audience segments fetch failed (Error Parsing Response)");
-            logger.debug(e.getMessage());
-            qualifiedSegments = null;
-        }
-
+        qualifiedSegments = apiManager.fetchQualifiedSegments(odpConfig.getApiKey(), odpConfig.getApiHost() + SEGMENT_URL_PATH, userKey.getKeyString(), userValue, odpConfig.getAllSegments());
         if (qualifiedSegments != null && !options.contains(ODPSegmentOption.IGNORE_CACHE)) {
             segmentsCache.save(cacheKey, qualifiedSegments);
         }

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPSegmentManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPSegmentManager.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2022, Optimizely
+ *    Copyright 2022-2023, Optimizely
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/odp/ODPManagerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/odp/ODPManagerTest.java
@@ -24,13 +24,14 @@ import org.mockito.Mockito;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 import static org.junit.Assert.*;
 
 public class ODPManagerTest {
-    private static final String API_RESPONSE = "{\"data\":{\"customer\":{\"audiences\":{\"edges\":[{\"node\":{\"name\":\"segment1\",\"state\":\"qualified\"}},{\"node\":{\"name\":\"segment2\",\"state\":\"qualified\"}}]}}}}";
+    private static final List<String> API_RESPONSE = Arrays.asList(new String[]{"segment1", "segment2"});
 
     @Mock
     ODPApiManager mockApiManager;

--- a/core-api/src/test/java/com/optimizely/ab/odp/ODPManagerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/odp/ODPManagerTest.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2022, Optimizely
+ *    Copyright 2022-2023, Optimizely
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-api/src/test/java/com/optimizely/ab/odp/ODPSegmentManagerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/odp/ODPSegmentManagerTest.java
@@ -43,7 +43,7 @@ public class ODPSegmentManagerTest {
     @Mock
     ODPApiManager mockApiManager;
 
-    private static final String API_RESPONSE = "{\"data\":{\"customer\":{\"audiences\":{\"edges\":[{\"node\":{\"name\":\"segment1\",\"state\":\"qualified\"}},{\"node\":{\"name\":\"segment2\",\"state\":\"qualified\"}}]}}}}";
+    private static final List<String> API_RESPONSE = Arrays.asList(new String[]{"segment1", "segment2"});
 
     @Before
     public void setup() {

--- a/core-api/src/test/java/com/optimizely/ab/odp/ODPSegmentManagerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/odp/ODPSegmentManagerTest.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2022, Optimizely
+ *    Copyright 2022-2023, Optimizely
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/odp/DefaultODPApiManager.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/odp/DefaultODPApiManager.java
@@ -193,8 +193,20 @@ public class DefaultODPApiManager implements ODPApiManager {
 
     /*
     eventPayload Format
-
-
+    [
+      {
+        "action": "identified",
+        "identifiers": {"vuid": <vuid>, "fs_user_id": <userId>, ....},
+        "data": {“source”: <source sdk>, ....},
+        "type": " fullstack "
+      },
+      {
+        "action": "client_initialized",
+        "identifiers": {"vuid": <vuid>, ....},
+        "data": {“source”: <source sdk>, ....},
+        "type": "fullstack"
+      }
+    ]
     Returns:
     1. null, When there was a non-recoverable error and no retry is needed.
     2. 0 If an unexpected error occurred and retrying can be useful.

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/odp/DefaultODPApiManager.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/odp/DefaultODPApiManager.java
@@ -185,7 +185,7 @@ public class DefaultODPApiManager implements ODPApiManager {
         } catch (Exception e) {
             logger.error("Audience segments fetch failed (Error Parsing Response)");
             logger.debug(e.getMessage());
-        }finally {
+        } finally {
             closeHttpResponse(response);
         }
         return null;

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/odp/DefaultODPApiManager.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/odp/DefaultODPApiManager.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2022, Optimizely Inc. and contributors
+ *    Copyright 2022-2023, Optimizely Inc. and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/odp/DefaultODPApiManagerTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/odp/DefaultODPApiManagerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2022, Optimizely Inc. and contributors
+ *    Copyright 2022-2023, Optimizely Inc. and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 public class DefaultODPApiManagerTest {
-    private static final List<String> validResponse = Arrays.asList(new String[]{"has_email", "has_email_opted_in"});
+    private static final List<String> validResponse = Arrays.asList(new String[] {"has_email", "has_email_opted_in"});
     private static final String validRequestResponse = "{\"data\":{\"customer\":{\"audiences\":{\"edges\":[{\"node\":{\"name\":\"has_email\",\"state\":\"qualified\"}},{\"node\":{\"name\":\"has_email_opted_in\",\"state\":\"qualified\"}}]}}}}";
 
     @Rule

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/odp/DefaultODPApiManagerTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/odp/DefaultODPApiManagerTest.java
@@ -30,13 +30,15 @@ import org.mockito.ArgumentCaptor;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 public class DefaultODPApiManagerTest {
-    private static final String validResponse = "{\"data\":{\"customer\":{\"audiences\":{\"edges\":[{\"node\":{\"name\":\"has_email\",\"state\":\"qualified\"}},{\"node\":{\"name\":\"has_email_opted_in\",\"state\":\"qualified\"}}]}}}}";
+    private static final List<String> validResponse = Arrays.asList(new String[]{"has_email", "has_email_opted_in"});
+    private static final String validRequestResponse = "{\"data\":{\"customer\":{\"audiences\":{\"edges\":[{\"node\":{\"name\":\"has_email\",\"state\":\"qualified\"}},{\"node\":{\"name\":\"has_email_opted_in\",\"state\":\"qualified\"}}]}}}}";
 
     @Rule
     public LogbackVerifier logbackVerifier = new LogbackVerifier();
@@ -55,7 +57,7 @@ public class DefaultODPApiManagerTest {
 
         when(statusLine.getStatusCode()).thenReturn(statusCode);
         when(httpResponse.getStatusLine()).thenReturn(statusLine);
-        when(httpResponse.getEntity()).thenReturn(new StringEntity(validResponse));
+        when(httpResponse.getEntity()).thenReturn(new StringEntity(validRequestResponse));
 
         when(mockHttpClient.execute(any(HttpPost.class)))
             .thenReturn(httpResponse);
@@ -99,19 +101,19 @@ public class DefaultODPApiManagerTest {
     @Test
     public void returnResponseStringWhenStatusIs200() throws Exception {
         ODPApiManager apiManager = new DefaultODPApiManager(mockHttpClient);
-        String responseString = apiManager.fetchQualifiedSegments("key", "endPoint", "fs_user_id", "test_user", new HashSet<>(Arrays.asList("segment_1", "segment_2")));
+        List<String> response = apiManager.fetchQualifiedSegments("key", "endPoint", "fs_user_id", "test_user", new HashSet<>(Arrays.asList("segment_1", "segment_2")));
         verify(mockHttpClient, times(1)).execute(any(HttpPost.class));
-        assertEquals(validResponse, responseString);
+        assertEquals(validResponse, response);
     }
 
     @Test
     public void returnNullWhenStatusIsNot200AndLogError() throws Exception {
         setupHttpClient(500);
         ODPApiManager apiManager = new DefaultODPApiManager(mockHttpClient);
-        String responseString = apiManager.fetchQualifiedSegments("key", "endPoint", "fs_user_id", "test_user", new HashSet<>(Arrays.asList("segment_1", "segment_2")));
+        List<String> response = apiManager.fetchQualifiedSegments("key", "endPoint", "fs_user_id", "test_user", new HashSet<>(Arrays.asList("segment_1", "segment_2")));
         verify(mockHttpClient, times(1)).execute(any(HttpPost.class));
         logbackVerifier.expectMessage(Level.ERROR, "Unexpected response from ODP server, Response code: 500, null");
-        assertNull(responseString);
+        assertNull(response);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Refactored code of ODPAPIManager fetchQualifiedSegments  function to return list of qualifiedSegments. This is to keep it consistent with other SDKs
- This allows user to override the function and return the qualifiedSegment and they won't have to figure out how to parse the graphql response. 

## Test plan
Fixed some unit tests according to this new change. All unit tests should pass. 

## Issues
- [FSSDK-8842](https://jira.sso.episerver.net/browse/FSSDK-8842)