### PR TITLE
fix(odp): check odp identifiers not empty before sending

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -1468,6 +1468,15 @@ public class Optimizely implements AutoCloseable {
         return odpManager;
     }
 
+
+    /**
+     * Send an event to the ODP server.
+     *
+     * @param type the event type (default = "fullstack").
+     * @param action the event action name.
+     * @param identifiers a dictionary for identifiers. The caller must provide at least one key-value pair.
+     * @param data a dictionary for associated data. The default event data will be added to this data before sending to the ODP server.
+     */
     public void sendODPEvent(@Nullable String type, @Nonnull String action, @Nullable Map<String, String> identifiers, @Nullable Map<String, Object> data) {
         if (odpManager != null) {
             ODPEvent event = new ODPEvent(type, action, identifiers, data);

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPEvent.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPEvent.java
@@ -84,4 +84,10 @@ public class ODPEvent {
         }
         return true;
     }
+
+    @Transient
+    public Boolean isIdentifiersValid() {
+        return !identifiers.isEmpty();
+    }
+
 }

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
@@ -119,12 +119,19 @@ public class ODPEventManager {
     }
 
     public void sendEvent(ODPEvent event) {
-        if (!event.isDataValid()) {
-            logger.error("ODP event send failed (ODP data is not valid)");
-            return;
-        }
         event.setData(augmentCommonData(event.getData()));
         event.setIdentifiers(augmentCommonIdentifiers(event.getIdentifiers()));
+
+        if (!event.isIdentifiersValid()) {
+            logger.error("ODP event send failed (event identifiers must have at least one key-value pair)");
+            return;
+        }
+
+        if (!event.isDataValid()) {
+            logger.error("ODP event send failed (event data is not valid)");
+            return;
+        }
+
         processEvent(event);
     }
 


### PR DESCRIPTION
## Summary
Check if ODP events have at least one key-value pair for identifiers.
If not, discard the request without sending to the ODP server.

## Test plan
- Add a test with empty identifiers.

## Issues
- [FSSDK-8947](https://jira.sso.episerver.net/browse/FSSDK-8947)