### PR TITLE
[AI-FSSDK] (DO NOT REVIEW) [FSSDK-12275] Skip unsupported experiment type during flag decision

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/bucketing/DecisionService.java
+++ b/core-api/src/main/java/com/optimizely/ab/bucketing/DecisionService.java
@@ -399,6 +399,17 @@ public class DecisionService {
             for (String experimentId : featureFlag.getExperimentIds()) {
                 Experiment experiment = projectConfig.getExperimentIdMapping().get(experimentId);
 
+                // Skip experiments with unsupported types.
+                // If the experiment type is null (not set in datafile), we still evaluate it.
+                // If the experiment type is set but not in the supported list, we skip it.
+                if (experiment != null && experiment.getType() != null && !Experiment.SUPPORTED_TYPES.contains(experiment.getType())) {
+                    String skipMessage = reasons.addInfo(
+                        "Skipping experiment \"%s\" with unsupported type \"%s\" for feature \"%s\".",
+                        experiment.getKey(), experiment.getType(), featureFlag.getKey());
+                    logger.debug(skipMessage);
+                    continue;
+                }
+
                 DecisionResponse<Variation> decisionVariation =
                     getVariationFromExperimentRule(projectConfig, featureFlag.getKey(), experiment, user, options, userProfileTracker, decisionPath);
                 reasons.merge(decisionVariation.getReasons());

--- a/core-api/src/main/java/com/optimizely/ab/config/Group.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/Group.java
@@ -55,6 +55,7 @@ public class Group implements IdMapped {
                 experiment = new Experiment(
                     experiment.getId(),
                     experiment.getKey(),
+                    experiment.getType(),
                     experiment.getStatus(),
                     experiment.getLayerId(),
                     experiment.getAudienceIds(),

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/GsonHelpers.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/GsonHelpers.java
@@ -137,6 +137,8 @@ final class GsonHelpers {
     static Experiment parseExperiment(JsonObject experimentJson, String groupId, JsonDeserializationContext context) {
         String id = experimentJson.get("id").getAsString();
         String key = experimentJson.get("key").getAsString();
+        String type = experimentJson.has("type") && !experimentJson.get("type").isJsonNull()
+            ? experimentJson.get("type").getAsString() : null;
         JsonElement experimentStatusJson = experimentJson.get("status");
         String status = experimentStatusJson.isJsonNull() ?
             ExperimentStatus.NOT_STARTED.toString() : experimentStatusJson.getAsString();
@@ -168,7 +170,7 @@ final class GsonHelpers {
             }
         }
 
-        return new Experiment(id, key, status, layerId, audienceIds, conditions, variations, userIdToVariationKeyMap,
+        return new Experiment(id, key, type, status, layerId, audienceIds, conditions, variations, userIdToVariationKeyMap,
             trafficAllocations, groupId, cmab);
     }
 

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/JsonConfigParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/JsonConfigParser.java
@@ -148,6 +148,8 @@ final public class JsonConfigParser implements ConfigParser {
             JSONObject experimentObject = (JSONObject) obj;
             String id = experimentObject.getString("id");
             String key = experimentObject.getString("key");
+            String type = experimentObject.has("type") && !experimentObject.isNull("type")
+                ? experimentObject.getString("type") : null;
             String status = experimentObject.isNull("status") ?
                 ExperimentStatus.NOT_STARTED.toString() : experimentObject.getString("status");
             String layerId = experimentObject.has("layerId") ? experimentObject.getString("layerId") : null;
@@ -179,7 +181,7 @@ final public class JsonConfigParser implements ConfigParser {
                 cmab = parseCmab(cmabObject);
             }
 
-            experiments.add(new Experiment(id, key, status, layerId, audienceIds, conditions, variations, userIdToVariationKeyMap,
+            experiments.add(new Experiment(id, key, type, status, layerId, audienceIds, conditions, variations, userIdToVariationKeyMap,
                 trafficAllocations, groupId, cmab));
         }
 

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/JsonSimpleConfigParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/JsonSimpleConfigParser.java
@@ -150,6 +150,8 @@ final public class JsonSimpleConfigParser implements ConfigParser {
             JSONObject experimentObject = (JSONObject) obj;
             String id = (String) experimentObject.get("id");
             String key = (String) experimentObject.get("key");
+            Object typeObj = experimentObject.get("type");
+            String type = typeObj != null ? (String) typeObj : null;
             Object statusJson = experimentObject.get("status");
             String status = statusJson == null ? ExperimentStatus.NOT_STARTED.toString() :
                 (String) experimentObject.get("status");
@@ -189,7 +191,7 @@ final public class JsonSimpleConfigParser implements ConfigParser {
                 }
             }
 
-            experiments.add(new Experiment(id, key, status, layerId, audienceIds, conditions, variations, 
+            experiments.add(new Experiment(id, key, type, status, layerId, audienceIds, conditions, variations,
                 userIdToVariationKeyMap, trafficAllocations, groupId, cmab));
         }
 


### PR DESCRIPTION
## Summary

Implements experiment type filtering in the decision service to skip unsupported experiment types during flag decision evaluation.

### Changes

- **Experiment Class**: Added `type` field with `SUPPORTED_TYPES` constant
- **Constructors**: Updated all constructors including `@JsonCreator` to accept `type`
- **Parsers**: Updated Gson, JSON, JSONSimple parsers to parse `type` from datafile
- **Decision Logic**: Updated `DecisionService.getVariationFromExperiment` to skip unsupported types

### Behavior

- If `type` is **null** (not set in datafile): Experiment is evaluated (backward compatible)
- If `type` is in `SUPPORTED_TYPES`: Experiment is evaluated
- If `type` is non-null but NOT in `SUPPORTED_TYPES`: Experiment is skipped

## Test Plan

- [x] All existing tests pass (no regression)
- [x] Gradle compiles without errors

## Related

- Jira: [FSSDK-12275](https://optimizely-ext.atlassian.net/browse/FSSDK-12275)

---

Generated with [Claude Code](https://claude.com/claude-code)

[FSSDK-12275]: https://optimizely-ext.atlassian.net/browse/FSSDK-12275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ