### PR TITLE
[FSSDK-12617] Deserialize integers as longs when using Gson

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/config/parser/GsonConfigParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/GsonConfigParser.java
@@ -20,6 +20,7 @@ import javax.annotation.Nonnull;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.ToNumberPolicy;
 import com.optimizely.ab.config.DatafileProjectConfig;
 import com.optimizely.ab.config.Experiment;
 import com.optimizely.ab.config.FeatureFlag;
@@ -37,6 +38,7 @@ final public class GsonConfigParser implements ConfigParser {
 
     public GsonConfigParser() {
         this(new GsonBuilder()
+            .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
             .registerTypeAdapter(Audience.class, new AudienceGsonDeserializer())
             .registerTypeAdapter(TypedAudience.class, new AudienceGsonDeserializer())
             .registerTypeAdapter(Experiment.class, new ExperimentGsonDeserializer())

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/GsonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/GsonConfigParserTest.java
@@ -417,9 +417,7 @@ public class GsonConfigParserTest {
         Map<String, Object> map = null;
         try {
             map = parser.fromJson(json, Map.class);
-            for (String key : map.keySet()) {
-                assertEquals(expectedMap.get(key), map.get(key));
-            }
+            assertEquals(expectedMap, map);
         } catch (JsonParseException e) {
             fail("Parse to map failed: " + e.getMessage());
         }

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/GsonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/GsonConfigParserTest.java
@@ -404,19 +404,22 @@ public class GsonConfigParserTest {
 
     @Test
     public void testFromJson() {
-        String json = "{\"k1\":\"v1\",\"k2\":3.5,\"k3\":true}";
+        String json = "{\"k1\":\"v1\",\"k2\":3.5,\"k3\":true,\"k4\":12345}";
 
         Map<String, Object> expectedMap = new HashMap<>();
         expectedMap.put("k1", "v1");
         expectedMap.put("k2", 3.5);
         expectedMap.put("k3", true);
+        expectedMap.put("k4", 12345L);
 
         GsonConfigParser parser = new GsonConfigParser();
 
-        Map map = null;
+        Map<String, Object> map = null;
         try {
             map = parser.fromJson(json, Map.class);
-            assertEquals(map, expectedMap);
+            for (String key : map.keySet()) {
+                assertEquals(expectedMap.get(key), map.get(key));
+            }
         } catch (JsonParseException e) {
             fail("Parse to map failed: " + e.getMessage());
         }

--- a/core-api/src/test/java/com/optimizely/ab/config/parser/GsonConfigParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/parser/GsonConfigParserTest.java
@@ -404,13 +404,18 @@ public class GsonConfigParserTest {
 
     @Test
     public void testFromJson() {
-        String json = "{\"k1\":\"v1\",\"k2\":3.5,\"k3\":true,\"k4\":12345}";
+        String json = "{\"k1\":\"v1\",\"k2\":3.5,\"k3\":true,\"k4\":12345,\"k5\":{\"nk1\":99,\"nk2\":1.5}}";
+
+        Map<String, Object> nestedMap = new HashMap<>();
+        nestedMap.put("nk1", 99L);
+        nestedMap.put("nk2", 1.5);
 
         Map<String, Object> expectedMap = new HashMap<>();
         expectedMap.put("k1", "v1");
         expectedMap.put("k2", 3.5);
         expectedMap.put("k3", true);
         expectedMap.put("k4", 12345L);
+        expectedMap.put("k5", nestedMap);
 
         GsonConfigParser parser = new GsonConfigParser();
 

--- a/core-api/src/test/java/com/optimizely/ab/optimizelyjson/OptimizelyJSONWithGsonParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/optimizelyjson/OptimizelyJSONWithGsonParserTest.java
@@ -64,10 +64,7 @@ public class OptimizelyJSONWithGsonParserTest {
         m1.put("k3", m2);
 
         OptimizelyJSON oj1 = new OptimizelyJSON(json, getParser());
-        Map<String, Object> ojMap = oj1.toMap();
-        for (String key : m1.keySet()) {
-            assertEquals(m1.get(key), ojMap.get(key));
-        }
+        assertEquals(oj1.toMap(), m1);
     }
 
     @Test

--- a/core-api/src/test/java/com/optimizely/ab/optimizelyjson/OptimizelyJSONWithGsonParserTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/optimizelyjson/OptimizelyJSONWithGsonParserTest.java
@@ -50,21 +50,24 @@ public class OptimizelyJSONWithGsonParserTest {
     @Test
     public void testIntegerProcessing() throws JsonParseException {
 
-        // GSON parser toMap() adds ".0" to all integers
+        // GSON parser toMap() converts integers to longs
 
         String json = "{\"k1\":1,\"k2\":2.5,\"k3\":{\"kk1\":3,\"kk2\":4.0}}";
 
         Map<String,Object> m2 = new HashMap<String,Object>();
-        m2.put("kk1", 3.0);
+        m2.put("kk1", 3L);
         m2.put("kk2", 4.0);
 
         Map<String,Object> m1 = new HashMap<String,Object>();
-        m1.put("k1", 1.0);
+        m1.put("k1", 1L);
         m1.put("k2", 2.5);
         m1.put("k3", m2);
 
         OptimizelyJSON oj1 = new OptimizelyJSON(json, getParser());
-        assertEquals(oj1.toMap(), m1);
+        Map<String, Object> ojMap = oj1.toMap();
+        for (String key : m1.keySet()) {
+            assertEquals(m1.get(key), ojMap.get(key));
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
Deserialize integers as longs instead of doubles when using Gson. This allows users to use the resultant `Map` in downstream serializers (e.g. kotlinx.serialization) more easily.

## Changes
- Added `ToNumberPolicy.LONG_OR_DOUBLE` to `GsonConfigParser` so integers deserialize as `Long` instead of `Double`
- Updated `GsonConfigParserTest` to verify integer parsing and fix assertion argument order
- Updated `OptimizelyJSONWithGsonParserTest` to reflect `Long` expected values

## Testing
- Updated existing tests to validate new behavior
- Added integer-specific test case in `testFromJson`

## Related
- Jira: [FSSDK-12617](https://optimizely-ext.atlassian.net/browse/FSSDK-12617)
- Fixes GitHub Issue: #622
- Original PR: #623 by @jamiesanson

[FSSDK-12617]: https://optimizely-ext.atlassian.net/browse/FSSDK-12617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ