### PR TITLE
[FSSDK-9127] fix: Handle ODP INVALID_IDENTIFIER_EXCEPTION code

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/odp/parser/impl/GsonParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/parser/impl/GsonParser.java
@@ -36,8 +36,8 @@ public class GsonParser implements ResponseJsonParser {
             if (root.has("errors")) {
                 JsonArray errors = root.getAsJsonArray("errors");
                 JsonObject extensions = errors.get(0).getAsJsonObject().get("extensions").getAsJsonObject();
-                if (extensions != null && extensions.has("code")) {
-                    if (extensions.get("code").getAsString().equals("INVALID_IDENTIFIER_EXCEPTION")) {
+                if (extensions != null) {
+                    if (extensions.has("code") && extensions.get("code").getAsString().equals("INVALID_IDENTIFIER_EXCEPTION")) {
                         logger.warn("Audience segments fetch failed (invalid identifier)");
                     } else {
                         String errorMessage = extensions.get("classification") == null ? "decode error" : extensions.get("classification").getAsString();

--- a/core-api/src/main/java/com/optimizely/ab/odp/parser/impl/JacksonParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/parser/impl/JacksonParser.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2022, Optimizely Inc. and contributors
+ *    Copyright 2022-2023, Optimizely Inc. and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -39,14 +39,15 @@ public class JacksonParser implements ResponseJsonParser {
 
             if (root.has("errors")) {
                 JsonNode errors = root.path("errors");
-                StringBuilder logMessage = new StringBuilder();
-                for (int i = 0; i < errors.size(); i++) {
-                    if (i > 0) {
-                        logMessage.append(", ");
+                JsonNode extensions = errors.get(0).path("extensions");
+                if (extensions != null && extensions.has("code")) {
+                    if (extensions.path("code").asText().equals("INVALID_IDENTIFIER_EXCEPTION")) {
+                        logger.warn("Audience segments fetch failed (invalid identifier)");
+                    } else {
+                        String errorMessage = extensions.has("classification") ? extensions.path("classification").asText() : "decode error";
+                        logger.error("Audience segments fetch failed (" + errorMessage + ")");
                     }
-                    logMessage.append(errors.get(i).path("message"));
                 }
-                logger.error(logMessage.toString());
                 return null;
             }
 

--- a/core-api/src/main/java/com/optimizely/ab/odp/parser/impl/JacksonParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/parser/impl/JacksonParser.java
@@ -40,8 +40,8 @@ public class JacksonParser implements ResponseJsonParser {
             if (root.has("errors")) {
                 JsonNode errors = root.path("errors");
                 JsonNode extensions = errors.get(0).path("extensions");
-                if (extensions != null && extensions.has("code")) {
-                    if (extensions.path("code").asText().equals("INVALID_IDENTIFIER_EXCEPTION")) {
+                if (extensions != null) {
+                    if (extensions.has("code") && extensions.path("code").asText().equals("INVALID_IDENTIFIER_EXCEPTION")) {
                         logger.warn("Audience segments fetch failed (invalid identifier)");
                     } else {
                         String errorMessage = extensions.has("classification") ? extensions.path("classification").asText() : "decode error";

--- a/core-api/src/main/java/com/optimizely/ab/odp/parser/impl/JsonParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/parser/impl/JsonParser.java
@@ -37,8 +37,8 @@ public class JsonParser implements ResponseJsonParser {
             if (root.has("errors")) {
                 JSONArray errors = root.getJSONArray("errors");
                 JSONObject extensions = errors.getJSONObject(0).getJSONObject("extensions");
-                if (extensions != null && extensions.has("code")) {
-                    if (extensions.getString("code").equals("INVALID_IDENTIFIER_EXCEPTION")) {
+                if (extensions != null) {
+                    if (extensions.has("code") && extensions.getString("code").equals("INVALID_IDENTIFIER_EXCEPTION")) {
                         logger.warn("Audience segments fetch failed (invalid identifier)");
                     } else {
                         String errorMessage = extensions.has("classification") ?

--- a/core-api/src/main/java/com/optimizely/ab/odp/parser/impl/JsonParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/parser/impl/JsonParser.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2022, Optimizely Inc. and contributors
+ *    Copyright 2022-2023, Optimizely Inc. and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -35,15 +35,17 @@ public class JsonParser implements ResponseJsonParser {
             JSONObject root = new JSONObject(responseJson);
 
             if (root.has("errors")) {
-                JSONArray errors =  root.getJSONArray("errors");
-                StringBuilder logMessage = new StringBuilder();
-                for (int i = 0; i < errors.length(); i++) {
-                    if (i > 0) {
-                        logMessage.append(", ");
+                JSONArray errors = root.getJSONArray("errors");
+                JSONObject extensions = errors.getJSONObject(0).getJSONObject("extensions");
+                if (extensions != null && extensions.has("code")) {
+                    if (extensions.getString("code").equals("INVALID_IDENTIFIER_EXCEPTION")) {
+                        logger.warn("Audience segments fetch failed (invalid identifier)");
+                    } else {
+                        String errorMessage = extensions.has("classification") ?
+                            extensions.getString("classification") : "decode error";
+                        logger.error("Audience segments fetch failed (" + errorMessage + ")");
                     }
-                    logMessage.append(errors.getJSONObject(i).getString("message"));
                 }
-                logger.error(logMessage.toString());
                 return null;
             }
 

--- a/core-api/src/main/java/com/optimizely/ab/odp/parser/impl/JsonSimpleParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/parser/impl/JsonSimpleParser.java
@@ -39,8 +39,8 @@ public class JsonSimpleParser implements ResponseJsonParser {
             if (root.containsKey("errors")) {
                 JSONArray errors = (JSONArray) root.get("errors");
                 JSONObject extensions = (JSONObject) ((JSONObject) errors.get(0)).get("extensions");
-                if (extensions != null && extensions.containsKey("code")) {
-                    if (extensions.get("code").equals("INVALID_IDENTIFIER_EXCEPTION")) {
+                if (extensions != null) {
+                    if (extensions.containsKey("code") && extensions.get("code").equals("INVALID_IDENTIFIER_EXCEPTION")) {
                         logger.warn("Audience segments fetch failed (invalid identifier)");
                     } else {
                         String errorMessage = extensions.get("classification") == null ? "decode error" : (String) extensions.get("classification");

--- a/core-api/src/main/java/com/optimizely/ab/odp/parser/impl/JsonSimpleParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/parser/impl/JsonSimpleParser.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2022, Optimizely Inc. and contributors
+ *    Copyright 2022-2023, Optimizely Inc. and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -36,17 +36,17 @@ public class JsonSimpleParser implements ResponseJsonParser {
         JSONObject root = null;
         try {
             root = (JSONObject) parser.parse(responseJson);
-
             if (root.containsKey("errors")) {
                 JSONArray errors = (JSONArray) root.get("errors");
-                StringBuilder logMessage = new StringBuilder();
-                for (int i = 0; i < errors.size(); i++) {
-                    if (i > 0) {
-                        logMessage.append(", ");
+                JSONObject extensions = (JSONObject) ((JSONObject) errors.get(0)).get("extensions");
+                if (extensions != null && extensions.containsKey("code")) {
+                    if (extensions.get("code").equals("INVALID_IDENTIFIER_EXCEPTION")) {
+                        logger.warn("Audience segments fetch failed (invalid identifier)");
+                    } else {
+                        String errorMessage = extensions.get("classification") == null ? "decode error" : (String) extensions.get("classification");
+                        logger.error("Audience segments fetch failed (" + errorMessage + ")");
                     }
-                    logMessage.append((String)((JSONObject) errors.get(i)).get("message"));
                 }
-                logger.error(logMessage.toString());
                 return null;
             }
 

--- a/core-api/src/test/java/com/optimizely/ab/odp/parser/ResponseJsonParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/odp/parser/ResponseJsonParserTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2022, Optimizely Inc. and contributors
+ *    Copyright 2022-2023, Optimizely Inc. and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ public class ResponseJsonParserTest {
 
     @Test
     public void returnNullAndLogCorrectErrorWhenErrorResponseIsReturned() {
-        String responseToParse = "{\"errors\":[{\"message\":\"Exception while fetching data (/customer) : java.lang.RuntimeException: could not resolve _fs_user_id = wrong_id\",\"locations\":[{\"line\":2,\"column\":3}],\"path\":[\"customer\"],\"extensions\":{\"classification\":\"InvalidIdentifierException\"}}],\"data\":{\"customer\":null}}";
+        String responseToParse = "{\"errors\":[{\"message\":\"Exception while fetching data (/customer) : java.lang.RuntimeException: could not resolve _fs_user_id = wrong_id\",\"locations\":[{\"line\":2,\"column\":3}],\"path\":[\"customer\"],\"extensions\":{\"code\":\"INVALID_IDENTIFIER_EXCEPTION\", \"classification\":\"DataFetchingException\"}}],\"data\":{\"customer\":null}}";
         List<String> parsedSegments =  jsonParser.parseQualifiedSegments(responseToParse);
         logbackVerifier.expectMessage(Level.ERROR, "Exception while fetching data (/customer) : java.lang.RuntimeException: could not resolve _fs_user_id = wrong_id");
         assertEquals(null, parsedSegments);

--- a/core-api/src/test/java/com/optimizely/ab/odp/parser/ResponseJsonParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/odp/parser/ResponseJsonParserTest.java
@@ -94,6 +94,7 @@ public class ResponseJsonParserTest {
     public void returnNullAndLogNoErrorWhenErrorResponseIsReturnedButCodeKeyIsNotPresent() {
         String responseToParse = "{\"errors\":[{\"message\":\"Exception while fetching data (/customer) : java.lang.RuntimeException: could not resolve _fs_user_id = wrong_id\",\"locations\":[{\"line\":2,\"column\":3}],\"path\":[\"customer\"],\"extensions\":{\"classification\":\"DataFetchingException\"}}],\"data\":{\"customer\":null}}";
         List<String> parsedSegments =  jsonParser.parseQualifiedSegments(responseToParse);
+        logbackVerifier.expectMessage(Level.ERROR, "Audience segments fetch failed (DataFetchingException)");
         assertEquals(null, parsedSegments);
     }
 

--- a/core-api/src/test/java/com/optimizely/ab/odp/parser/ResponseJsonParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/odp/parser/ResponseJsonParserTest.java
@@ -86,7 +86,31 @@ public class ResponseJsonParserTest {
     public void returnNullAndLogCorrectErrorWhenErrorResponseIsReturned() {
         String responseToParse = "{\"errors\":[{\"message\":\"Exception while fetching data (/customer) : java.lang.RuntimeException: could not resolve _fs_user_id = wrong_id\",\"locations\":[{\"line\":2,\"column\":3}],\"path\":[\"customer\"],\"extensions\":{\"code\":\"INVALID_IDENTIFIER_EXCEPTION\", \"classification\":\"DataFetchingException\"}}],\"data\":{\"customer\":null}}";
         List<String> parsedSegments =  jsonParser.parseQualifiedSegments(responseToParse);
-        logbackVerifier.expectMessage(Level.ERROR, "Exception while fetching data (/customer) : java.lang.RuntimeException: could not resolve _fs_user_id = wrong_id");
+        logbackVerifier.expectMessage(Level.WARN, "Audience segments fetch failed (invalid identifier)");
         assertEquals(null, parsedSegments);
     }
+
+    @Test
+    public void returnNullAndLogNoErrorWhenErrorResponseIsReturnedButCodeKeyIsNotPresent() {
+        String responseToParse = "{\"errors\":[{\"message\":\"Exception while fetching data (/customer) : java.lang.RuntimeException: could not resolve _fs_user_id = wrong_id\",\"locations\":[{\"line\":2,\"column\":3}],\"path\":[\"customer\"],\"extensions\":{\"classification\":\"DataFetchingException\"}}],\"data\":{\"customer\":null}}";
+        List<String> parsedSegments =  jsonParser.parseQualifiedSegments(responseToParse);
+        assertEquals(null, parsedSegments);
+    }
+
+    @Test
+    public void returnNullAndLogCorrectErrorWhenErrorResponseIsReturnedButCodeValueIsNotInvalidIdentifierException() {
+        String responseToParse = "{\"errors\":[{\"message\":\"Exception while fetching data (/customer) : java.lang.RuntimeException: could not resolve _fs_user_id = wrong_id\",\"locations\":[{\"line\":2,\"column\":3}],\"path\":[\"customer\"],\"extensions\":{\"code\":\"OTHER_EXCEPTIONS\", \"classification\":\"DataFetchingException\"}}],\"data\":{\"customer\":null}}";
+        List<String> parsedSegments =  jsonParser.parseQualifiedSegments(responseToParse);
+        logbackVerifier.expectMessage(Level.ERROR, "Audience segments fetch failed (DataFetchingException)");
+        assertEquals(null, parsedSegments);
+    }
+
+    @Test
+    public void returnNullAndLogCorrectErrorWhenErrorResponseIsReturnedButCodeValueIsNotInvalidIdentifierExceptionNullClassification() {
+        String responseToParse = "{\"errors\":[{\"message\":\"Exception while fetching data (/customer) : java.lang.RuntimeException: could not resolve _fs_user_id = wrong_id\",\"locations\":[{\"line\":2,\"column\":3}],\"path\":[\"customer\"],\"extensions\":{\"code\":\"OTHER_EXCEPTIONS\"}}],\"data\":{\"customer\":null}}";
+        List<String> parsedSegments =  jsonParser.parseQualifiedSegments(responseToParse);
+        logbackVerifier.expectMessage(Level.ERROR, "Audience segments fetch failed (decode error)");
+        assertEquals(null, parsedSegments);
+    }
+
 }

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/odp/DefaultODPApiManager.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/odp/DefaultODPApiManager.java
@@ -137,7 +137,8 @@ public class DefaultODPApiManager implements ODPApiManager {
              "customer"
            ],
            "extensions": {
-             "classification": "InvalidIdentifierException"
+             "code": "INVALID_IDENTIFIER_EXCEPTION",
+             "classification": "DataFetchingException"
            }
          }
        ],


### PR DESCRIPTION
## Summary

Support a new format for ODP `InvalidIdentifierException` (when SDK fetches segments with a non-registered userId).

```
       "extensions": {
            "code": "INVALID_IDENTIFIER_EXCEPTION",
            "classification": "DataFetchingException"
       }
```

## Test plan
- updated unit tests to cover the new response format.
- Existing unit tests should pass
- FSC should continue to pass

## Issues
- FSSDK-9127