### PR TITLE
[FSSDK-9056] fix: add config check in odp methods

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -1445,6 +1445,11 @@ public class Optimizely implements AutoCloseable {
     }
 
     public List<String> fetchQualifiedSegments(String userId, @Nonnull List<ODPSegmentOption> segmentOptions) {
+        ProjectConfig projectConfig = getProjectConfig();
+        if (projectConfig == null) {
+            logger.error("Optimizely instance is not valid, failing fetchQualifiedSegments call.");
+            return null;
+        }
         if (odpManager != null) {
             synchronized (odpManager) {
                 return odpManager.getSegmentManager().getQualifiedSegments(userId, segmentOptions);
@@ -1455,6 +1460,12 @@ public class Optimizely implements AutoCloseable {
     }
 
     public void fetchQualifiedSegments(String userId, ODPSegmentManager.ODPSegmentFetchCallback callback, List<ODPSegmentOption> segmentOptions) {
+        ProjectConfig projectConfig = getProjectConfig();
+        if (projectConfig == null) {
+            logger.error("Optimizely instance is not valid, failing fetchQualifiedSegments call.");
+            callback.onCompleted(null);
+            return;
+        }
         if (odpManager == null) {
             logger.error("Audience segments fetch failed (ODP is not enabled).");
             callback.onCompleted(null);
@@ -1478,6 +1489,11 @@ public class Optimizely implements AutoCloseable {
      * @param data a dictionary for associated data. The default event data will be added to this data before sending to the ODP server.
      */
     public void sendODPEvent(@Nullable String type, @Nonnull String action, @Nullable Map<String, String> identifiers, @Nullable Map<String, Object> data) {
+        ProjectConfig projectConfig = getProjectConfig();
+        if (projectConfig == null) {
+            logger.error("Optimizely instance is not valid, failing sendODPEvent call.");
+            return;
+        }
         if (odpManager != null) {
             ODPEvent event = new ODPEvent(type, action, identifiers, data);
             odpManager.getEventManager().sendEvent(event);
@@ -1487,6 +1503,11 @@ public class Optimizely implements AutoCloseable {
     }
 
     public void identifyUser(@Nonnull String userId) {
+        ProjectConfig projectConfig = getProjectConfig();
+        if (projectConfig == null) {
+            logger.error("Optimizely instance is not valid, failing identifyUser call.");
+            return;
+        }
         ODPManager odpManager = getODPManager();
         if (odpManager != null) {
             odpManager.getEventManager().identifyUser(userId);

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -4763,6 +4763,33 @@ public class OptimizelyTest {
     }
 
     @Test
+    public void sendODPEventInvalidConfig() {
+        ProjectConfigManager mockProjectConfigManager = mock(ProjectConfigManager.class);
+        Mockito.when(mockProjectConfigManager.getConfig()).thenReturn(null);
+        ODPEventManager mockODPEventManager = mock(ODPEventManager.class);
+        ODPManager mockODPManager = mock(ODPManager.class);
+
+        Mockito.when(mockODPManager.getEventManager()).thenReturn(mockODPEventManager);
+        Optimizely optimizely = Optimizely.builder()
+            .withConfigManager(mockProjectConfigManager)
+            .withODPManager(mockODPManager)
+            .build();
+
+        verify(mockODPEventManager).start();
+
+        Map<String, String> identifiers = new HashMap<>();
+        identifiers.put("id1", "value1");
+        identifiers.put("id2", "value2");
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("sdk", "java");
+        data.put("revision", 52);
+
+        optimizely.sendODPEvent("fullstack", "identify", identifiers, data);
+        logbackVerifier.expectMessage(Level.ERROR, "Optimizely instance is not valid, failing sendODPEvent call.");
+    }
+
+    @Test
     public void sendODPEventError() {
         ProjectConfigManager mockProjectConfigManager = mock(ProjectConfigManager.class);
 

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -4733,6 +4733,7 @@ public class OptimizelyTest {
     @Test
     public void sendODPEvent() {
         ProjectConfigManager mockProjectConfigManager = mock(ProjectConfigManager.class);
+        Mockito.when(mockProjectConfigManager.getConfig()).thenReturn(validProjectConfig);
         ODPEventManager mockODPEventManager = mock(ODPEventManager.class);
         ODPManager mockODPManager = mock(ODPManager.class);
 
@@ -4792,7 +4793,7 @@ public class OptimizelyTest {
     @Test
     public void sendODPEventError() {
         ProjectConfigManager mockProjectConfigManager = mock(ProjectConfigManager.class);
-
+        Mockito.when(mockProjectConfigManager.getConfig()).thenReturn(validProjectConfig);
         Optimizely optimizely = Optimizely.builder()
             .withConfigManager(mockProjectConfigManager)
             .build();
@@ -4812,6 +4813,7 @@ public class OptimizelyTest {
     @Test
     public void identifyUser() {
         ProjectConfigManager mockProjectConfigManager = mock(ProjectConfigManager.class);
+        Mockito.when(mockProjectConfigManager.getConfig()).thenReturn(validProjectConfig);
         ODPEventManager mockODPEventManager = mock(ODPEventManager.class);
         ODPManager mockODPManager = mock(ODPManager.class);
 

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyUserContextTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyUserContextTest.java
@@ -1787,7 +1787,7 @@ public class OptimizelyUserContextTest {
             .withODPManager(mockODPManager)
             .build();
 
-        OptimizelyUserContext userContext = optimizely.createUserContext("test-user");
+        optimizely.createUserContext("test-user");
         verify(mockODPEventManager, never()).identifyUser("test-user");
         Mockito.reset(mockODPEventManager);
 

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyUserContextTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyUserContextTest.java
@@ -1628,6 +1628,8 @@ public class OptimizelyUserContextTest {
         Mockito.when(mockODPManager.getSegmentManager()).thenReturn(mockODPSegmentManager);
 
         Optimizely optimizely = Optimizely.builder()
+            .withDatafile(datafile)
+            .withEventProcessor(new ForwardingEventProcessor(eventHandler, null))
             .withODPManager(mockODPManager)
             .build();
 
@@ -1665,6 +1667,8 @@ public class OptimizelyUserContextTest {
     @Test
     public void fetchQualifiedSegmentsError() {
         Optimizely optimizely = Optimizely.builder()
+            .withDatafile(datafile)
+            .withEventProcessor(new ForwardingEventProcessor(eventHandler, null))
             .build();
         OptimizelyUserContext userContext = optimizely.createUserContext("test-user");
 
@@ -1689,6 +1693,8 @@ public class OptimizelyUserContextTest {
         Mockito.when(mockODPManager.getSegmentManager()).thenReturn(mockODPSegmentManager);
 
         Optimizely optimizely = Optimizely.builder()
+            .withDatafile(datafile)
+            .withEventProcessor(new ForwardingEventProcessor(eventHandler, null))
             .withODPManager(mockODPManager)
             .build();
 
@@ -1720,6 +1726,8 @@ public class OptimizelyUserContextTest {
     @Test
     public void fetchQualifiedSegmentsAsyncError() throws InterruptedException {
         Optimizely optimizely = Optimizely.builder()
+            .withDatafile(datafile)
+            .withEventProcessor(new ForwardingEventProcessor(eventHandler, null))
             .build();
 
         OptimizelyUserContext userContext = optimizely.createUserContext("test-user");
@@ -1796,6 +1804,8 @@ public class OptimizelyUserContextTest {
         Mockito.when(mockODPManager.getSegmentManager()).thenReturn(mockODPSegmentManager);
 
         Optimizely optimizely = Optimizely.builder()
+            .withDatafile(datafile)
+            .withEventProcessor(new ForwardingEventProcessor(eventHandler, null))
             .withODPManager(mockODPManager)
             .build();
 


### PR DESCRIPTION
## Summary
- Add check for ProjectConfig in odp methods.
This will ensure the datafile has been fetched first.

## Test plan
all tests pass

## Ticket
[FSSDK-9056](https://jira.sso.episerver.net/browse/FSSDK-9056)