### PR TITLE
[FSSDK-9041] chore: upgrade dependency versions

### DIFF
--- a/core-httpclient-impl/gradle.properties
+++ b/core-httpclient-impl/gradle.properties
@@ -1,1 +1,0 @@
-httpClientVersion = 4.5.13

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,14 +10,15 @@ org.gradle.daemon = true
 org.gradle.parallel = true
 
 # Application Packages
-gsonVersion = 2.8.6
+gsonVersion = 2.10.1
 guavaVersion = 22.0
 hamcrestVersion = 1.3
-jacksonVersion = 2.11.2
+jacksonVersion = 2.15.2
 jsonVersion = 20190722
 jsonSimpleVersion = 1.1.1
 logbackVersion = 1.2.3
 slf4jVersion = 1.7.30
+httpClientVersion = 4.5.14
 
 # Style Packages
 findbugsAnnotationVersion = 3.0.1

--- a/java-quickstart/build.gradle
+++ b/java-quickstart/build.gradle
@@ -4,9 +4,9 @@ dependencies {
     compile project(':core-api')
     compile project(':core-httpclient-impl')
 
-    compile group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
-    compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.12'
-    compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.30'
+    compile group: 'com.google.code.gson', name: 'gson', version: gsonVersion
+    compile group: 'org.apache.httpcomponents', name: 'httpclient', version: httpClientVersion
+    compile group: 'org.slf4j', name: 'slf4j-simple', version: slf4jVersion
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }


### PR DESCRIPTION
## Summary
Upgrade dependency versions to clear source clear warnings
- gson: 2.8.6 -> 2.10.1
- HttpClient: 4.5.13 -> 4.5.14
- Jackson-annotations: 2.11.2 -> 2.15.2

## Test plan
- pass all existing tests

## Issues
- FSSDK-9041