### PR TITLE
[AI-FSSDK] prepare for release java v4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,7 @@ Apr 30, 2026
 - Add Feature Rollout support ([#601](https://github.com/optimizely/java-sdk/pull/601)).
 - Remove experiment type validation from config parsing ([#602](https://github.com/optimizely/java-sdk/pull/602)).
 - Remove legacy flag-level holdout fields ([#604](https://github.com/optimizely/java-sdk/pull/604)).
-
-### Fixes
 - Arnica risk fixes ([#600](https://github.com/optimizely/java-sdk/pull/600)).
-
-### Other
 - Fix documentation links in README.md ([#598](https://github.com/optimizely/java-sdk/pull/598)).
 
 ## [4.3.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Optimizely Java X SDK Changelog
 
+## [4.4.0]
+Apr 30, 2026
+
+### New Features
+
+**Feature Rollout**: Introduced Feature Rollout capabilities. Feature Rollouts represent a new experiment type merging Targeted Delivery simplicity with A/B test measurement capabilities. See [Feature Rollout docs](https://docs.developers.optimizely.com/feature-experimentation/docs/cmab-cache-config-for-the-java-sdk ) for implementation details.
+
+- [AI-FSSDK] [FSSDK-12368] Remove legacy flag-level holdout fields ([#604](https://github.com/optimizely/java-sdk/pull/604))
+- [AI-FSSDK] [FSSDK-12418] Remove experiment type validation from config parsing ([#602](https://github.com/optimizely/java-sdk/pull/602))
+- [AI-FSSDK] [FSSDK-12337] Add Feature Rollout support ([#601](https://github.com/optimizely/java-sdk/pull/601))
+
+### Fixes
+- [FSSDK-12315] Arnica risk fixes ([#600](https://github.com/optimizely/java-sdk/pull/600))
+
+### Other
+- Fix documentation links in README.md ([#598](https://github.com/optimizely/java-sdk/pull/598))
+
 ## [4.3.1]
 Jan 20, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,15 @@ Apr 30, 2026
 ### New Features
 
 **Feature Rollout**: Introduced Feature Rollout capabilities. Feature Rollouts represent a new experiment type merging Targeted Delivery simplicity with A/B test measurement capabilities. See [Feature Rollout docs](https://docs.developers.optimizely.com/feature-experimentation/docs/cmab-cache-config-for-the-java-sdk ) for implementation details.
-
-- [AI-FSSDK] [FSSDK-12368] Remove legacy flag-level holdout fields ([#604](https://github.com/optimizely/java-sdk/pull/604))
-- [AI-FSSDK] [FSSDK-12418] Remove experiment type validation from config parsing ([#602](https://github.com/optimizely/java-sdk/pull/602))
-- [AI-FSSDK] [FSSDK-12337] Add Feature Rollout support ([#601](https://github.com/optimizely/java-sdk/pull/601))
+- Add Feature Rollout support ([#601](https://github.com/optimizely/java-sdk/pull/601)).
+- Remove experiment type validation from config parsing ([#602](https://github.com/optimizely/java-sdk/pull/602)).
+- Remove legacy flag-level holdout fields ([#604](https://github.com/optimizely/java-sdk/pull/604)).
 
 ### Fixes
-- [FSSDK-12315] Arnica risk fixes ([#600](https://github.com/optimizely/java-sdk/pull/600))
+- Arnica risk fixes ([#600](https://github.com/optimizely/java-sdk/pull/600)).
 
 ### Other
-- Fix documentation links in README.md ([#598](https://github.com/optimizely/java-sdk/pull/598))
+- Fix documentation links in README.md ([#598](https://github.com/optimizely/java-sdk/pull/598)).
 
 ## [4.3.1]
 Jan 20, 2025

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Maven version
-version = 3.1.0-SNAPSHOT
+version = 4.4.0
 
 # Artifact paths
 mavenS3Bucket = optimizely-maven


### PR DESCRIPTION
## Summary

Prepare for release v4.4.0

## Release Details
- Version Bump: v4.3.1 → v4.4.0 (minor)

[FSSDK-12546](https://optimizely-ext.atlassian.net/browse/FSSDK-12546)

[FSSDK-12546]: https://optimizely-ext.atlassian.net/browse/FSSDK-12546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ