### PR TITLE
fix(ats): convert graphQL query for fetchQualifiedSegments with vuid

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
@@ -108,10 +108,10 @@ public class ODPEventManager {
             identifiers.put(ODPUserKey.VUID.getKeyString(), vuid);
         }
         if (userId != null) {
-            if (isVuid(userId)) {
-                        identifiers.put(ODPUserKey.VUID.getKeyString(), userId);
+            if (ODPManager.isVuid(userId)) {
+                identifiers.put(ODPUserKey.VUID.getKeyString(), userId);
             } else {
-                        identifiers.put(ODPUserKey.FS_USER_ID.getKeyString(), userId);
+                identifiers.put(ODPUserKey.FS_USER_ID.getKeyString(), userId);
             }
         }
         ODPEvent event = new ODPEvent("fullstack", "identified", identifiers, null);
@@ -151,10 +151,6 @@ public class ODPEventManager {
         identifiers.putAll(userCommonIdentifiers);
         identifiers.putAll(sourceIdentifiers);
         return identifiers;
-    }
-
-    private boolean isVuid(String userId) {
-        return userId.startsWith("vuid_");
     }
 
     private void processEvent(ODPEvent event) {

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPManager.java
@@ -68,6 +68,10 @@ public class ODPManager implements AutoCloseable {
         eventManager.stop();
     }
 
+    public static boolean isVuid(String userId) {
+        return userId.startsWith("vuid_");
+    }
+
     public static Builder builder() {
         return new Builder();
     }

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPSegmentManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPSegmentManager.java
@@ -52,11 +52,15 @@ public class ODPSegmentManager {
         this.segmentsCache = new DefaultLRUCache<>(cacheSize, cacheTimeoutSeconds);
     }
 
-    public List<String> getQualifiedSegments(String fsUserId) {
-        return getQualifiedSegments(ODPUserKey.FS_USER_ID, fsUserId, Collections.emptyList());
+    public List<String> getQualifiedSegments(String userId) {
+        return getQualifiedSegments(userId, Collections.emptyList());
     }
-    public List<String> getQualifiedSegments(String fsUserId, List<ODPSegmentOption> options) {
-        return getQualifiedSegments(ODPUserKey.FS_USER_ID, fsUserId, options);
+    public List<String> getQualifiedSegments(String userId, List<ODPSegmentOption> options) {
+        if (ODPManager.isVuid(userId)) {
+            return getQualifiedSegments(ODPUserKey.VUID, userId, options);
+        } else {
+            return getQualifiedSegments(ODPUserKey.FS_USER_ID, userId, options);
+        }
     }
 
     public List<String> getQualifiedSegments(ODPUserKey userKey, String userValue) {

--- a/core-api/src/test/java/com/optimizely/ab/odp/ODPEventManagerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/odp/ODPEventManagerTest.java
@@ -212,6 +212,64 @@ public class ODPEventManagerTest {
     }
 
     @Test
+    public void identifyUserWithVuidAndUserId() throws InterruptedException {
+        ODPEventManager eventManager = spy(new ODPEventManager(mockApiManager));
+        ArgumentCaptor<ODPEvent> captor = ArgumentCaptor.forClass(ODPEvent.class);
+
+        eventManager.identifyUser("vuid_123", "test-user");
+        verify(eventManager, times(1)).sendEvent(captor.capture());
+
+        ODPEvent event = captor.getValue();
+        Map<String, String> identifiers = event.getIdentifiers();
+        assertEquals(identifiers.size(), 2);
+        assertEquals(identifiers.get("vuid"), "vuid_123");
+        assertEquals(identifiers.get("fs_user_id"), "test-user");
+    }
+
+    @Test
+    public void identifyUserWithVuidOnly() throws InterruptedException {
+        ODPEventManager eventManager = spy(new ODPEventManager(mockApiManager));
+        ArgumentCaptor<ODPEvent> captor = ArgumentCaptor.forClass(ODPEvent.class);
+
+        eventManager.identifyUser("vuid_123", null);
+        verify(eventManager, times(1)).sendEvent(captor.capture());
+
+        ODPEvent event = captor.getValue();
+        Map<String, String> identifiers = event.getIdentifiers();
+        assertEquals(identifiers.size(), 1);
+        assertEquals(identifiers.get("vuid"), "vuid_123");
+    }
+
+    @Test
+    public void identifyUserWithUserIdOnly() throws InterruptedException {
+        ODPEventManager eventManager = spy(new ODPEventManager(mockApiManager));
+        ArgumentCaptor<ODPEvent> captor = ArgumentCaptor.forClass(ODPEvent.class);
+
+        eventManager.identifyUser(null, "test-user");
+        verify(eventManager, times(1)).sendEvent(captor.capture());
+
+        ODPEvent event = captor.getValue();
+        Map<String, String> identifiers = event.getIdentifiers();
+        assertEquals(identifiers.size(), 1);
+        assertEquals(identifiers.get("fs_user_id"), "test-user");
+    }
+
+    @Test
+    public void identifyUserWithVuidAsUserId() throws InterruptedException {
+        ODPEventManager eventManager = spy(new ODPEventManager(mockApiManager));
+        ArgumentCaptor<ODPEvent> captor = ArgumentCaptor.forClass(ODPEvent.class);
+
+        eventManager.identifyUser(null, "vuid_123");
+        verify(eventManager, times(1)).sendEvent(captor.capture());
+
+        ODPEvent event = captor.getValue();
+        Map<String, String> identifiers = event.getIdentifiers();
+        assertEquals(identifiers.size(), 1);
+        // SDK will convert userId to vuid when userId has a valid vuid format.
+        assertEquals(identifiers.get("vuid"), "vuid_123");
+    }
+
+    @Test
     public void applyUpdatedODPConfigWhenAvailable() throws InterruptedException {
         Mockito.reset(mockApiManager);
         Mockito.when(mockApiManager.sendEvents(any(), any(), any())).thenReturn(202);

--- a/core-api/src/test/java/com/optimizely/ab/odp/ODPManagerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/odp/ODPManagerTest.java
@@ -121,4 +121,12 @@ public class ODPManagerTest {
         odpManager = ODPManager.builder().withApiManager(mockApiManager).build();
         assertNotNull(odpManager.getSegmentManager());
     }
+
+    @Test
+    public void isVuid() {
+        assertTrue(ODPManager.isVuid("vuid_123"));
+        assertFalse(ODPManager.isVuid("vuid123"));
+        assertFalse(ODPManager.isVuid("any_123"));
+        assertFalse(ODPManager.isVuid(""));
+    }
 }

--- a/core-api/src/test/java/com/optimizely/ab/odp/ODPSegmentManagerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/odp/ODPSegmentManagerTest.java
@@ -398,4 +398,20 @@ public class ODPSegmentManagerTest {
 
         logbackVerifier.expectMessage(Level.DEBUG, "No Segments are used in the project, Not Fetching segments. Returning empty list");
     }
+
+    @Test
+    public void getQualifiedSegmentsWithUserId() {
+        ODPSegmentManager segmentManager = spy(new ODPSegmentManager(mockApiManager, mockCache));
+        segmentManager.getQualifiedSegments("test-user");
+        verify(segmentManager).getQualifiedSegments(ODPUserKey.FS_USER_ID, "test-user", Collections.emptyList());
+    }
+
+    @Test
+    public void getQualifiedSegmentsWithVuid() {
+        ODPSegmentManager segmentManager = spy(new ODPSegmentManager(mockApiManager, mockCache));
+        segmentManager.getQualifiedSegments("vuid_123");
+        // SDK will convert userId to vuid when userId has a valid vuid format.
+        verify(segmentManager).getQualifiedSegments(ODPUserKey.VUID, "vuid_123", Collections.emptyList());
+    }
+
 }


### PR DESCRIPTION
## Summary
When vuid is used as userId, graphQL fetch segments api should be called with "vuid" as a query identifier.

## Test plan
- Unit test validating "vuid" as a query identifier.

## Issues
- [FSSDK-8383](https://jira.sso.episerver.net/browse/FSSDK-8383)