### PR TITLE
[FSSDK-9422] fix(AsyncEventHandler): add evict timeout to logx connections

### DIFF
--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/event/AsyncEventHandler.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/event/AsyncEventHandler.java
@@ -119,6 +119,8 @@ public class AsyncEventHandler implements EventHandler, AutoCloseable {
             .withMaxTotalConnections(maxConnections)
             .withMaxPerRoute(connectionsPerRoute)
             .withValidateAfterInactivity(validateAfter)
+            // infrequent event discards observed. staled connections force-closed after a long idle time.
+            .withEvictIdleConnections(1L, TimeUnit.MINUTES)
             .build();
 
         this.workerExecutor = new ThreadPoolExecutor(numWorkers, numWorkers,


### PR DESCRIPTION
## Summary
Sporadic logx event discards reported. A staled connections after a long idle time may be one of the culprits.
Max connection idle time of 1min is added to AsyncEventHandler, after which connection is forced-closed.

## Test plan
- pass all existing tests.

## Issues
- FSSDK-9422