### PR TITLE
[FSSDK-10095] fix events dropped on staled connections.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,21 +94,22 @@ configure(publishedProjects) {
     }
 
     dependencies {
-        compile group: 'commons-codec', name: 'commons-codec', version: commonCodecVersion
+        implementation group: 'commons-codec', name: 'commons-codec', version: commonCodecVersion
 
-        testCompile group: 'junit', name: 'junit', version: junitVersion
-        testCompile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
-        testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: hamcrestVersion
-        testCompile group: 'com.google.guava', name: 'guava', version: guavaVersion
+        testImplementation group: 'junit', name: 'junit', version: junitVersion
+        testImplementation group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
+        testImplementation group: 'org.hamcrest', name: 'hamcrest-all', version: hamcrestVersion
+        testImplementation group: 'com.google.guava', name: 'guava', version: guavaVersion
 
         // logging dependencies (logback)
-        testCompile group: 'ch.qos.logback', name: 'logback-classic', version: logbackVersion
-        testCompile group: 'ch.qos.logback', name: 'logback-core', version: logbackVersion
+        testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: logbackVersion
+        testImplementation group: 'ch.qos.logback', name: 'logback-core', version: logbackVersion
+        testImplementation 'org.mock-server:mockserver-netty:5.1.1'
 
-        testCompile group: 'com.google.code.gson', name: 'gson', version: gsonVersion
-        testCompile group: 'org.json', name: 'json', version: jsonVersion
-        testCompile group: 'com.googlecode.json-simple', name: 'json-simple', version: jsonSimpleVersion
-        testCompile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
+        testImplementation group: 'com.google.code.gson', name: 'gson', version: gsonVersion
+        testImplementation group: 'org.json', name: 'json', version: jsonVersion
+        testImplementation group: 'com.googlecode.json-simple', name: 'json-simple', version: jsonSimpleVersion
+        testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
     }
 
     def docTitle = "Optimizely Java SDK"

--- a/build.gradle
+++ b/build.gradle
@@ -94,22 +94,21 @@ configure(publishedProjects) {
     }
 
     dependencies {
-        implementation group: 'commons-codec', name: 'commons-codec', version: commonCodecVersion
+        compile group: 'commons-codec', name: 'commons-codec', version: commonCodecVersion
 
-        testImplementation group: 'junit', name: 'junit', version: junitVersion
-        testImplementation group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
-        testImplementation group: 'org.hamcrest', name: 'hamcrest-all', version: hamcrestVersion
-        testImplementation group: 'com.google.guava', name: 'guava', version: guavaVersion
+        testCompile group: 'junit', name: 'junit', version: junitVersion
+        testCompile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
+        testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: hamcrestVersion
+        testCompile group: 'com.google.guava', name: 'guava', version: guavaVersion
 
         // logging dependencies (logback)
-        testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: logbackVersion
-        testImplementation group: 'ch.qos.logback', name: 'logback-core', version: logbackVersion
-        testImplementation 'org.mock-server:mockserver-netty:5.1.1'
+        testCompile group: 'ch.qos.logback', name: 'logback-classic', version: logbackVersion
+        testCompile group: 'ch.qos.logback', name: 'logback-core', version: logbackVersion
 
-        testImplementation group: 'com.google.code.gson', name: 'gson', version: gsonVersion
-        testImplementation group: 'org.json', name: 'json', version: jsonVersion
-        testImplementation group: 'com.googlecode.json-simple', name: 'json-simple', version: jsonSimpleVersion
-        testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
+        testCompile group: 'com.google.code.gson', name: 'gson', version: gsonVersion
+        testCompile group: 'org.json', name: 'json', version: jsonVersion
+        testCompile group: 'com.googlecode.json-simple', name: 'json-simple', version: jsonSimpleVersion
+        testCompile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
     }
 
     def docTitle = "Optimizely Java SDK"

--- a/core-api/src/test/java/com/optimizely/ab/odp/ODPEventManagerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/odp/ODPEventManagerTest.java
@@ -51,11 +51,6 @@ public class ODPEventManagerTest {
     @Captor
     ArgumentCaptor<String> payloadCaptor;
 
-    @Before
-    public void setup() {
-        mockApiManager = mock(ODPApiManager.class);
-    }
-
     @Test
     public void logAndDiscardEventWhenEventManagerIsNotRunning() {
         ODPConfig odpConfig = new ODPConfig("key", "host", null);

--- a/core-httpclient-impl/README.md
+++ b/core-httpclient-impl/README.md
@@ -106,24 +106,24 @@ The number of workers determines the number of threads the thread pool uses.
 ### Builder Methods
 The following builder methods can be used to custom configure the `AsyncEventHandler`.
 
-|Method Name|Default Value| Description                                        |
-|---|---|----------------------------------------------------|
-|`withQueueCapacity(int)`|10000| Queue size for pending logEvents                   |
-|`withNumWorkers(int)`|2| Number of worker threads                           |
-|`withMaxTotalConnections(int)`|200| Maximum number of connections                      |
-|`withMaxPerRoute(int)`|20| Maximum number of connections per route            |
-|`withValidateAfterInactivity(int)`|5000| Time to maintain idle connections (in milliseconds) |
+|Method Name|Default Value|Description|
+|---|---|-----------------------------------------------|
+|`withQueueCapacity(int)`|10000|Queue size for pending logEvents|
+|`withNumWorkers(int)`|2|Number of worker threads|
+|`withMaxTotalConnections(int)`|200|Maximum number of connections|
+|`withMaxPerRoute(int)`|20|Maximum number of connections per route|
+|`withValidateAfterInactivity(int)`|5000|Time to maintain idle connections (in milliseconds)|
 
 ### Advanced configuration
 The following properties can be set to override the default configuration.
 
-|Property Name|Default Value| Description                                        |
-|---|---|----------------------------------------------------|
-|**async.event.handler.queue.capacity**|10000| Queue size for pending logEvents                   |
-|**async.event.handler.num.workers**|2| Number of worker threads                           |
-|**async.event.handler.max.connections**|200| Maximum number of connections                      |
-|**async.event.handler.event.max.per.route**|20| Maximum number of connections per route            |
-|**async.event.handler.validate.after**|5000| Time to maintain idle connections (in milliseconds) |
+|Property Name|Default Value|Description|
+|---|---|-----------------------------------------------|
+|**async.event.handler.queue.capacity**|10000|Queue size for pending logEvents|
+|**async.event.handler.num.workers**|2|Number of worker threads|
+|**async.event.handler.max.connections**|200|Maximum number of connections|
+|**async.event.handler.event.max.per.route**|20|Maximum number of connections per route|
+|**async.event.handler.validate.after**|5000|Time to maintain idle connections (in milliseconds)|
 
 ## HttpProjectConfigManager
 

--- a/core-httpclient-impl/README.md
+++ b/core-httpclient-impl/README.md
@@ -112,7 +112,7 @@ The following builder methods can be used to custom configure the `AsyncEventHan
 |`withNumWorkers(int)`|2|Number of worker threads|
 |`withMaxTotalConnections(int)`|200|Maximum number of connections|
 |`withMaxPerRoute(int)`|20|Maximum number of connections per route|
-|`withValidateAfterInactivity(int)`|5000|Time to maintain idle connections (in milliseconds)|
+|`withValidateAfterInactivity(int)`|1000|Time to maintain idle connections (in milliseconds)|
 
 ### Advanced configuration
 The following properties can be set to override the default configuration.
@@ -123,7 +123,7 @@ The following properties can be set to override the default configuration.
 |**async.event.handler.num.workers**|2|Number of worker threads|
 |**async.event.handler.max.connections**|200|Maximum number of connections|
 |**async.event.handler.event.max.per.route**|20|Maximum number of connections per route|
-|**async.event.handler.validate.after**|5000|Time to maintain idle connections (in milliseconds)|
+|**async.event.handler.validate.after**|1000|Time to maintain idle connections (in milliseconds)|
 
 ## HttpProjectConfigManager
 

--- a/core-httpclient-impl/README.md
+++ b/core-httpclient-impl/README.md
@@ -106,24 +106,24 @@ The number of workers determines the number of threads the thread pool uses.
 ### Builder Methods
 The following builder methods can be used to custom configure the `AsyncEventHandler`.
 
-|Method Name|Default Value|Description|
-|---|---|---|
-|`withQueueCapacity(int)`|10000|Queue size for pending logEvents|
-|`withNumWorkers(int)`|2|Number of worker threads|
-|`withMaxTotalConnections(int)`|200|Maximum number of connections|
-|`withMaxPerRoute(int)`|20|Maximum number of connections per route|
-|`withValidateAfterInactivity(int)`|5000|Time to maintain idol connections (in milliseconds)|
+|Method Name|Default Value| Description                                        |
+|---|---|----------------------------------------------------|
+|`withQueueCapacity(int)`|10000| Queue size for pending logEvents                   |
+|`withNumWorkers(int)`|2| Number of worker threads                           |
+|`withMaxTotalConnections(int)`|200| Maximum number of connections                      |
+|`withMaxPerRoute(int)`|20| Maximum number of connections per route            |
+|`withValidateAfterInactivity(int)`|5000| Time to maintain idle connections (in milliseconds) |
 
 ### Advanced configuration
 The following properties can be set to override the default configuration.
 
-|Property Name|Default Value|Description|
-|---|---|---|
-|**async.event.handler.queue.capacity**|10000|Queue size for pending logEvents|
-|**async.event.handler.num.workers**|2|Number of worker threads|
-|**async.event.handler.max.connections**|200|Maximum number of connections|
-|**async.event.handler.event.max.per.route**|20|Maximum number of connections per route|
-|**async.event.handler.validate.after**|5000|Time to maintain idol connections (in milliseconds)|
+|Property Name|Default Value| Description                                        |
+|---|---|----------------------------------------------------|
+|**async.event.handler.queue.capacity**|10000| Queue size for pending logEvents                   |
+|**async.event.handler.num.workers**|2| Number of worker threads                           |
+|**async.event.handler.max.connections**|200| Maximum number of connections                      |
+|**async.event.handler.event.max.per.route**|20| Maximum number of connections per route            |
+|**async.event.handler.validate.after**|5000| Time to maintain idle connections (in milliseconds) |
 
 ## HttpProjectConfigManager
 

--- a/core-httpclient-impl/build.gradle
+++ b/core-httpclient-impl/build.gradle
@@ -1,14 +1,9 @@
 dependencies {
-    compile project(':core-api')
-
+    implementation project(':core-api')
     compileOnly group: 'com.google.code.gson', name: 'gson', version: gsonVersion
+    implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: httpClientVersion
 
-    compile group: 'org.apache.httpcomponents', name: 'httpclient', version: httpClientVersion
-
-    testImplementation 'io.javalin:javalin:3.13.10'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
-    testImplementation 'io.rest-assured:rest-assured:4.4.0'
+    testImplementation 'org.mock-server:mockserver-netty:5.15.0'
 }
 
 task exhaustiveTest {

--- a/core-httpclient-impl/build.gradle
+++ b/core-httpclient-impl/build.gradle
@@ -2,8 +2,6 @@ dependencies {
     implementation project(':core-api')
     compileOnly group: 'com.google.code.gson', name: 'gson', version: gsonVersion
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: httpClientVersion
-
-    testImplementation 'org.mock-server:mockserver-netty:5.15.0'
 }
 
 task exhaustiveTest {

--- a/core-httpclient-impl/build.gradle
+++ b/core-httpclient-impl/build.gradle
@@ -4,6 +4,11 @@ dependencies {
     compileOnly group: 'com.google.code.gson', name: 'gson', version: gsonVersion
 
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version: httpClientVersion
+
+    testImplementation 'io.javalin:javalin:3.13.10'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
+    testImplementation 'io.rest-assured:rest-assured:4.4.0'
 }
 
 task exhaustiveTest {

--- a/core-httpclient-impl/build.gradle
+++ b/core-httpclient-impl/build.gradle
@@ -1,7 +1,8 @@
 dependencies {
-    implementation project(':core-api')
+    compile project(':core-api')
     compileOnly group: 'com.google.code.gson', name: 'gson', version: gsonVersion
-    implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: httpClientVersion
+    compile group: 'org.apache.httpcomponents', name: 'httpclient', version: httpClientVersion
+    testCompile 'org.mock-server:mockserver-netty:5.1.1'
 }
 
 task exhaustiveTest {

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/HttpClientUtils.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/HttpClientUtils.java
@@ -26,7 +26,7 @@ public final class HttpClientUtils {
     public static final int CONNECTION_TIMEOUT_MS = 10000;
     public static final int CONNECTION_REQUEST_TIMEOUT_MS = 5000;
     public static final int SOCKET_TIMEOUT_MS = 10000;
-    public static final int DEFAULT_VALIDATE_AFTER_INACTIVITY = 5000;
+    public static final int DEFAULT_VALIDATE_AFTER_INACTIVITY = 1000;
     public static final int DEFAULT_MAX_CONNECTIONS = 200;
     public static final int DEFAULT_MAX_PER_ROUTE = 20;
     private static RequestConfig requestConfigWithTimeout;

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/HttpClientUtils.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/HttpClientUtils.java
@@ -26,7 +26,9 @@ public final class HttpClientUtils {
     public static final int CONNECTION_TIMEOUT_MS = 10000;
     public static final int CONNECTION_REQUEST_TIMEOUT_MS = 5000;
     public static final int SOCKET_TIMEOUT_MS = 10000;
-
+    public static final int DEFAULT_VALIDATE_AFTER_INACTIVITY = 5000;
+    public static final int DEFAULT_MAX_CONNECTIONS = 200;
+    public static final int DEFAULT_MAX_PER_ROUTE = 20;
     private static RequestConfig requestConfigWithTimeout;
 
     private HttpClientUtils() {

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyHttpClient.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/OptimizelyHttpClient.java
@@ -81,6 +81,8 @@ public class OptimizelyHttpClient implements Closeable {
         // The maximum number of connections allowed for a route
         int maxPerRoute = HttpClientUtils.DEFAULT_MAX_PER_ROUTE;
         // Defines period of inactivity in milliseconds after which persistent connections must be re-validated prior to being leased to the consumer.
+        // If this is too long, it's expected to see more requests dropped on staled connections (dropped by the server or networks).
+        // We can configure retries (POST for AsyncEventDispatcher) to cover the staled connections.
         int validateAfterInactivity = HttpClientUtils.DEFAULT_VALIDATE_AFTER_INACTIVITY;
         // force-close the connection after this idle time (with 0, eviction is disabled by default)
         long evictConnectionIdleTimePeriod = 0;

--- a/core-httpclient-impl/src/main/java/com/optimizely/ab/event/AsyncEventHandler.java
+++ b/core-httpclient-impl/src/main/java/com/optimizely/ab/event/AsyncEventHandler.java
@@ -143,7 +143,7 @@ public class AsyncEventHandler implements EventHandler, AutoCloseable {
                 .withValidateAfterInactivity(validateAfter)
                 // infrequent event discards observed. staled connections force-closed after a long idle time.
                 .withEvictIdleConnections(1L, TimeUnit.MINUTES)
-                // enable retry on POST
+                // enable retry on event POST (default: retry on GET only)
                 .withRetryHandler(new DefaultHttpRequestRetryHandler(3, true))
                 .build();
         }

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyHttpClientTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyHttpClientTest.java
@@ -64,7 +64,7 @@ public class OptimizelyHttpClientTest {
     @Test
     public void testDefaultConfiguration() {
         OptimizelyHttpClient.Builder builder = builder();
-        assertEquals(builder.validateAfterInactivity, 5000);
+        assertEquals(builder.validateAfterInactivity, 1000);
         assertEquals(builder.maxTotalConnections, 200);
         assertEquals(builder.maxPerRoute, 20);
         assertNull(builder.customRetryHandler);

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyHttpClientTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/OptimizelyHttpClientTest.java
@@ -16,27 +16,29 @@
  */
 package com.optimizely.ab;
 
+import io.javalin.Javalin;
+import org.apache.http.NoHttpResponseException;
+import org.apache.http.client.HttpRequestRetryHandler;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.conn.HttpHostConnectException;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
+import org.junit.*;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.optimizely.ab.OptimizelyHttpClient.builder;
 import static java.util.concurrent.TimeUnit.*;
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
 
 public class OptimizelyHttpClientTest {
-
     @Before
     public void setUp() {
         System.setProperty("https.proxyHost", "localhost");
@@ -51,7 +53,13 @@ public class OptimizelyHttpClientTest {
 
     @Test
     public void testDefaultConfiguration() {
-        OptimizelyHttpClient optimizelyHttpClient = builder().build();
+        OptimizelyHttpClient.Builder builder = builder();
+        assertEquals(builder.validateAfterInactivity, 5000);
+        assertEquals(builder.maxTotalConnections, 200);
+        assertEquals(builder.maxPerRoute, 20);
+        assertNull(builder.customRetryHandler);
+
+        OptimizelyHttpClient optimizelyHttpClient = builder.build();
         assertTrue(optimizelyHttpClient.getHttpClient() instanceof CloseableHttpClient);
     }
 
@@ -101,4 +109,76 @@ public class OptimizelyHttpClientTest {
         OptimizelyHttpClient optimizelyHttpClient = new OptimizelyHttpClient(mockHttpClient);
         assertTrue(optimizelyHttpClient.execute(httpUriRequest, responseHandler));
     }
+
+    @Test
+    public void testRetries() throws IOException {
+        // Javalin intercepts before proxy, so host and port should be set correct here
+        String host = "http://localhost";
+        int port = 8000;
+        Javalin app = Javalin.create().start(port);
+        int maxFailures = 2;
+
+        AtomicInteger callTimes = new AtomicInteger();
+        app.get("/", ctx -> {
+            callTimes.addAndGet(1);
+            int count = callTimes.get();
+            if (count < maxFailures) {
+                throw new NoHttpResponseException("TESTING CONNECTION FAILURE");
+            } else {
+                ctx.status(200).result("Success");
+            }
+        });
+
+        OptimizelyHttpClient optimizelyHttpClient = spy(OptimizelyHttpClient.builder().build());
+        optimizelyHttpClient.execute(new HttpGet(host + ":" + String.valueOf(port)));
+        assertEquals(3, callTimes.get());
+    }
+
+    @Test
+    public void testRetriesWithCustom() throws IOException {
+        // Javalin intercepts before proxy, so host and port should be set correct here
+        String host = "http://localhost";
+        int port = 8000;
+        Javalin app = Javalin.create().start(port);
+        int maxFailures = 2;
+
+        AtomicInteger callTimes = new AtomicInteger();
+        app.get("/", ctx -> {
+            callTimes.addAndGet(1);
+            int count = callTimes.get();
+            if (count < maxFailures) {
+//                throw new NoHttpResponseException("TESTING CONNECTION FAILURE");
+                throw new IOException("TESTING CONNECTION FAILURE");
+
+//                ctx.status(500).result("TESTING Server Error");
+            } else {
+                ctx.status(200).result("Success");
+            }
+        });
+
+        HttpRequestRetryHandler retryHandler = new DefaultHttpRequestRetryHandler(3, true);
+        OptimizelyHttpClient optimizelyHttpClient = spy(OptimizelyHttpClient.builder().withRetryHandler(retryHandler).build());
+
+        optimizelyHttpClient.execute(new HttpGet(host + ":" + String.valueOf(port)));
+        assertEquals(3, callTimes.get());
+    }
+
+//
+//    @Test
+//    public void testRetriesWithCustom() throws IOException {
+//        CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
+//        CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+//
+//        HttpRequestRetryHandler mockRetryHandler = spy(new DefaultHttpRequestRetryHandler(3, true));
+//        when(mockRetryHandler.retryRequest(any(), any(), any())).thenReturn(true);
+//
+//        OptimizelyHttpClient optimizelyHttpClient = OptimizelyHttpClient.builder().withRetryHandler(mockRetryHandler).build();
+//        try {
+//            optimizelyHttpClient.execute(new HttpGet("https://example.com"));
+//        } catch(Exception e) {
+//            assert(e instanceof IOException);
+//        }
+//        verify(mockRetryHandler, times(3)).retryRequest(any(), any(), any());
+// }
+
 }

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/event/AsyncEventHandlerTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/event/AsyncEventHandlerTest.java
@@ -136,7 +136,7 @@ public class AsyncEventHandlerTest {
     @Test
     public void testBuilderWithDefaultHttpClient() {
         AsyncEventHandler.Builder builder = builder();
-        assertEquals(builder.validateAfterInactivity, 5000);
+        assertEquals(builder.validateAfterInactivity, 1000);
         assertEquals(builder.maxTotalConnections, 200);
         assertEquals(builder.maxPerRoute, 20);
 

--- a/core-httpclient-impl/src/test/java/com/optimizely/ab/event/AsyncEventHandlerTest.java
+++ b/core-httpclient-impl/src/test/java/com/optimizely/ab/event/AsyncEventHandlerTest.java
@@ -124,6 +124,7 @@ public class AsyncEventHandlerTest {
 
         AsyncEventHandler eventHandler = builder()
             .withOptimizelyHttpClient(customHttpClient)
+            // these params will be ignored when customHttpClient is injected
             .withMaxTotalConnections(1)
             .withMaxPerRoute(2)
             .withCloseTimeout(10, TimeUnit.SECONDS)
@@ -134,6 +135,17 @@ public class AsyncEventHandlerTest {
 
     @Test
     public void testBuilderWithDefaultHttpClient() {
+        AsyncEventHandler.Builder builder = builder();
+        assertEquals(builder.validateAfterInactivity, 5000);
+        assertEquals(builder.maxTotalConnections, 200);
+        assertEquals(builder.maxPerRoute, 20);
+
+        AsyncEventHandler eventHandler = builder.build();
+        assert(eventHandler.httpClient != null);
+    }
+
+    @Test
+    public void testBuilderWithDefaultHttpClientAndCustomParams() {
         AsyncEventHandler eventHandler = builder()
             .withMaxTotalConnections(3)
             .withMaxPerRoute(4)


### PR DESCRIPTION
## Summary

Events can be discarded for staled connections with httpclient connection pooling.
This PR fixs it with -
1. reduce the time for connection validation from 5 to 1sec.
2. enable retries (x3) for event POST.

## Test plan
- new unit tests covering parameter configurations and retries

## Issues
- [FSSDK-10095](https://jira.sso.episerver.net/browse/FSSDK-10095)
- [BUG-7238](https://jira.sso.episerver.net/browse/BUG-7238)