### PR TITLE
[AI-FSSDK] prepare for release java-sdk v4.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Optimizely Java X SDK Changelog
 
+## [4.4.1]
+May 28, 2026
+
+### Fixes
+- Block ODP identify event for single identifier ([#629](https://github.com/optimizely/java-sdk/pull/629))
+- Add local holdouts support ([#628](https://github.com/optimizely/java-sdk/pull/628))
+
+
 ## [4.4.0]
 May 4, 2026
 


### PR DESCRIPTION
## Summary
Prepare for releasing java-sdk v4.4.1

## Release Details
- Version Bump: v4.4.0 → v4.4.1

## Jira Ticket
FSSDK-0000