### PR TITLE
[AI-FSSDK] [FSSDK-12418] Remove experiment type validation from config parsing

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/config/parser/DatafileGsonDeserializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/DatafileGsonDeserializer.java
@@ -126,28 +126,6 @@ public class DatafileGsonDeserializer implements JsonDeserializer<ProjectConfig>
             region = jsonObject.get("region").getAsString();
         }
 
-        // Validate experiment types
-        Set<String> validExperimentTypes = new HashSet<>(Arrays.asList(
-            Experiment.TYPE_AB, Experiment.TYPE_MAB, Experiment.TYPE_CMAB,
-            Experiment.TYPE_TD, Experiment.TYPE_FR
-        ));
-        for (Experiment experiment : experiments) {
-            if (experiment.getType() != null && !validExperimentTypes.contains(experiment.getType())) {
-                throw new JsonParseException(
-                    String.format("Experiment \"%s\" has invalid type \"%s\". Valid types: %s.",
-                        experiment.getKey(), experiment.getType(), validExperimentTypes));
-            }
-        }
-        for (Group group : groups) {
-            for (Experiment experiment : group.getExperiments()) {
-                if (experiment.getType() != null && !validExperimentTypes.contains(experiment.getType())) {
-                    throw new JsonParseException(
-                        String.format("Experiment \"%s\" has invalid type \"%s\". Valid types: %s.",
-                            experiment.getKey(), experiment.getType(), validExperimentTypes));
-                }
-            }
-        }
-
         return new DatafileProjectConfig(
             accountId,
             anonymizeIP,

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/DatafileJacksonDeserializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/DatafileJacksonDeserializer.java
@@ -100,28 +100,6 @@ class DatafileJacksonDeserializer extends JsonDeserializer<DatafileProjectConfig
             region = node.get("region").textValue();
         }
 
-        // Validate experiment types
-        Set<String> validExperimentTypes = new HashSet<>(Arrays.asList(
-            Experiment.TYPE_AB, Experiment.TYPE_MAB, Experiment.TYPE_CMAB,
-            Experiment.TYPE_TD, Experiment.TYPE_FR
-        ));
-        for (Experiment experiment : experiments) {
-            if (experiment.getType() != null && !validExperimentTypes.contains(experiment.getType())) {
-                throw new IOException(
-                    String.format("Experiment \"%s\" has invalid type \"%s\". Valid types: %s.",
-                        experiment.getKey(), experiment.getType(), validExperimentTypes));
-            }
-        }
-        for (Group group : groups) {
-            for (Experiment experiment : group.getExperiments()) {
-                if (experiment.getType() != null && !validExperimentTypes.contains(experiment.getType())) {
-                    throw new IOException(
-                        String.format("Experiment \"%s\" has invalid type \"%s\". Valid types: %s.",
-                            experiment.getKey(), experiment.getType(), validExperimentTypes));
-                }
-            }
-        }
-
         return new DatafileProjectConfig(
             accountId,
             anonymizeIP,

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/JsonConfigParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/JsonConfigParser.java
@@ -105,28 +105,6 @@ final public class JsonConfigParser implements ConfigParser {
                 String regionString = rootObject.getString("region");
             }
 
-            // Validate experiment types
-            Set<String> validExperimentTypes = new HashSet<>(Arrays.asList(
-                Experiment.TYPE_AB, Experiment.TYPE_MAB, Experiment.TYPE_CMAB,
-                Experiment.TYPE_TD, Experiment.TYPE_FR
-            ));
-            for (Experiment experiment : experiments) {
-                if (experiment.getType() != null && !validExperimentTypes.contains(experiment.getType())) {
-                    throw new ConfigParseException(
-                        String.format("Experiment \"%s\" has invalid type \"%s\". Valid types: %s.",
-                            experiment.getKey(), experiment.getType(), validExperimentTypes));
-                }
-            }
-            for (Group group : groups) {
-                for (Experiment experiment : group.getExperiments()) {
-                    if (experiment.getType() != null && !validExperimentTypes.contains(experiment.getType())) {
-                        throw new ConfigParseException(
-                            String.format("Experiment \"%s\" has invalid type \"%s\". Valid types: %s.",
-                                experiment.getKey(), experiment.getType(), validExperimentTypes));
-                    }
-                }
-            }
-
             return new DatafileProjectConfig(
                 accountId,
                 anonymizeIP,
@@ -149,8 +127,6 @@ final public class JsonConfigParser implements ConfigParser {
                 rollouts,
                 integrations
             );
-        } catch (ConfigParseException e) {
-            throw e;
         } catch (RuntimeException e) {
             throw new ConfigParseException("Unable to parse datafile: " + json, e);
         } catch (Exception e) {

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/JsonSimpleConfigParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/JsonSimpleConfigParser.java
@@ -108,28 +108,6 @@ final public class JsonSimpleConfigParser implements ConfigParser {
                 String regionString = (String) rootObject.get("region");
             }
 
-            // Validate experiment types
-            Set<String> validExperimentTypes = new HashSet<>(Arrays.asList(
-                Experiment.TYPE_AB, Experiment.TYPE_MAB, Experiment.TYPE_CMAB,
-                Experiment.TYPE_TD, Experiment.TYPE_FR
-            ));
-            for (Experiment experiment : experiments) {
-                if (experiment.getType() != null && !validExperimentTypes.contains(experiment.getType())) {
-                    throw new ConfigParseException(
-                        String.format("Experiment \"%s\" has invalid type \"%s\". Valid types: %s.",
-                            experiment.getKey(), experiment.getType(), validExperimentTypes));
-                }
-            }
-            for (Group group : groups) {
-                for (Experiment experiment : group.getExperiments()) {
-                    if (experiment.getType() != null && !validExperimentTypes.contains(experiment.getType())) {
-                        throw new ConfigParseException(
-                            String.format("Experiment \"%s\" has invalid type \"%s\". Valid types: %s.",
-                                experiment.getKey(), experiment.getType(), validExperimentTypes));
-                    }
-                }
-            }
-
             return new DatafileProjectConfig(
                 accountId,
                 anonymizeIP,
@@ -152,8 +130,6 @@ final public class JsonSimpleConfigParser implements ConfigParser {
                 rollouts,
                 integrations
             );
-        } catch (ConfigParseException e) {
-            throw e;
         } catch (RuntimeException ex) {
             throw new ConfigParseException("Unable to parse datafile: " + json, ex);
         } catch (Exception e) {

--- a/core-api/src/test/java/com/optimizely/ab/config/FeatureRolloutConfigTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/FeatureRolloutConfigTest.java
@@ -135,7 +135,22 @@ public class FeatureRolloutConfigTest {
     }
 
     /**
-     * Test 6: Type field parsed - experiments with type field in the datafile
+     * Test 6: Unknown type accepted - experiment with type "new_unknown_type"
+     * does NOT cause error or rejection, and config parsing succeeds.
+     */
+    @Test
+    public void unknownExperimentTypeAccepted() {
+        Experiment experiment = projectConfig.getExperimentKeyMapping().get("unknown_type_experiment");
+        assertNotNull("Experiment with unknown type should be parsed successfully", experiment);
+        assertEquals("new_unknown_type", experiment.getType());
+        assertEquals("exp_unknown_type", experiment.getId());
+        assertEquals("unknown_type_experiment", experiment.getKey());
+        assertEquals(1, experiment.getVariations().size());
+        assertEquals("unknown_variation", experiment.getVariations().get(0).getKey());
+    }
+
+    /**
+     * Test 7: Type field parsed - experiments with type field in the datafile
      * have the value correctly preserved after config parsing.
      */
     @Test

--- a/core-api/src/test/resources/config/feature-rollout-config.json
+++ b/core-api/src/test/resources/config/feature-rollout-config.json
@@ -110,6 +110,28 @@
           "endOfRange": 5000
         }
       ]
+    },
+    {
+      "id": "exp_unknown_type",
+      "key": "unknown_type_experiment",
+      "status": "Running",
+      "layerId": "layer_5",
+      "audienceIds": [],
+      "forcedVariations": {},
+      "type": "new_unknown_type",
+      "variations": [
+        {
+          "id": "var_unknown_1",
+          "key": "unknown_variation",
+          "featureEnabled": true
+        }
+      ],
+      "trafficAllocation": [
+        {
+          "entityId": "var_unknown_1",
+          "endOfRange": 10000
+        }
+      ]
     }
   ],
   "featureFlags": [


### PR DESCRIPTION
## Summary

Removes experiment type validation from config parsing to ensure forward compatibility. Previously, all four config parsers validated the experiment "type" field against a known set of values and rejected the entire datafile if an unknown type was encountered, which would break existing SDK versions when new experiment types are added in the future.

## Changes

- Removed type validation blocks from all four config parsers (JsonConfigParser, JsonSimpleConfigParser, DatafileGsonDeserializer, DatafileJacksonDeserializer)
- Unknown experiment types are now silently accepted and stored as-is
- Added test verifying unknown experiment types are accepted during config parsing

## Jira Ticket
[FSSDK-12418](https://optimizely-ext.atlassian.net/browse/FSSDK-12418)

[FSSDK-12418]: https://optimizely-ext.atlassian.net/browse/FSSDK-12418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ