### PR TITLE
[FSSDK-10041] fix to inject common httpclient to projectConfigManager, eventHandler and odpManager

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -77,7 +77,6 @@ public class Optimizely implements AutoCloseable {
     private static final Logger logger = LoggerFactory.getLogger(Optimizely.class);
 
     final DecisionService decisionService;
-    @VisibleForTesting
     @Deprecated
     final EventHandler eventHandler;
     @VisibleForTesting
@@ -87,7 +86,8 @@ public class Optimizely implements AutoCloseable {
 
     public final List<OptimizelyDecideOption> defaultDecideOptions;
 
-    private final ProjectConfigManager projectConfigManager;
+    @VisibleForTesting
+    final ProjectConfigManager projectConfigManager;
 
     @Nullable
     private final OptimizelyConfigManager optimizelyConfigManager;

--- a/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/BatchEventProcessor.java
@@ -16,6 +16,7 @@
  */
 package com.optimizely.ab.event;
 
+import com.optimizely.ab.annotations.VisibleForTesting;
 import com.optimizely.ab.config.ProjectConfig;
 import com.optimizely.ab.event.internal.EventFactory;
 import com.optimizely.ab.event.internal.UserEvent;
@@ -57,7 +58,8 @@ public class BatchEventProcessor implements EventProcessor, AutoCloseable {
     private static final Object FLUSH_SIGNAL    = new Object();
 
     private final BlockingQueue<Object> eventQueue;
-    private final EventHandler eventHandler;
+    @VisibleForTesting
+    public final EventHandler eventHandler;
 
     final int batchSize;
     final long flushInterval;

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
@@ -53,8 +53,8 @@ public class ODPEventManager {
     //      needs to see the change immediately.
     private volatile ODPConfig odpConfig;
     private EventDispatcherThread eventDispatcherThread;
-
-    private final ODPApiManager apiManager;
+    @VisibleForTesting
+    public final ODPApiManager apiManager;
 
     // The eventQueue needs to be thread safe. We are not doing anything extra for thread safety here
     //      because `LinkedBlockingQueue` itself is thread safe.

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPManager.java
@@ -16,6 +16,7 @@
  */
 package com.optimizely.ab.odp;
 
+import com.optimizely.ab.annotations.VisibleForTesting;
 import com.optimizely.ab.internal.Cache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPSegmentManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPSegmentManager.java
@@ -16,6 +16,7 @@
  */
 package com.optimizely.ab.odp;
 
+import com.optimizely.ab.annotations.VisibleForTesting;
 import com.optimizely.ab.internal.Cache;
 import com.optimizely.ab.internal.DefaultLRUCache;
 import com.optimizely.ab.odp.parser.ResponseJsonParser;
@@ -31,8 +32,8 @@ public class ODPSegmentManager {
     private static final Logger logger = LoggerFactory.getLogger(ODPSegmentManager.class);
 
     private static final String SEGMENT_URL_PATH = "/v3/graphql";
-
-    private final ODPApiManager apiManager;
+    @VisibleForTesting
+    public final ODPApiManager apiManager;
 
     private volatile ODPConfig odpConfig;
 

--- a/core-httpclient-impl/build.gradle
+++ b/core-httpclient-impl/build.gradle
@@ -1,5 +1,4 @@
 dependencies {
-    implementation 'org.jetbrains:annotations:24.0.0'
     compile project(':core-api')
 
     compileOnly group: 'com.google.code.gson', name: 'gson', version: gsonVersion

--- a/core-httpclient-impl/build.gradle
+++ b/core-httpclient-impl/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+    implementation 'org.jetbrains:annotations:24.0.0'
     compile project(':core-api')
 
     compileOnly group: 'com.google.code.gson', name: 'gson', version: gsonVersion

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyFactory.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyFactory.java
@@ -279,22 +279,38 @@ public final class OptimizelyFactory {
      * @param customHttpClient  Customizable CloseableHttpClient to build OptimizelyHttpClient.
      * @return A new Optimizely instance
      */
-    public static Optimizely newDefaultInstance(String sdkKey, String fallback, String datafileAccessToken, CloseableHttpClient customHttpClient) {
+    public static Optimizely newDefaultInstance(
+        String sdkKey,
+        String fallback,
+        String datafileAccessToken,
+        CloseableHttpClient customHttpClient
+    ) {
+        OptimizelyHttpClient optimizelyHttpClient = customHttpClient == null ? null : new OptimizelyHttpClient(customHttpClient);
+
         NotificationCenter notificationCenter = new NotificationCenter();
-        OptimizelyHttpClient optimizelyHttpClient = new OptimizelyHttpClient(customHttpClient);
-        HttpProjectConfigManager.Builder builder;
-        builder = HttpProjectConfigManager.builder()
+
+        HttpProjectConfigManager.Builder builder = HttpProjectConfigManager.builder()
             .withDatafile(fallback)
             .withNotificationCenter(notificationCenter)
-            .withOptimizelyHttpClient(customHttpClient == null ? null : optimizelyHttpClient)
+            .withOptimizelyHttpClient(optimizelyHttpClient)
             .withSdkKey(sdkKey);
 
         if (datafileAccessToken != null) {
             builder.withDatafileAccessToken(datafileAccessToken);
         }
 
-        return newDefaultInstance(builder.build(), notificationCenter);
+        ProjectConfigManager configManager = builder.build();
+
+        EventHandler eventHandler = AsyncEventHandler.builder()
+            .withOptimizelyHttpClient(optimizelyHttpClient)
+            .build();
+
+        ODPApiManager odpApiManager = new DefaultODPApiManager(optimizelyHttpClient);
+
+        return newDefaultInstance(configManager, notificationCenter, eventHandler, odpApiManager);
     }
+
+
 
     /**
      * Returns a new Optimizely instance based on preset configuration.
@@ -329,6 +345,19 @@ public final class OptimizelyFactory {
      * @return A new Optimizely instance
      * */
     public static Optimizely newDefaultInstance(ProjectConfigManager configManager, NotificationCenter notificationCenter, EventHandler eventHandler) {
+        return newDefaultInstance(configManager, notificationCenter, eventHandler, null);
+    }
+
+    /**
+     * Returns a new Optimizely instance based on preset configuration.
+     *
+     * @param configManager      The {@link ProjectConfigManager} supplied to Optimizely instance.
+     * @param notificationCenter The {@link ProjectConfigManager} supplied to Optimizely instance.
+     * @param eventHandler       The {@link EventHandler} supplied to Optimizely instance.
+     * @param odpApiManager      The {@link ODPApiManager} supplied to Optimizely instance.
+     * @return A new Optimizely instance
+     * */
+    public static Optimizely newDefaultInstance(ProjectConfigManager configManager, NotificationCenter notificationCenter, EventHandler eventHandler, ODPApiManager odpApiManager) {
         if (notificationCenter == null) {
             notificationCenter = new NotificationCenter();
         }
@@ -338,9 +367,8 @@ public final class OptimizelyFactory {
             .withNotificationCenter(notificationCenter)
             .build();
 
-        ODPApiManager defaultODPApiManager = new DefaultODPApiManager();
         ODPManager odpManager = ODPManager.builder()
-            .withApiManager(defaultODPApiManager)
+            .withApiManager(odpApiManager != null ? odpApiManager : new DefaultODPApiManager())
             .build();
 
         return Optimizely.builder()

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyHttpClient.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyHttpClient.java
@@ -41,7 +41,6 @@ import java.util.concurrent.TimeUnit;
 public class OptimizelyHttpClient implements Closeable {
 
     private static final Logger logger = LoggerFactory.getLogger(OptimizelyHttpClient.class);
-
     private final CloseableHttpClient httpClient;
 
     OptimizelyHttpClient(CloseableHttpClient httpClient) {

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/config/HttpProjectConfigManager.java
@@ -58,7 +58,8 @@ public class HttpProjectConfigManager extends PollingProjectConfigManager {
 
     private static final Logger logger = LoggerFactory.getLogger(HttpProjectConfigManager.class);
 
-    private final OptimizelyHttpClient httpClient;
+    @VisibleForTesting
+    public final OptimizelyHttpClient httpClient;
     private final URI uri;
     private final String datafileAccessToken;
     private String datafileLastModified;

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/event/AsyncEventHandler.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/event/AsyncEventHandler.java
@@ -30,7 +30,6 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.StringEntity;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +44,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
 
 /**
  * {@link EventHandler} implementation that queues events and has a separate pool of threads responsible
@@ -67,7 +67,8 @@ public class AsyncEventHandler implements EventHandler, AutoCloseable {
     private static final Logger logger = LoggerFactory.getLogger(AsyncEventHandler.class);
     private static final ProjectConfigResponseHandler EVENT_RESPONSE_HANDLER = new ProjectConfigResponseHandler();
 
-    private final OptimizelyHttpClient httpClient;
+    @VisibleForTesting
+    public final OptimizelyHttpClient httpClient;
     private final ExecutorService workerExecutor;
 
     private final long closeTimeout;

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/odp/DefaultODPApiManager.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/odp/DefaultODPApiManager.java
@@ -42,8 +42,10 @@ import java.util.concurrent.TimeUnit;
 public class DefaultODPApiManager implements ODPApiManager {
     private static final Logger logger = LoggerFactory.getLogger(DefaultODPApiManager.class);
 
-    private final OptimizelyHttpClient httpClientSegments;
-    private final OptimizelyHttpClient httpClientEvents;
+    @VisibleForTesting
+    public final OptimizelyHttpClient httpClientSegments;
+    @VisibleForTesting
+    public final OptimizelyHttpClient httpClientEvents;
 
     public DefaultODPApiManager() {
         this(null);

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/odp/DefaultODPApiManager.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/odp/DefaultODPApiManager.java
@@ -15,8 +15,12 @@
  */
 package com.optimizely.ab.odp;
 
+import com.optimizely.ab.Optimizely;
 import com.optimizely.ab.OptimizelyHttpClient;
 import com.optimizely.ab.annotations.VisibleForTesting;
+import com.optimizely.ab.config.HttpProjectConfigManager;
+import com.optimizely.ab.event.AsyncEventHandler;
+import com.optimizely.ab.internal.PropertyUtils;
 import com.optimizely.ab.odp.parser.ResponseJsonParser;
 import com.optimizely.ab.odp.parser.ResponseJsonParserFactory;
 import org.apache.http.StatusLine;
@@ -27,11 +31,13 @@ import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 public class DefaultODPApiManager implements ODPApiManager {
     private static final Logger logger = LoggerFactory.getLogger(DefaultODPApiManager.class);
@@ -40,7 +46,7 @@ public class DefaultODPApiManager implements ODPApiManager {
     private final OptimizelyHttpClient httpClientEvents;
 
     public DefaultODPApiManager() {
-        this(OptimizelyHttpClient.builder().build());
+        this(null);
     }
 
     public DefaultODPApiManager(int segmentFetchTimeoutMillis, int eventDispatchTimeoutMillis) {
@@ -53,10 +59,13 @@ public class DefaultODPApiManager implements ODPApiManager {
         }
     }
 
-    @VisibleForTesting
-    DefaultODPApiManager(OptimizelyHttpClient httpClient) {
-        this.httpClientSegments = httpClient;
-        this.httpClientEvents = httpClient;
+    public DefaultODPApiManager(@Nullable OptimizelyHttpClient httpClient) {
+        OptimizelyHttpClient customHttpClient = httpClient;
+        if (httpClient == null) {
+            customHttpClient = OptimizelyHttpClient.builder().build();
+        }
+        this.httpClientSegments = customHttpClient;
+        this.httpClientEvents = customHttpClient;
     }
 
     @VisibleForTesting

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/config/HttpProjectConfigManagerTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/config/HttpProjectConfigManagerTest.java
@@ -20,7 +20,6 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import com.optimizely.ab.OptimizelyHttpClient;
 import org.apache.http.HttpHeaders;
-import org.apache.http.HttpResponse;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.StatusLine;
 import org.apache.http.client.ClientProtocolException;
@@ -44,7 +43,6 @@ import static com.optimizely.ab.config.HttpProjectConfigManager.*;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/event/AsyncEventHandlerTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/event/AsyncEventHandlerTest.java
@@ -22,14 +22,9 @@ import com.optimizely.ab.OptimizelyHttpClient;
 import com.optimizely.ab.event.internal.payload.EventBatch;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -38,7 +33,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static com.optimizely.ab.event.AsyncEventHandler.builder;

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/odp/DefaultODPApiManagerTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/odp/DefaultODPApiManagerTest.java
@@ -33,7 +33,6 @@ import java.util.HashSet;
 import java.util.List;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 public class DefaultODPApiManagerTest {


### PR DESCRIPTION
## Summary
OptimizelyFactory method for injecting customHttpClient is fixed to share it for all modules using httpClient
- HttpProjectConfigManager
- AsyncEventHander
- ODPManager

Related to this issue: https://github.com/optimizely/java-sdk/issues/538

## Test plan
- new tests for customHttpClient

## Issues
- [FSSDK-10041](https://jira.sso.episerver.net/browse/FSSDK-10041)