### PR TITLE
[AI-FSSDK] prepare for release java v4.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 July 7, 2026
 
 ### New Features
+
+**Local Holdouts**: Added support for Local Holdouts, enabling holdout experiments
+to be scoped to specific feature flags rather than applied globally.
+Local Holdouts let you measure the true incremental impact of individual features
+by holding out a subset of users from specific rollouts while still serving them other experiences.
+See [Holdouts docs](https://support.optimizely.com/hc/en-us/articles/38941939408269-Global-holdouts) for more information.
+
 - Add localHoldouts to datafile for backward compatibility ([#633](https://github.com/optimizely/java-sdk/pull/633))
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Optimizely Java X SDK Changelog
 
+## [4.5.0]
+July 7, 2026
+
+### Fixes
+- Use attribute id instead of key for CMAB prediction requests ([#635](https://github.com/optimizely/java-sdk/pull/635))
+- Normalize decision event campaign_id, variation_id, and entity_id ([#634](https://github.com/optimizely/java-sdk/pull/634))
+- Add localHoldouts to datafile for backward compatibility ([#633](https://github.com/optimizely/java-sdk/pull/633))
+
+
 ## [4.4.2]
 May 29, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 ## [4.5.0]
 July 7, 2026
 
+### New Features
+- Add localHoldouts to datafile for backward compatibility ([#633](https://github.com/optimizely/java-sdk/pull/633))
+
 ### Fixes
 - Use attribute id instead of key for CMAB prediction requests ([#635](https://github.com/optimizely/java-sdk/pull/635))
 - Normalize decision event campaign_id, variation_id, and entity_id ([#634](https://github.com/optimizely/java-sdk/pull/634))
-- Add localHoldouts to datafile for backward compatibility ([#633](https://github.com/optimizely/java-sdk/pull/633))
 
 
 ## [4.4.2]


### PR DESCRIPTION
## Summary

Prepare for releasing java v4.5.0

## Release Details
- Version Bump: v4.4.2 → v4.5.0 (minor)

## Jira Ticket
FSSDK-0000