### PR TITLE
[BUG-8620] Make DefaultJsonSerializer resilient to init failures

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/event/internal/serializer/DefaultJsonSerializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/serializer/DefaultJsonSerializer.java
@@ -47,23 +47,45 @@ public final class DefaultJsonSerializer {
      */
     private static @Nonnull
     Serializer create() {
-        Serializer serializer;
-
         if (isPresent("com.fasterxml.jackson.databind.ObjectMapper")) {
-            serializer = new JacksonSerializer();
-        } else if (isPresent("com.google.gson.Gson")) {
-            serializer = new GsonSerializer();
-        } else if (isPresent("org.json.simple.JSONObject")) {
-            serializer = new JsonSimpleSerializer();
-        } else if (isPresent("org.json.JSONObject")) {
-            serializer = new JsonSerializer();
-        } else {
-            throw new MissingJsonParserException("unable to locate a JSON parser. "
-                + "Please see <link> for more information");
+            try {
+                Serializer serializer = new JacksonSerializer();
+                logger.debug("using json serializer: {}", serializer.getClass().getSimpleName());
+                return serializer;
+            } catch (Throwable t) {
+                logger.warn("Jackson found on classpath but serializer initialization failed, trying next option.", t);
+            }
+        }
+        if (isPresent("com.google.gson.Gson")) {
+            try {
+                Serializer serializer = new GsonSerializer();
+                logger.debug("using json serializer: {}", serializer.getClass().getSimpleName());
+                return serializer;
+            } catch (Throwable t) {
+                logger.warn("Gson found on classpath but serializer initialization failed, trying next option.", t);
+            }
+        }
+        if (isPresent("org.json.simple.JSONObject")) {
+            try {
+                Serializer serializer = new JsonSimpleSerializer();
+                logger.debug("using json serializer: {}", serializer.getClass().getSimpleName());
+                return serializer;
+            } catch (Throwable t) {
+                logger.warn("json-simple found on classpath but serializer initialization failed, trying next option.", t);
+            }
+        }
+        if (isPresent("org.json.JSONObject")) {
+            try {
+                Serializer serializer = new JsonSerializer();
+                logger.debug("using json serializer: {}", serializer.getClass().getSimpleName());
+                return serializer;
+            } catch (Throwable t) {
+                logger.warn("org.json found on classpath but serializer initialization failed.", t);
+            }
         }
 
-        logger.debug("using json serializer: {}", serializer.getClass().getSimpleName());
-        return serializer;
+        throw new MissingJsonParserException("unable to locate a JSON parser. "
+            + "Please see <link> for more information");
     }
 
     private static boolean isPresent(@Nonnull String className) {

--- a/core-api/src/main/java/com/optimizely/ab/event/internal/serializer/DefaultJsonSerializer.java
+++ b/core-api/src/main/java/com/optimizely/ab/event/internal/serializer/DefaultJsonSerializer.java
@@ -22,6 +22,8 @@ import org.slf4j.LoggerFactory;
 import com.optimizely.ab.config.parser.MissingJsonParserException;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.concurrent.Callable;
 
 /**
  * Factory for generating {@link Serializer} instances, based on the json library available on the classpath.
@@ -47,45 +49,28 @@ public final class DefaultJsonSerializer {
      */
     private static @Nonnull
     Serializer create() {
-        if (isPresent("com.fasterxml.jackson.databind.ObjectMapper")) {
-            try {
-                Serializer serializer = new JacksonSerializer();
-                logger.debug("using json serializer: {}", serializer.getClass().getSimpleName());
-                return serializer;
-            } catch (Throwable t) {
-                logger.warn("Jackson found on classpath but serializer initialization failed, trying next option.", t);
-            }
+        Serializer serializer;
+        if ((serializer = tryCreate("com.fasterxml.jackson.databind.ObjectMapper", JacksonSerializer::new)) != null ||
+            (serializer = tryCreate("com.google.gson.Gson", GsonSerializer::new)) != null ||
+            (serializer = tryCreate("org.json.simple.JSONObject", JsonSimpleSerializer::new)) != null ||
+            (serializer = tryCreate("org.json.JSONObject", JsonSerializer::new)) != null) {
+            logger.debug("using json serializer: {}", serializer.getClass().getSimpleName());
+            return serializer;
         }
-        if (isPresent("com.google.gson.Gson")) {
-            try {
-                Serializer serializer = new GsonSerializer();
-                logger.debug("using json serializer: {}", serializer.getClass().getSimpleName());
-                return serializer;
-            } catch (Throwable t) {
-                logger.warn("Gson found on classpath but serializer initialization failed, trying next option.", t);
-            }
-        }
-        if (isPresent("org.json.simple.JSONObject")) {
-            try {
-                Serializer serializer = new JsonSimpleSerializer();
-                logger.debug("using json serializer: {}", serializer.getClass().getSimpleName());
-                return serializer;
-            } catch (Throwable t) {
-                logger.warn("json-simple found on classpath but serializer initialization failed, trying next option.", t);
-            }
-        }
-        if (isPresent("org.json.JSONObject")) {
-            try {
-                Serializer serializer = new JsonSerializer();
-                logger.debug("using json serializer: {}", serializer.getClass().getSimpleName());
-                return serializer;
-            } catch (Throwable t) {
-                logger.warn("org.json found on classpath but serializer initialization failed.", t);
-            }
-        }
-
         throw new MissingJsonParserException("unable to locate a JSON parser. "
             + "Please see <link> for more information");
+    }
+
+    private static @Nullable Serializer tryCreate(String className, Callable<Serializer> factory) {
+        if (!isPresent(className)) {
+            return null;
+        }
+        try {
+            return factory.call();
+        } catch (Throwable t) {
+            logger.warn("{} found on classpath but serializer init failed, trying next option.", className, t);
+            return null;
+        }
     }
 
     private static boolean isPresent(@Nonnull String className) {

--- a/core-api/src/test/java/com/optimizely/ab/event/internal/serializer/DefaultJsonSerializerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/event/internal/serializer/DefaultJsonSerializerTest.java
@@ -1,0 +1,45 @@
+/**
+ *
+ *    Copyright 2026, Optimizely and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.optimizely.ab.event.internal.serializer;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class DefaultJsonSerializerTest {
+
+    @Test
+    public void getInstanceReturnsNonNull() {
+        Serializer serializer = DefaultJsonSerializer.getInstance();
+        assertNotNull("getInstance() should return a non-null serializer", serializer);
+    }
+
+    @Test
+    public void getInstanceReturnsSameInstance() {
+        Serializer first = DefaultJsonSerializer.getInstance();
+        Serializer second = DefaultJsonSerializer.getInstance();
+        assertSame("getInstance() should return the same singleton instance", first, second);
+    }
+
+    @Test
+    public void instanceCanSerialize() {
+        Serializer serializer = DefaultJsonSerializer.getInstance();
+        String result = serializer.serialize(java.util.Collections.singletonMap("test_key", "test_value"));
+        assertNotNull("Serializer should produce non-null output", result);
+        assertTrue("Serialized output should contain the key", result.contains("test_key"));
+        assertTrue("Serialized output should contain the value", result.contains("test_value"));
+    }
+}


### PR DESCRIPTION
## Summary
- Wraps each serializer instantiation in `DefaultJsonSerializer.create()` with try-catch so that if one library's initialization fails (e.g., Jackson's `PropertyNamingStrategies` fields obfuscated by R8), the factory falls through to the next available JSON library instead of crashing with `NoClassDefFoundError`
- Catches `Throwable` (not just `Exception`) to handle `NoClassDefFoundError`, `ExceptionInInitializerError`, and similar linkage errors
- Adds `DefaultJsonSerializerTest` with smoke tests for the singleton

## Context
PetSmart reports that event dispatch fails with `NoClassDefFoundError: DefaultJsonSerializer$LazyHolder` when Jackson is on the classpath with its `PropertyNamingStrategies.SNAKE_CASE` field obfuscated by R8. The current `create()` method doesn't handle serializer constructor failures, so a Jackson init failure kills the entire serializer factory.

**Companion PR:** android-sdk ProGuard rules (defense-in-depth)

## Test plan
- [x] All existing serializer tests pass (`JacksonSerializerTest`, `GsonSerializerTest`, `JsonSerializerTest`, `JsonSimpleSerializerTest`)
- [x] New `DefaultJsonSerializerTest` passes (3 tests)
- [ ] Manual verification with test-app using obfuscated Jackson + R8

## Issue
- [BUG-8620](https://optimizely-ext.atlassian.net/browse/BUG-8620)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BUG-8620]: https://optimizely-ext.atlassian.net/browse/BUG-8620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ