### PR TITLE
chore: fix ubuntu version for github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ on:
         required: true
 jobs:
   run_build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: set up JDK 8


### PR DESCRIPTION
## Summary
ubuntu-18.04 not supported any more. upgrade it to latest.

## Issues
- FSSDK-123