### PR TITLE
[FSSDK-9785] handle duplicate experiment keys with a warning

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/optimizelyconfig/OptimizelyConfigService.java
+++ b/core-api/src/main/java/com/optimizely/ab/optimizelyconfig/OptimizelyConfigService.java
@@ -18,6 +18,8 @@ package com.optimizely.ab.optimizelyconfig;
 import com.optimizely.ab.annotations.VisibleForTesting;
 import com.optimizely.ab.config.*;
 import com.optimizely.ab.config.audience.Audience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
@@ -30,6 +32,8 @@ public class OptimizelyConfigService {
     private Map<String, String> audiencesMap;
     private Map<String, List<FeatureVariable>> featureIdToVariablesMap = new HashMap<>();
     private Map<String, OptimizelyExperiment> experimentMapByExperimentId = new HashMap<>();
+
+    private static final Logger logger = LoggerFactory.getLogger(OptimizelyConfigService.class);
 
     public OptimizelyConfigService(ProjectConfig projectConfig) {
         this.projectConfig = projectConfig;
@@ -124,6 +128,11 @@ public class OptimizelyConfigService {
                 getVariationsMap(experiment.getVariations(), experiment.getId(), null),
                 experiment.serializeConditions(this.audiencesMap)
             );
+
+            if (featureExperimentMap.containsKey(experiment.getKey())) {
+                // continue with this warning, so the later experiment will be used.
+                logger.warn("Duplicate experiment keys found in datafile: {}", experiment.getKey());
+            }
 
             featureExperimentMap.put(experiment.getKey(), optimizelyExperiment);
             experimentMapByExperimentId.put(experiment.getId(), optimizelyExperiment);

--- a/core-api/src/main/java/com/optimizely/ab/optimizelyconfig/OptimizelyConfigService.java
+++ b/core-api/src/main/java/com/optimizely/ab/optimizelyconfig/OptimizelyConfigService.java
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2020-2021, Optimizely, Inc. and contributors                        *
+ * Copyright 2020-2021, 2023, Optimizely, Inc. and contributors             *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/core-api/src/test/java/com/optimizely/ab/optimizelyconfig/OptimizelyConfigServiceTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/optimizelyconfig/OptimizelyConfigServiceTest.java
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2020-2021, Optimizely, Inc. and contributors                        *
+ * Copyright 2020-2021, 2023, Optimizely, Inc. and contributors             *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/core-api/src/test/java/com/optimizely/ab/optimizelyconfig/OptimizelyConfigServiceTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/optimizelyconfig/OptimizelyConfigServiceTest.java
@@ -68,7 +68,7 @@ public class OptimizelyConfigServiceTest {
                 Collections.<Variation>emptyList(), Collections.<String, String>emptyMap(), Collections.<TrafficAllocation>emptyList()
             )
         );
-        
+
         ProjectConfig projectConfig = mock(ProjectConfig.class);
         OptimizelyConfigService optimizelyConfigService = new OptimizelyConfigService(projectConfig);
         when(projectConfig.getExperiments()).thenReturn(experiments);

--- a/java-quickstart/src/main/java/com/optimizely/Example.java
+++ b/java-quickstart/src/main/java/com/optimizely/Example.java
@@ -56,7 +56,7 @@ public class Example {
 
     public static void main(String[] args) throws InterruptedException {
         Optimizely optimizely = OptimizelyFactory.newDefaultInstance("BX9Y3bTa4YErpHZEMpAwHm");
-
+        
         Example example = new Example(optimizely);
         Random random = new Random();
 


### PR DESCRIPTION
## Summary
When duplicate experiment keys are found in a datafile, SDK returns a correct experimentMap in OptimizelyConfig:
1. the experimentMap will contain the experiment later in the datafile experiments list.
2. add a warning log about "Duplicate experiment keys found in datafile: {key-name}"

## Test plan
- add a test for OptimizelyConfig with duplicate experiment keys

## Issues
- [FSSDK-9785](https://jira.sso.episerver.net/browse/FSSDK-9785)