### PR TITLE
[FSSDK-12670] Include commonIdentifiers in identifyUser identifier count

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
+++ b/core-api/src/main/java/com/optimizely/ab/odp/ODPEventManager.java
@@ -151,14 +151,18 @@ public class ODPEventManager {
             }
         }
 
+        // android-sdk sets vuid in commonIdentifiers. Augment here so the vuid is included
+        // when counting identifiers. Idempotent with augment in sendEvent.
+        Map<String, String> allIdentifiers = augmentCommonIdentifiers(validIdentifiers);
+
         // An identify event requires at least 2 identifiers to link (e.g., vuid + fs_user_id).
         // A single identifier has no cross-reference value and would generate unnecessary traffic.
-        if (validIdentifiers.size() < 2) {
+        if (allIdentifiers.size() < 2) {
             logger.debug("ODP identify event is not dispatched (fewer than 2 valid identifiers).");
             return;
         }
 
-        ODPEvent event = new ODPEvent("fullstack", "identified", validIdentifiers, null);
+        ODPEvent event = new ODPEvent("fullstack", "identified", allIdentifiers, null);
         sendEvent(event);
     }
 

--- a/core-api/src/test/java/com/optimizely/ab/odp/ODPEventManagerTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/odp/ODPEventManagerTest.java
@@ -358,6 +358,32 @@ public class ODPEventManagerTest {
     }
 
     @Test
+    public void identifyUserSendsWhenCommonIdentifiersProvideSecondIdentifier() throws InterruptedException {
+        ODPEventManager eventManager = spy(new ODPEventManager(mockApiManager));
+        ArgumentCaptor<ODPEvent> captor = ArgumentCaptor.forClass(ODPEvent.class);
+
+        // VUID is set as a common identifier (e.g., vuid enabled in ODPManager)
+        Map<String, String> commonIdentifiers = new HashMap<>();
+        commonIdentifiers.put("vuid", "vuid_abc123");
+        eventManager.setUserCommonIdentifiers(commonIdentifiers);
+
+        // createUserContext passes only fs_user_id — a single identifier in the call
+        Map<String, String> identifiers = new HashMap<>();
+        identifiers.put("fs_user_id", "test-user");
+        eventManager.identifyUser(identifiers);
+
+        // Should NOT be dropped: common identifiers provide the second identifier (vuid),
+        // making this a valid identify event with 2 identifiers total.
+        verify(eventManager, times(1)).sendEvent(captor.capture());
+
+        ODPEvent event = captor.getValue();
+        Map<String, String> eventIdentifiers = event.getIdentifiers();
+        assertEquals(2, eventIdentifiers.size());
+        assertEquals("test-user", eventIdentifiers.get("fs_user_id"));
+        assertEquals("vuid_abc123", eventIdentifiers.get("vuid"));
+    }
+
+    @Test
     public void identifyUserSendsWithThreeIdentifiers() throws InterruptedException {
         ODPEventManager eventManager = spy(new ODPEventManager(mockApiManager));
         ArgumentCaptor<ODPEvent> captor = ArgumentCaptor.forClass(ODPEvent.class);


### PR DESCRIPTION
## Summary

`identifyUser()` was checking the identifier count before augmenting with `userCommonIdentifiers` (e.g., vuid set by android-sdk). This caused valid identify events with `fs_user_id` + `vuid` to be incorrectly dropped as single-identifier events.

## Changes

- Augment identifiers with `commonIdentifiers` before the size check in `identifyUser()` so vuid from common identifiers is counted
- Add test covering the scenario where common identifiers provide the second identifier

## Jira Ticket
[FSSDK-12670](https://optimizely-ext.atlassian.net/browse/FSSDK-12670)

[FSSDK-12670]: https://optimizely-ext.atlassian.net/browse/FSSDK-12670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ