### PR TITLE
[AI-FSSDK] [FSSDK-12670] Block ODP identify event for single identifier

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -57,6 +57,7 @@ import com.optimizely.ab.odp.ODPEvent;
 import com.optimizely.ab.odp.ODPManager;
 import com.optimizely.ab.odp.ODPSegmentManager;
 import com.optimizely.ab.odp.ODPSegmentOption;
+import com.optimizely.ab.odp.ODPUserKey;
 import com.optimizely.ab.optimizelyconfig.OptimizelyConfig;
 import com.optimizely.ab.optimizelyconfig.OptimizelyConfigManager;
 import com.optimizely.ab.optimizelyconfig.OptimizelyConfigService;
@@ -1794,7 +1795,13 @@ public class Optimizely implements AutoCloseable {
         }
         ODPManager odpManager = getODPManager();
         if (odpManager != null) {
-            odpManager.getEventManager().identifyUser(userId);
+            Map<String, String> identifiers = new HashMap<>();
+            if (ODPManager.isVuid(userId)) {
+                identifiers.put(ODPUserKey.VUID.getKeyString(), userId);
+            } else {
+                identifiers.put(ODPUserKey.FS_USER_ID.getKeyString(), userId);
+            }
+            odpManager.getEventManager().identifyUser(identifiers);
         }
     }
 

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
@@ -139,6 +139,11 @@ public class ODPEventManager {
     }
 
     public void identifyUser(@Nonnull Map<String, String> identifiers) {
+        if (identifiers == null) {
+            logger.debug("ODP identify event is not dispatched (fewer than 2 valid identifiers).");
+            return;
+        }
+
         Map<String, String> validIdentifiers = new HashMap<>();
         for (Map.Entry<String, String> entry : identifiers.entrySet()) {
             if (entry.getValue() != null && !entry.getValue().isEmpty()) {
@@ -147,7 +152,7 @@ public class ODPEventManager {
         }
 
         if (validIdentifiers.size() < 2) {
-            logger.debug("ODP identify event is not dispatched (only one identifier provided).");
+            logger.debug("ODP identify event is not dispatched (fewer than 2 valid identifiers).");
             return;
         }
 

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
@@ -111,23 +111,21 @@ public class ODPEventManager {
         }
     }
 
-    public void identifyUser(String userId) {
-        identifyUser(null, userId);
-    }
-
-    public void identifyUser(@Nullable String vuid, @Nullable String userId) {
-        Map<String, String> identifiers = new HashMap<>();
-        if (vuid != null) {
-            identifiers.put(ODPUserKey.VUID.getKeyString(), vuid);
-        }
-        if (userId != null) {
-            if (ODPManager.isVuid(userId)) {
-                identifiers.put(ODPUserKey.VUID.getKeyString(), userId);
-            } else {
-                identifiers.put(ODPUserKey.FS_USER_ID.getKeyString(), userId);
+    public void identifyUser(@Nonnull Map<String, String> identifiers) {
+        // Filter out identifiers with null or empty values
+        Map<String, String> validIdentifiers = new HashMap<>();
+        for (Map.Entry<String, String> entry : identifiers.entrySet()) {
+            if (entry.getValue() != null && !entry.getValue().isEmpty()) {
+                validIdentifiers.put(entry.getKey(), entry.getValue());
             }
         }
-        ODPEvent event = new ODPEvent("fullstack", "identified", identifiers, null);
+
+        if (validIdentifiers.size() < 2) {
+            logger.debug("ODP identify event is not dispatched (only one identifier provided).");
+            return;
+        }
+
+        ODPEvent event = new ODPEvent("fullstack", "identified", validIdentifiers, null);
         sendEvent(event);
     }
 

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
@@ -111,8 +111,34 @@ public class ODPEventManager {
         }
     }
 
+    /**
+     * @deprecated Use {@link #identifyUser(Map)} instead.
+     */
+    @Deprecated
+    public void identifyUser(String userId) {
+        identifyUser(null, userId);
+    }
+
+    /**
+     * @deprecated Use {@link #identifyUser(Map)} instead.
+     */
+    @Deprecated
+    public void identifyUser(@Nullable String vuid, @Nullable String userId) {
+        Map<String, String> identifiers = new HashMap<>();
+        if (vuid != null) {
+            identifiers.put(ODPUserKey.VUID.getKeyString(), vuid);
+        }
+        if (userId != null) {
+            if (ODPManager.isVuid(userId)) {
+                identifiers.put(ODPUserKey.VUID.getKeyString(), userId);
+            } else {
+                identifiers.put(ODPUserKey.FS_USER_ID.getKeyString(), userId);
+            }
+        }
+        identifyUser(identifiers);
+    }
+
     public void identifyUser(@Nonnull Map<String, String> identifiers) {
-        // Filter out identifiers with null or empty values
         Map<String, String> validIdentifiers = new HashMap<>();
         for (Map.Entry<String, String> entry : identifiers.entrySet()) {
             if (entry.getValue() != null && !entry.getValue().isEmpty()) {

--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
@@ -151,6 +151,8 @@ public class ODPEventManager {
             }
         }
 
+        // An identify event requires at least 2 identifiers to link (e.g., vuid + fs_user_id).
+        // A single identifier has no cross-reference value and would generate unnecessary traffic.
         if (validIdentifiers.size() < 2) {
             logger.debug("ODP identify event is not dispatched (fewer than 2 valid identifiers).");
             return;

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyTest.java
@@ -5084,7 +5084,10 @@ public class OptimizelyTest {
             .build();
 
         optimizely.identifyUser("the-user");
-        Mockito.verify(mockODPEventManager, times(1)).identifyUser("the-user");
+        ArgumentCaptor<Map> identifiersCaptor = ArgumentCaptor.forClass(Map.class);
+        Mockito.verify(mockODPEventManager, times(1)).identifyUser(identifiersCaptor.capture());
+        Map<String, String> capturedIdentifiers = identifiersCaptor.getValue();
+        assertEquals("the-user", capturedIdentifiers.get("fs_user_id"));
     }
 
     @Test

--- a/core-api/src/test/java/com/optimizely/ab/OptimizelyUserContextTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/OptimizelyUserContextTest.java
@@ -1970,7 +1970,7 @@ public class OptimizelyUserContextTest {
             .build();
 
         optimizely.createUserContext("test-user");
-        verify(mockODPEventManager, never()).identifyUser("test-user");
+        verify(mockODPEventManager, never()).identifyUser(any(Map.class));
         Mockito.reset(mockODPEventManager);
 
         logbackVerifier.expectMessage(Level.ERROR, "Optimizely instance is not valid, failing identifyUser call.");
@@ -1992,13 +1992,16 @@ public class OptimizelyUserContextTest {
             .build();
 
         OptimizelyUserContext userContext = optimizely.createUserContext("test-user");
-        verify(mockODPEventManager).identifyUser("test-user");
+        ArgumentCaptor<Map> identifiersCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(mockODPEventManager).identifyUser(identifiersCaptor.capture());
+        Map<String, String> capturedIdentifiers = identifiersCaptor.getValue();
+        assertEquals("test-user", capturedIdentifiers.get("fs_user_id"));
 
         Mockito.reset(mockODPEventManager);
         OptimizelyUserContext userContextClone = userContext.copy();
 
-        // identifyUser should not be called the new userContext is created through copy
-        verify(mockODPEventManager, never()).identifyUser("test-user");
+        // identifyUser should not be called when the new userContext is created through copy
+        verify(mockODPEventManager, never()).identifyUser(any(Map.class));
 
         assertNotSame(userContextClone, userContext);
     }

--- a/core-api/src/test/java/com/optimizely/ab/odp/ODPEventManagerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/odp/ODPEventManagerTest.java
@@ -203,7 +203,10 @@ public class ODPEventManagerTest {
         eventManager.updateSettings(odpConfig);
         eventManager.start();
         for (int i = 0; i < 2; i++) {
-            eventManager.identifyUser("the-vuid-" + i, "the-fs-user-id-" + i);
+            Map<String, String> identifiers = new HashMap<>();
+            identifiers.put("vuid", "the-vuid-" + i);
+            identifiers.put("fs_user_id", "the-fs-user-id-" + i);
+            eventManager.identifyUser(identifiers);
         }
 
         Thread.sleep(1500);
@@ -290,61 +293,88 @@ public class ODPEventManagerTest {
     }
 
     @Test
-    public void identifyUserWithVuidAndUserId() throws InterruptedException {
+    public void identifyUserWithMultipleIdentifiers() throws InterruptedException {
         ODPEventManager eventManager = spy(new ODPEventManager(mockApiManager));
         ArgumentCaptor<ODPEvent> captor = ArgumentCaptor.forClass(ODPEvent.class);
 
-        eventManager.identifyUser("vuid_123", "test-user");
+        Map<String, String> identifiers = new HashMap<>();
+        identifiers.put("vuid", "vuid_123");
+        identifiers.put("fs_user_id", "test-user");
+        eventManager.identifyUser(identifiers);
         verify(eventManager, times(1)).sendEvent(captor.capture());
 
         ODPEvent event = captor.getValue();
-        Map<String, String> identifiers = event.getIdentifiers();
-        assertEquals(identifiers.size(), 2);
-        assertEquals(identifiers.get("vuid"), "vuid_123");
-        assertEquals(identifiers.get("fs_user_id"), "test-user");
+        Map<String, String> eventIdentifiers = event.getIdentifiers();
+        assertEquals(eventIdentifiers.size(), 2);
+        assertEquals(eventIdentifiers.get("vuid"), "vuid_123");
+        assertEquals(eventIdentifiers.get("fs_user_id"), "test-user");
     }
 
     @Test
-    public void identifyUserWithVuidOnly() throws InterruptedException {
+    public void identifyUserSkippedWithSingleIdentifier() throws InterruptedException {
         ODPEventManager eventManager = spy(new ODPEventManager(mockApiManager));
-        ArgumentCaptor<ODPEvent> captor = ArgumentCaptor.forClass(ODPEvent.class);
 
-        eventManager.identifyUser("vuid_123", null);
-        verify(eventManager, times(1)).sendEvent(captor.capture());
-
-        ODPEvent event = captor.getValue();
-        Map<String, String> identifiers = event.getIdentifiers();
-        assertEquals(identifiers.size(), 1);
-        assertEquals(identifiers.get("vuid"), "vuid_123");
+        Map<String, String> identifiers = new HashMap<>();
+        identifiers.put("fs_user_id", "test-user");
+        eventManager.identifyUser(identifiers);
+        verify(eventManager, never()).sendEvent(any(ODPEvent.class));
+        logbackVerifier.expectMessage(Level.DEBUG, "ODP identify event is not dispatched (only one identifier provided).");
     }
 
     @Test
-    public void identifyUserWithUserIdOnly() throws InterruptedException {
+    public void identifyUserSkippedWithEmptyValues() throws InterruptedException {
         ODPEventManager eventManager = spy(new ODPEventManager(mockApiManager));
-        ArgumentCaptor<ODPEvent> captor = ArgumentCaptor.forClass(ODPEvent.class);
 
-        eventManager.identifyUser(null, "test-user");
-        verify(eventManager, times(1)).sendEvent(captor.capture());
-
-        ODPEvent event = captor.getValue();
-        Map<String, String> identifiers = event.getIdentifiers();
-        assertEquals(identifiers.size(), 1);
-        assertEquals(identifiers.get("fs_user_id"), "test-user");
+        // Two keys but one has empty value - only 1 valid identifier
+        Map<String, String> identifiers = new HashMap<>();
+        identifiers.put("fs_user_id", "test-user");
+        identifiers.put("email", "");
+        eventManager.identifyUser(identifiers);
+        verify(eventManager, never()).sendEvent(any(ODPEvent.class));
+        logbackVerifier.expectMessage(Level.DEBUG, "ODP identify event is not dispatched (only one identifier provided).");
     }
 
     @Test
-    public void identifyUserWithVuidAsUserId() throws InterruptedException {
+    public void identifyUserSkippedWithNullValues() throws InterruptedException {
+        ODPEventManager eventManager = spy(new ODPEventManager(mockApiManager));
+
+        // Two keys but one has null value - only 1 valid identifier
+        Map<String, String> identifiers = new HashMap<>();
+        identifiers.put("fs_user_id", "test-user");
+        identifiers.put("vuid", null);
+        eventManager.identifyUser(identifiers);
+        verify(eventManager, never()).sendEvent(any(ODPEvent.class));
+        logbackVerifier.expectMessage(Level.DEBUG, "ODP identify event is not dispatched (only one identifier provided).");
+    }
+
+    @Test
+    public void identifyUserSkippedWithEmptyMap() throws InterruptedException {
+        ODPEventManager eventManager = spy(new ODPEventManager(mockApiManager));
+
+        Map<String, String> identifiers = new HashMap<>();
+        eventManager.identifyUser(identifiers);
+        verify(eventManager, never()).sendEvent(any(ODPEvent.class));
+        logbackVerifier.expectMessage(Level.DEBUG, "ODP identify event is not dispatched (only one identifier provided).");
+    }
+
+    @Test
+    public void identifyUserSendsWithThreeIdentifiers() throws InterruptedException {
         ODPEventManager eventManager = spy(new ODPEventManager(mockApiManager));
         ArgumentCaptor<ODPEvent> captor = ArgumentCaptor.forClass(ODPEvent.class);
 
-        eventManager.identifyUser(null, "vuid_123");
+        Map<String, String> identifiers = new HashMap<>();
+        identifiers.put("vuid", "vuid_123");
+        identifiers.put("fs_user_id", "test-user");
+        identifiers.put("email", "test@example.com");
+        eventManager.identifyUser(identifiers);
         verify(eventManager, times(1)).sendEvent(captor.capture());
 
         ODPEvent event = captor.getValue();
-        Map<String, String> identifiers = event.getIdentifiers();
-        assertEquals(identifiers.size(), 1);
-        // SDK will convert userId to vuid when userId has a valid vuid format.
-        assertEquals(identifiers.get("vuid"), "vuid_123");
+        Map<String, String> eventIdentifiers = event.getIdentifiers();
+        assertEquals(3, eventIdentifiers.size());
+        assertEquals("vuid_123", eventIdentifiers.get("vuid"));
+        assertEquals("test-user", eventIdentifiers.get("fs_user_id"));
+        assertEquals("test@example.com", eventIdentifiers.get("email"));
     }
 
     @Test

--- a/core-api/src/test/java/com/optimizely/ab/odp/ODPEventManagerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/odp/ODPEventManagerTest.java
@@ -305,9 +305,9 @@ public class ODPEventManagerTest {
 
         ODPEvent event = captor.getValue();
         Map<String, String> eventIdentifiers = event.getIdentifiers();
-        assertEquals(eventIdentifiers.size(), 2);
-        assertEquals(eventIdentifiers.get("vuid"), "vuid_123");
-        assertEquals(eventIdentifiers.get("fs_user_id"), "test-user");
+        assertEquals(2, eventIdentifiers.size());
+        assertEquals("vuid_123", eventIdentifiers.get("vuid"));
+        assertEquals("test-user", eventIdentifiers.get("fs_user_id"));
     }
 
     @Test
@@ -318,7 +318,7 @@ public class ODPEventManagerTest {
         identifiers.put("fs_user_id", "test-user");
         eventManager.identifyUser(identifiers);
         verify(eventManager, never()).sendEvent(any(ODPEvent.class));
-        logbackVerifier.expectMessage(Level.DEBUG, "ODP identify event is not dispatched (only one identifier provided).");
+        logbackVerifier.expectMessage(Level.DEBUG, "ODP identify event is not dispatched (fewer than 2 valid identifiers).");
     }
 
     @Test
@@ -331,7 +331,7 @@ public class ODPEventManagerTest {
         identifiers.put("email", "");
         eventManager.identifyUser(identifiers);
         verify(eventManager, never()).sendEvent(any(ODPEvent.class));
-        logbackVerifier.expectMessage(Level.DEBUG, "ODP identify event is not dispatched (only one identifier provided).");
+        logbackVerifier.expectMessage(Level.DEBUG, "ODP identify event is not dispatched (fewer than 2 valid identifiers).");
     }
 
     @Test
@@ -344,7 +344,7 @@ public class ODPEventManagerTest {
         identifiers.put("vuid", null);
         eventManager.identifyUser(identifiers);
         verify(eventManager, never()).sendEvent(any(ODPEvent.class));
-        logbackVerifier.expectMessage(Level.DEBUG, "ODP identify event is not dispatched (only one identifier provided).");
+        logbackVerifier.expectMessage(Level.DEBUG, "ODP identify event is not dispatched (fewer than 2 valid identifiers).");
     }
 
     @Test
@@ -354,7 +354,7 @@ public class ODPEventManagerTest {
         Map<String, String> identifiers = new HashMap<>();
         eventManager.identifyUser(identifiers);
         verify(eventManager, never()).sendEvent(any(ODPEvent.class));
-        logbackVerifier.expectMessage(Level.DEBUG, "ODP identify event is not dispatched (only one identifier provided).");
+        logbackVerifier.expectMessage(Level.DEBUG, "ODP identify event is not dispatched (fewer than 2 valid identifiers).");
     }
 
     @Test

--- a/core-api/src/test/java/com/optimizely/ab/odp/ODPManagerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/odp/ODPManagerTest.java
@@ -23,8 +23,10 @@ import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
@@ -75,13 +77,16 @@ public class ODPManagerTest {
         ODPManager odpManager = ODPManager.builder().withApiManager(mockApiManager).build();
         odpManager.updateSettings("test-host", "test-key", new HashSet<>(Arrays.asList("segment1", "segment2")));
 
-        odpManager.getEventManager().identifyUser("vuid", "fsuid");
+        Map<String, String> identifiers = new HashMap<>();
+        identifiers.put("vuid", "vuid_value");
+        identifiers.put("fs_user_id", "fsuid");
+        odpManager.getEventManager().identifyUser(identifiers);
         Thread.sleep(2000);
         verify(mockApiManager, times(1))
             .sendEvents(eq("test-key"), eq("test-host/v3/events"), any());
 
         odpManager.updateSettings("test-host-updated", "test-key-updated", new HashSet<>(Arrays.asList("segment1")));
-        odpManager.getEventManager().identifyUser("vuid", "fsuid");
+        odpManager.getEventManager().identifyUser(identifiers);
         Thread.sleep(1200);
         verify(mockApiManager, times(1))
             .sendEvents(eq("test-key-updated"), eq("test-host-updated/v3/events"), any());


### PR DESCRIPTION
## Summary

Fixes the ODP identify event to only send when multiple valid identifiers exist. Previously, identify events were always sent even with a single identifier, which provided no linking value and generated unnecessary network traffic.

## Changes
- Changed ODPEventManager.identifyUser to accept a Map of identifiers and filter out null/empty values
- Added guard to skip identify event when fewer than 2 valid identifiers remain
- Updated Optimizely.identifyUser to construct identifier map internally while keeping backward-compatible String parameter

## Jira Ticket
[FSSDK-12670](https://optimizely-ext.atlassian.net/browse/FSSDK-12670)

## Notes
- Reference implementation: Python SDK PR #513

[FSSDK-12670]: https://optimizely-ext.atlassian.net/browse/FSSDK-12670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ