### PR TITLE
[AI-FSSDK] [FSSDK-12735] Add holdout exclusion logic for Targeted Delivery rules

### DIFF
--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -1356,6 +1356,19 @@ public class Optimizely implements AutoCloseable {
                 cmabUuid);
         }
 
+        if (flagDecision.holdoutDecision != null && !allOptions.contains(OptimizelyDecideOption.DISABLE_DECISION_EVENT)) {
+            sendImpression(
+                projectConfig,
+                flagDecision.holdoutDecision.experiment,
+                userId,
+                copiedAttributes,
+                flagDecision.holdoutDecision.variation,
+                flagKey,
+                flagDecision.holdoutDecision.decisionSource != null ? flagDecision.holdoutDecision.decisionSource.toString() : FeatureDecision.DecisionSource.HOLDOUT.toString(),
+                flagDecision.holdoutDecision.variation != null && flagDecision.holdoutDecision.variation.getFeatureEnabled(),
+                null);
+        }
+
         DecisionNotification decisionNotification = DecisionNotification.newFlagDecisionNotificationBuilder()
             .withUserId(userId)
             .withAttributes(copiedAttributes)

--- a/core-api/src/main/java/com/optimizely/ab/Optimizely.java
+++ b/core-api/src/main/java/com/optimizely/ab/Optimizely.java
@@ -1357,7 +1357,7 @@ public class Optimizely implements AutoCloseable {
         }
 
         if (flagDecision.holdoutDecision != null && !allOptions.contains(OptimizelyDecideOption.DISABLE_DECISION_EVENT)) {
-            sendImpression(
+            decisionEventDispatched = sendImpression(
                 projectConfig,
                 flagDecision.holdoutDecision.experiment,
                 userId,
@@ -1366,7 +1366,7 @@ public class Optimizely implements AutoCloseable {
                 flagKey,
                 flagDecision.holdoutDecision.decisionSource != null ? flagDecision.holdoutDecision.decisionSource.toString() : FeatureDecision.DecisionSource.HOLDOUT.toString(),
                 flagDecision.holdoutDecision.variation != null && flagDecision.holdoutDecision.variation.getFeatureEnabled(),
-                null);
+                null) || decisionEventDispatched;
         }
 
         DecisionNotification decisionNotification = DecisionNotification.newFlagDecisionNotificationBuilder()

--- a/core-api/src/main/java/com/optimizely/ab/bucketing/DecisionService.java
+++ b/core-api/src/main/java/com/optimizely/ab/bucketing/DecisionService.java
@@ -347,6 +347,10 @@ public class DecisionService {
                 continue flagLoop;
             }
 
+            if (globalHoldoutDecision != null && excludeTargetedDeliveries) {
+                reasons.addInfo("Holdout '%s' has excludeTargetedDeliveries enabled, continuing to rollout evaluation.", globalHoldoutDecision.experiment.getKey());
+            }
+
             if (globalHoldoutDecision == null) {
                 DecisionResponse<FeatureDecision> decisionVariationResponse = getVariationFromExperiment(projectConfig, featureFlag, user, options, userProfileTracker, decisionPath);
                 reasons.merge(decisionVariationResponse.getReasons());

--- a/core-api/src/main/java/com/optimizely/ab/bucketing/DecisionService.java
+++ b/core-api/src/main/java/com/optimizely/ab/bucketing/DecisionService.java
@@ -365,10 +365,20 @@ public class DecisionService {
             FeatureDecision decision = decisionFeatureResponse.getResult();
 
             if (decision != null && decision.variation != null) {
+                if (globalHoldoutDecision != null) {
+                    decision.setHoldoutDecision(globalHoldoutDecision);
+                }
+                String message = reasons.addInfo("The user \"%s\" was bucketed into a rollout for feature flag \"%s\".",
+                    user.getUserId(), featureFlag.getKey());
+                logger.info(message);
                 decisions.add(new DecisionResponse(decision, reasons));
-            } else if (globalHoldoutDecision != null) {
-                decisions.add(new DecisionResponse<>(globalHoldoutDecision, reasons));
             } else {
+                if (globalHoldoutDecision != null) {
+                    if (decision == null) {
+                        decision = new FeatureDecision(null, null, null);
+                    }
+                    decision.setHoldoutDecision(globalHoldoutDecision);
+                }
                 String message = reasons.addInfo("The user \"%s\" was not bucketed into a rollout for feature flag \"%s\".",
                     user.getUserId(), featureFlag.getKey());
                 logger.info(message);
@@ -715,14 +725,10 @@ public class DecisionService {
 
     DecisionResponse<FeatureDecision> evaluateLocalHoldouts(@Nonnull ExperimentCore rule,
                                                             @Nonnull ProjectConfig projectConfig,
-                                                            @Nonnull OptimizelyUserContext user,
-                                                            boolean isDeliveryRule) {
+                                                            @Nonnull OptimizelyUserContext user) {
         DecisionReasons reasons = DefaultDecisionReasons.newInstance();
         List<Holdout> localHoldouts = projectConfig.getHoldoutsForRule(rule.getId());
         for (Holdout holdout : localHoldouts) {
-            if (isDeliveryRule && holdout.isExcludeTargetedDeliveries()) {
-                continue;
-            }
             DecisionResponse<Variation> holdoutDecision = getVariationForHoldout(holdout, user, projectConfig);
             reasons.merge(holdoutDecision.getReasons());
             if (holdoutDecision.getResult() != null) {
@@ -871,7 +877,7 @@ public class DecisionService {
 
         // Step 2: Check local holdouts
         if (rule != null) {
-            DecisionResponse<FeatureDecision> holdoutResponse = evaluateLocalHoldouts(rule, projectConfig, user, false);
+            DecisionResponse<FeatureDecision> holdoutResponse = evaluateLocalHoldouts(rule, projectConfig, user);
             reasons.merge(holdoutResponse.getReasons());
             if (holdoutResponse.getResult() != null) {
                 return new DecisionResponse<>(holdoutResponse.getResult(), reasons);
@@ -933,7 +939,7 @@ public class DecisionService {
         }
 
         // Step 2: Check local holdouts
-        DecisionResponse<FeatureDecision> holdoutResponse = evaluateLocalHoldouts(rule, projectConfig, user, true);
+        DecisionResponse<FeatureDecision> holdoutResponse = evaluateLocalHoldouts(rule, projectConfig, user);
         reasons.merge(holdoutResponse.getReasons());
         if (holdoutResponse.getResult() != null) {
             resultPair = new AbstractMap.SimpleEntry<>(holdoutResponse.getResult(), false);

--- a/core-api/src/main/java/com/optimizely/ab/bucketing/DecisionService.java
+++ b/core-api/src/main/java/com/optimizely/ab/bucketing/DecisionService.java
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2017-2022, 2024, Optimizely, Inc. and contributors             *
+ * Copyright 2017-2022, 2024, 2026, Optimizely, Inc. and contributors             *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -328,43 +328,52 @@ public class DecisionService {
 
             // Evaluate global holdouts at flag level (before any rules are iterated)
             List<Holdout> globalHoldouts = projectConfig.getGlobalHoldouts();
+            FeatureDecision globalHoldoutDecision = null;
+            boolean excludeTargetedDeliveries = false;
             if (!globalHoldouts.isEmpty()) {
                 for (Holdout holdout : globalHoldouts) {
                     DecisionResponse<Variation> holdoutDecision = getVariationForHoldout(holdout, user, projectConfig);
                     reasons.merge(holdoutDecision.getReasons());
                     if (holdoutDecision.getResult() != null) {
-                        decisions.add(new DecisionResponse<>(new FeatureDecision(holdout, holdoutDecision.getResult(), FeatureDecision.DecisionSource.HOLDOUT), reasons));
-                        continue flagLoop;
+                        globalHoldoutDecision = new FeatureDecision(holdout, holdoutDecision.getResult(), FeatureDecision.DecisionSource.HOLDOUT);
+                        excludeTargetedDeliveries = holdout.isExcludeTargetedDeliveries();
+                        break;
                     }
                 }
             }
 
-            DecisionResponse<FeatureDecision> decisionVariationResponse = getVariationFromExperiment(projectConfig, featureFlag, user, options, userProfileTracker, decisionPath);
-            reasons.merge(decisionVariationResponse.getReasons());
+            if (globalHoldoutDecision != null && !excludeTargetedDeliveries) {
+                decisions.add(new DecisionResponse<>(globalHoldoutDecision, reasons));
+                continue flagLoop;
+            }
 
-            FeatureDecision decision = decisionVariationResponse.getResult();
-            boolean error = decisionVariationResponse.isError();
+            if (globalHoldoutDecision == null) {
+                DecisionResponse<FeatureDecision> decisionVariationResponse = getVariationFromExperiment(projectConfig, featureFlag, user, options, userProfileTracker, decisionPath);
+                reasons.merge(decisionVariationResponse.getReasons());
 
-            if (decision != null) {
-                decisions.add(new DecisionResponse(decision, reasons, error, decision.cmabUuid));
-                continue;
+                FeatureDecision decision = decisionVariationResponse.getResult();
+                boolean error = decisionVariationResponse.isError();
+
+                if (decision != null) {
+                    decisions.add(new DecisionResponse(decision, reasons, error, decision.cmabUuid));
+                    continue flagLoop;
+                }
             }
 
             DecisionResponse<FeatureDecision> decisionFeatureResponse = getVariationForFeatureInRollout(featureFlag, user, projectConfig);
             reasons.merge(decisionFeatureResponse.getReasons());
-            decision = decisionFeatureResponse.getResult();
+            FeatureDecision decision = decisionFeatureResponse.getResult();
 
-            String message;
-            if (decision.variation == null) {
-                message = reasons.addInfo("The user \"%s\" was not bucketed into a rollout for feature flag \"%s\".",
-                    user.getUserId(), featureFlag.getKey());
+            if (decision != null && decision.variation != null) {
+                decisions.add(new DecisionResponse(decision, reasons));
+            } else if (globalHoldoutDecision != null) {
+                decisions.add(new DecisionResponse<>(globalHoldoutDecision, reasons));
             } else {
-                message = reasons.addInfo("The user \"%s\" was bucketed into a rollout for feature flag \"%s\".",
+                String message = reasons.addInfo("The user \"%s\" was not bucketed into a rollout for feature flag \"%s\".",
                     user.getUserId(), featureFlag.getKey());
+                logger.info(message);
+                decisions.add(new DecisionResponse(decision, reasons));
             }
-            logger.info(message);
-
-            decisions.add(new DecisionResponse(decision, reasons));
         }
 
         if (userProfileService != null && !ignoreUPS) {
@@ -706,10 +715,14 @@ public class DecisionService {
 
     DecisionResponse<FeatureDecision> evaluateLocalHoldouts(@Nonnull ExperimentCore rule,
                                                             @Nonnull ProjectConfig projectConfig,
-                                                            @Nonnull OptimizelyUserContext user) {
+                                                            @Nonnull OptimizelyUserContext user,
+                                                            boolean isDeliveryRule) {
         DecisionReasons reasons = DefaultDecisionReasons.newInstance();
         List<Holdout> localHoldouts = projectConfig.getHoldoutsForRule(rule.getId());
         for (Holdout holdout : localHoldouts) {
+            if (isDeliveryRule && holdout.isExcludeTargetedDeliveries()) {
+                continue;
+            }
             DecisionResponse<Variation> holdoutDecision = getVariationForHoldout(holdout, user, projectConfig);
             reasons.merge(holdoutDecision.getReasons());
             if (holdoutDecision.getResult() != null) {
@@ -858,7 +871,7 @@ public class DecisionService {
 
         // Step 2: Check local holdouts
         if (rule != null) {
-            DecisionResponse<FeatureDecision> holdoutResponse = evaluateLocalHoldouts(rule, projectConfig, user);
+            DecisionResponse<FeatureDecision> holdoutResponse = evaluateLocalHoldouts(rule, projectConfig, user, false);
             reasons.merge(holdoutResponse.getReasons());
             if (holdoutResponse.getResult() != null) {
                 return new DecisionResponse<>(holdoutResponse.getResult(), reasons);
@@ -920,7 +933,7 @@ public class DecisionService {
         }
 
         // Step 2: Check local holdouts
-        DecisionResponse<FeatureDecision> holdoutResponse = evaluateLocalHoldouts(rule, projectConfig, user);
+        DecisionResponse<FeatureDecision> holdoutResponse = evaluateLocalHoldouts(rule, projectConfig, user, true);
         reasons.merge(holdoutResponse.getReasons());
         if (holdoutResponse.getResult() != null) {
             resultPair = new AbstractMap.SimpleEntry<>(holdoutResponse.getResult(), false);

--- a/core-api/src/main/java/com/optimizely/ab/bucketing/DecisionService.java
+++ b/core-api/src/main/java/com/optimizely/ab/bucketing/DecisionService.java
@@ -348,7 +348,7 @@ public class DecisionService {
             }
 
             if (globalHoldoutDecision != null && excludeTargetedDeliveries) {
-                reasons.addInfo("Holdout '%s' has excludeTargetedDeliveries enabled, continuing to rollout evaluation.", globalHoldoutDecision.experiment.getKey());
+                reasons.addInfo("Holdout \"%s\" has excludeTargetedDeliveries enabled, continuing to rollout evaluation.", globalHoldoutDecision.experiment.getKey());
             }
 
             if (globalHoldoutDecision == null) {

--- a/core-api/src/main/java/com/optimizely/ab/bucketing/FeatureDecision.java
+++ b/core-api/src/main/java/com/optimizely/ab/bucketing/FeatureDecision.java
@@ -45,6 +45,13 @@ public class FeatureDecision {
     @Nullable
     public String cmabUuid;
 
+    @Nullable
+    public FeatureDecision holdoutDecision;
+
+    public void setHoldoutDecision(@Nullable FeatureDecision holdoutDecision) {
+        this.holdoutDecision = holdoutDecision;
+    }
+
     public enum DecisionSource {
         FEATURE_TEST("feature-test"),
         ROLLOUT("rollout"),

--- a/core-api/src/main/java/com/optimizely/ab/config/Holdout.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/Holdout.java
@@ -51,6 +51,8 @@ public class Holdout implements ExperimentCore {
     @Nullable
     private final List<String> includedRules;
 
+    private final boolean excludeTargetedDeliveries;
+
     private final Map<String, Variation> variationKeyToVariationMap;
     private final Map<String, Variation> variationIdToVariationMap;
     // Not necessary for HO
@@ -75,7 +77,7 @@ public class Holdout implements ExperimentCore {
 
     @VisibleForTesting
     public Holdout(String id, String key) {
-        this(id, key, "Running", Collections.emptyList(), null, Collections.emptyList(), Collections.emptyList(), null);
+        this(id, key, "Running", Collections.emptyList(), null, Collections.emptyList(), Collections.emptyList(), null, false);
     }
 
     /**
@@ -88,7 +90,7 @@ public class Holdout implements ExperimentCore {
             @Nullable Condition audienceConditions,
             @Nonnull List<Variation> variations,
             @Nonnull List<TrafficAllocation> trafficAllocation) {
-        this(id, key, status, audienceIds, audienceConditions, variations, trafficAllocation, null);
+        this(id, key, status, audienceIds, audienceConditions, variations, trafficAllocation, null, false);
     }
 
     /**
@@ -105,7 +107,8 @@ public class Holdout implements ExperimentCore {
             @JsonProperty("audienceConditions") @Nullable Condition audienceConditions,
             @JsonProperty("variations") @Nonnull List<Variation> variations,
             @JsonProperty("trafficAllocation") @Nonnull List<TrafficAllocation> trafficAllocation,
-            @JsonProperty("includedRules") @Nullable List<String> includedRules) {
+            @JsonProperty("includedRules") @Nullable List<String> includedRules,
+            @JsonProperty("exclude_targeted_deliveries") @Nullable Boolean excludeTargetedDeliveries) {
         this.id = id;
         this.key = key;
         this.status = status;
@@ -114,6 +117,7 @@ public class Holdout implements ExperimentCore {
         this.variations = variations;
         this.trafficAllocation = trafficAllocation;
         this.includedRules = includedRules;
+        this.excludeTargetedDeliveries = excludeTargetedDeliveries != null ? excludeTargetedDeliveries : false;
         this.variationKeyToVariationMap = ProjectConfigUtils.generateNameMapping(this.variations);
         this.variationIdToVariationMap = ProjectConfigUtils.generateIdMapping(this.variations);
     }
@@ -188,6 +192,10 @@ public class Holdout implements ExperimentCore {
      *
      * @return true if this is a global holdout, false if it is a local holdout
      */
+    public boolean isExcludeTargetedDeliveries() {
+        return excludeTargetedDeliveries;
+    }
+
     public boolean isGlobal() {
         return includedRules == null;
     }
@@ -204,6 +212,7 @@ public class Holdout implements ExperimentCore {
                 + ", variationKeyToVariationMap=" + variationKeyToVariationMap
                 + ", trafficAllocation=" + trafficAllocation
                 + ", includedRules=" + includedRules
+                + ", excludeTargetedDeliveries=" + excludeTargetedDeliveries
                 + '}';
     }
 }

--- a/core-api/src/main/java/com/optimizely/ab/config/HoldoutConfig.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/HoldoutConfig.java
@@ -193,7 +193,8 @@ public class HoldoutConfig {
             holdout.getAudienceConditions(),
             holdout.getVariations(),
             holdout.getTrafficAllocation(),
-            null
+            null,
+            holdout.isExcludeTargetedDeliveries()
         );
     }
 

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/GsonHelpers.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/GsonHelpers.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2016-2017, 2019, Optimizely and contributors
+ *    Copyright 2016-2017, 2019, 2026, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -212,7 +212,12 @@ final class GsonHelpers {
             }
         }
 
-        return new Holdout(id, key, status, audienceIds, conditions, variations, trafficAllocations, includedRules);
+        boolean excludeTargetedDeliveries = false;
+        if (holdoutJson.has("exclude_targeted_deliveries") && !holdoutJson.get("exclude_targeted_deliveries").isJsonNull()) {
+            excludeTargetedDeliveries = holdoutJson.get("exclude_targeted_deliveries").getAsBoolean();
+        }
+
+        return new Holdout(id, key, status, audienceIds, conditions, variations, trafficAllocations, includedRules, excludeTargetedDeliveries);
     }
 
     static FeatureFlag parseFeatureFlag(JsonObject featureFlagJson, JsonDeserializationContext context) {

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/JsonConfigParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/JsonConfigParser.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2016-2022, Optimizely and contributors
+ *    Copyright 2016-2022, 2026, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -238,8 +238,13 @@ final public class JsonConfigParser implements ConfigParser {
                 }
             }
 
+            boolean excludeTargetedDeliveries = false;
+            if (holdoutObject.has("exclude_targeted_deliveries") && !holdoutObject.isNull("exclude_targeted_deliveries")) {
+                excludeTargetedDeliveries = holdoutObject.getBoolean("exclude_targeted_deliveries");
+            }
+
             holdouts.add(new Holdout(id, key, status, audienceIds, conditions, variations,
-                trafficAllocations, includedRules));
+                trafficAllocations, includedRules, excludeTargetedDeliveries));
         }
 
         return holdouts;

--- a/core-api/src/main/java/com/optimizely/ab/config/parser/JsonSimpleConfigParser.java
+++ b/core-api/src/main/java/com/optimizely/ab/config/parser/JsonSimpleConfigParser.java
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright 2016-2022, Optimizely and contributors
+ *    Copyright 2016-2022, 2026, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -257,8 +257,13 @@ final public class JsonSimpleConfigParser implements ConfigParser {
                 }
             }
 
+            boolean excludeTargetedDeliveries = false;
+            if (hoObject.containsKey("exclude_targeted_deliveries") && hoObject.get("exclude_targeted_deliveries") != null) {
+                excludeTargetedDeliveries = (Boolean) hoObject.get("exclude_targeted_deliveries");
+            }
+
             holdouts.add(new Holdout(id, key, status, audienceIds, conditions, variations,
-                trafficAllocations, includedRules));
+                trafficAllocations, includedRules, excludeTargetedDeliveries));
         }
 
         return holdouts;

--- a/core-api/src/test/java/com/optimizely/ab/bucketing/DecisionServiceTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/bucketing/DecisionServiceTest.java
@@ -2168,6 +2168,28 @@ public class DecisionServiceTest {
         assertEquals(HOLDOUT_GLOBAL_EXCLUDE_TARGETED_DELIVERIES, decision.holdoutDecision.experiment);
     }
 
+    @Test
+    public void globalHoldout_excludeTD_addsDecisionReason() {
+        ProjectConfig config = ValidProjectConfigV4.generateValidProjectConfigV4_globalHoldoutExcludeTargetedDeliveries();
+
+        Bucketer bucketer = new Bucketer();
+        DecisionService ds = new DecisionService(bucketer, mockErrorHandler, null, mockCmabService);
+
+        DecisionResponse<FeatureDecision> response = ds.getVariationForFeature(
+            FEATURE_FLAG_SINGLE_VARIABLE_INTEGER,
+            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap()),
+            config
+        );
+
+        List<String> reasons = response.getReasons().toReport();
+        String expectedReason = String.format(
+            "Holdout '%s' has excludeTargetedDeliveries enabled, continuing to rollout evaluation.",
+            HOLDOUT_GLOBAL_EXCLUDE_TARGETED_DELIVERIES.getKey()
+        );
+        assertTrue("Reasons should contain excludeTargetedDeliveries bypass message",
+            reasons.contains(expectedReason));
+    }
+
     private Experiment createMockCmabExperiment() {
         List<Variation> variations = Arrays.asList(
             new Variation("111151", "variation_1"),

--- a/core-api/src/test/java/com/optimizely/ab/bucketing/DecisionServiceTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/bucketing/DecisionServiceTest.java
@@ -2183,7 +2183,7 @@ public class DecisionServiceTest {
 
         List<String> reasons = response.getReasons().toReport();
         String expectedReason = String.format(
-            "Holdout '%s' has excludeTargetedDeliveries enabled, continuing to rollout evaluation.",
+            "Holdout \"%s\" has excludeTargetedDeliveries enabled, continuing to rollout evaluation.",
             HOLDOUT_GLOBAL_EXCLUDE_TARGETED_DELIVERIES.getKey()
         );
         assertTrue("Reasons should contain excludeTargetedDeliveries bypass message",

--- a/core-api/src/test/java/com/optimizely/ab/bucketing/DecisionServiceTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/bucketing/DecisionServiceTest.java
@@ -82,6 +82,8 @@ import static com.optimizely.ab.config.ValidProjectConfigV4.FEATURE_FLAG_SINGLE_
 import static com.optimizely.ab.config.ValidProjectConfigV4.FEATURE_MULTI_VARIATE_FEATURE_KEY;
 import static com.optimizely.ab.config.ValidProjectConfigV4.HOLDOUT_BASIC_HOLDOUT;
 import static com.optimizely.ab.config.ValidProjectConfigV4.HOLDOUT_TYPEDAUDIENCE_HOLDOUT;
+import static com.optimizely.ab.config.ValidProjectConfigV4.HOLDOUT_GLOBAL_EXCLUDE_TARGETED_DELIVERIES;
+import static com.optimizely.ab.config.ValidProjectConfigV4.HOLDOUT_LOCAL_EXCLUDE_TARGETED_DELIVERIES;
 import static com.optimizely.ab.config.ValidProjectConfigV4.ROLLOUT_2;
 import static com.optimizely.ab.config.ValidProjectConfigV4.ROLLOUT_3_EVERYONE_ELSE_RULE;
 import static com.optimizely.ab.config.ValidProjectConfigV4.ROLLOUT_3_EVERYONE_ELSE_RULE_ENABLED_VARIATION;
@@ -307,7 +309,7 @@ public class DecisionServiceTest {
 
     }
 
-    //========== get Variation for Feature tests ==========//
+    //========= get Variation for Feature tests =========/
 
     /**
      * Verify that {@link DecisionService#getVariationForFeature(FeatureFlag, OptimizelyUserContext, ProjectConfig)}
@@ -556,7 +558,7 @@ public class DecisionServiceTest {
         );
     }
 
-    //========== getVariationForFeatureList tests ==========//
+    //========= getVariationForFeatureList tests =========/
 
     @Test
     public void getVariationsForFeatureListBatchesUpsLoadAndSave() throws Exception {
@@ -583,7 +585,7 @@ public class DecisionServiceTest {
     }
 
 
-    //========== getVariationForFeatureInRollout tests ==========//
+    //========= getVariationForFeatureInRollout tests =========/
 
     /**
      * Verify that {@link DecisionService#getVariationForFeatureInRollout(FeatureFlag, OptimizelyUserContext, ProjectConfig)}
@@ -889,7 +891,7 @@ public class DecisionServiceTest {
         assertEquals(variationKey, variation.getKey());
     }
 
-    //========= white list tests ==========/
+    //========= white list tests =========/
 
     /**
      * Test {@link DecisionService#getWhitelistedVariation(Experiment, String)} correctly returns a whitelisted variation.
@@ -938,7 +940,7 @@ public class DecisionServiceTest {
         assertNull(decisionService.getWhitelistedVariation(whitelistedExperiment, genericUserId).getResult());
     }
 
-    //======== User Profile tests =========//
+    //========= User Profile tests =========/
 
     /**
      * Verify that {@link DecisionService#getStoredVariation(Experiment, UserProfile, ProjectConfig)} returns a variation that is
@@ -1746,7 +1748,6 @@ public class DecisionServiceTest {
             String.format("Saved user profile of user \"%s\".", genericUserId));
     }
 
-    // ===================================================================
     //========= evaluateLocalHoldouts tests =========/
 
     @Test
@@ -1759,7 +1760,8 @@ public class DecisionServiceTest {
 
         DecisionResponse<FeatureDecision> response = decisionService.evaluateLocalHoldouts(
             targetedRule, localHoldoutConfig,
-            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap())
+            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap()),
+            false
         );
 
         assertNotNull(response.getResult());
@@ -1779,7 +1781,8 @@ public class DecisionServiceTest {
 
         DecisionResponse<FeatureDecision> response = decisionService.evaluateLocalHoldouts(
             untargetedRule, localHoldoutConfig,
-            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap())
+            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap()),
+            false
         );
 
         assertNull(response.getResult());
@@ -1795,14 +1798,14 @@ public class DecisionServiceTest {
 
         DecisionResponse<FeatureDecision> response = decisionService.evaluateLocalHoldouts(
             rule, noHoldoutConfig,
-            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap())
+            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap()),
+            false
         );
 
         assertNull(response.getResult());
     }
 
-    // Local holdout decision service tests (FSSDK-12369)
-    // ===================================================================
+    //========= global holdout tests =========/
 
     /**
      * Global holdout is evaluated at flag level — a user bucketed into a global holdout
@@ -1937,6 +1940,169 @@ public class DecisionServiceTest {
         assertNotNull("Forced decision should produce a result", featureDecision);
         assertNotEquals("Forced decision must NOT return holdout variation",
             FeatureDecision.DecisionSource.HOLDOUT, featureDecision.decisionSource);
+    }
+
+    //========= excludeTargetedDeliveries tests =========/
+
+    @Test
+    public void excludeTargetedDeliveries_defaultsToFalse() {
+        assertFalse(HOLDOUT_BASIC_HOLDOUT.isExcludeTargetedDeliveries());
+    }
+
+    @Test
+    public void excludeTargetedDeliveries_trueWhenSetOnHoldout() {
+        assertTrue(HOLDOUT_GLOBAL_EXCLUDE_TARGETED_DELIVERIES.isExcludeTargetedDeliveries());
+    }
+
+    @Test
+    public void excludeTargetedDeliveries_globalHoldoutFalse_blocksAllRules() {
+        ProjectConfig holdoutConfig = generateValidProjectConfigV4_holdout();
+
+        Bucketer bucketer = new Bucketer();
+        DecisionService ds = new DecisionService(bucketer, mockErrorHandler, null, mockCmabService);
+
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("$opt_bucketing_id", "ppid160000");
+        FeatureDecision decision = ds.getVariationForFeature(
+            FEATURE_FLAG_BOOLEAN_FEATURE,
+            optimizely.createUserContext("user123", attributes),
+            holdoutConfig
+        ).getResult();
+
+        assertEquals(FeatureDecision.DecisionSource.HOLDOUT, decision.decisionSource);
+        assertEquals(HOLDOUT_BASIC_HOLDOUT, decision.experiment);
+    }
+
+    @Test
+    public void excludeTargetedDeliveries_globalHoldoutTrue_blocksExperimentRules() {
+        ProjectConfig config = ValidProjectConfigV4.generateValidProjectConfigV4_globalHoldoutExcludeTargetedDeliveries();
+
+        Bucketer bucketer = new Bucketer();
+        DecisionService ds = new DecisionService(bucketer, mockErrorHandler, null, mockCmabService);
+
+        FeatureDecision decision = ds.getVariationForFeature(
+            ValidProjectConfigV4.FEATURE_FLAG_BASIC_EXPERIMENT_FEATURE,
+            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap()),
+            config
+        ).getResult();
+
+        assertNotNull(decision);
+        assertEquals(FeatureDecision.DecisionSource.HOLDOUT, decision.decisionSource);
+    }
+
+    @Test
+    public void excludeTargetedDeliveries_globalHoldoutTrue_allowsDeliveryRules() {
+        ProjectConfig config = ValidProjectConfigV4.generateValidProjectConfigV4_globalHoldoutExcludeTargetedDeliveries();
+
+        Bucketer bucketer = new Bucketer();
+        DecisionService ds = new DecisionService(bucketer, mockErrorHandler, null, mockCmabService);
+
+        FeatureDecision decision = ds.getVariationForFeature(
+            FEATURE_FLAG_SINGLE_VARIABLE_INTEGER,
+            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap()),
+            config
+        ).getResult();
+
+        assertNotNull(decision);
+        assertNotNull(decision.variation);
+        assertEquals(FeatureDecision.DecisionSource.ROLLOUT, decision.decisionSource);
+    }
+
+    @Test
+    public void excludeTargetedDeliveries_globalHoldoutTrue_noDeliveryMatch_returnsHoldout() {
+        ProjectConfig config = ValidProjectConfigV4.generateValidProjectConfigV4_globalHoldoutExcludeTargetedDeliveries();
+
+        Bucketer bucketer = new Bucketer();
+        DecisionService ds = new DecisionService(bucketer, mockErrorHandler, null, mockCmabService);
+
+        FeatureDecision decision = ds.getVariationForFeature(
+            FEATURE_FLAG_BOOLEAN_FEATURE,
+            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap()),
+            config
+        ).getResult();
+
+        assertNotNull(decision);
+        assertEquals(FeatureDecision.DecisionSource.HOLDOUT, decision.decisionSource);
+        assertEquals(HOLDOUT_GLOBAL_EXCLUDE_TARGETED_DELIVERIES, decision.experiment);
+    }
+
+    @Test
+    public void excludeTargetedDeliveries_localHoldoutTrue_skipsHoldoutForDeliveryRules() {
+        ProjectConfig config = ValidProjectConfigV4.generateValidProjectConfigV4_localHoldoutExcludeTargetedDeliveries();
+
+        Bucketer bucketer = new Bucketer();
+        DecisionService ds = new DecisionService(bucketer, mockErrorHandler, null, mockCmabService);
+
+        Experiment deliveryRule = mock(Experiment.class);
+        when(deliveryRule.getId()).thenReturn(ValidProjectConfigV4.EXPERIMENT_BASIC_EXPERIMENT_KEY);
+
+        DecisionResponse<FeatureDecision> response = ds.evaluateLocalHoldouts(
+            deliveryRule, config,
+            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap()),
+            true
+        );
+
+        assertNull(response.getResult());
+    }
+
+    @Test
+    public void excludeTargetedDeliveries_localHoldoutTrue_appliesForExperimentRules() {
+        ProjectConfig config = ValidProjectConfigV4.generateValidProjectConfigV4_localHoldoutExcludeTargetedDeliveries();
+
+        Bucketer bucketer = new Bucketer();
+        DecisionService ds = new DecisionService(bucketer, mockErrorHandler, null, mockCmabService);
+
+        FeatureDecision decision = ds.getVariationForFeature(
+            ValidProjectConfigV4.FEATURE_FLAG_BASIC_EXPERIMENT_FEATURE,
+            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap()),
+            config
+        ).getResult();
+
+        assertNotNull(decision);
+        assertEquals(FeatureDecision.DecisionSource.HOLDOUT, decision.decisionSource);
+        assertEquals(HOLDOUT_LOCAL_EXCLUDE_TARGETED_DELIVERIES, decision.experiment);
+    }
+
+    @Test
+    public void excludeTargetedDeliveries_evaluateLocalHoldouts_falseDoesNotSkipForDeliveryRules() {
+        ProjectConfig config = ValidProjectConfigV4.generateValidProjectConfigV4_localHoldout();
+        Experiment targetedRule = config.getExperimentIdMapping().get("1323241596");
+
+        Bucketer bucketer = new Bucketer();
+        DecisionService ds = new DecisionService(bucketer, mockErrorHandler, null, mockCmabService);
+
+        DecisionResponse<FeatureDecision> response = ds.evaluateLocalHoldouts(
+            targetedRule, config,
+            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap()),
+            true
+        );
+
+        assertNotNull(response.getResult());
+        assertEquals(FeatureDecision.DecisionSource.HOLDOUT, response.getResult().decisionSource);
+    }
+
+    @Test
+    public void excludeTargetedDeliveries_forcedDecisionBeatsLocalHoldoutWithExcludeFlag() {
+        ProjectConfig config = ValidProjectConfigV4.generateValidProjectConfigV4_localHoldoutExcludeTargetedDeliveries();
+
+        Bucketer bucketer = new Bucketer();
+        DecisionService ds = new DecisionService(bucketer, mockErrorHandler, null, mockCmabService);
+
+        OptimizelyUserContext userContext = optimizely.createUserContext("forced_user", Collections.<String, Object>emptyMap());
+        userContext.setForcedDecision(
+            new OptimizelyDecisionContext(ValidProjectConfigV4.FEATURE_FLAG_BASIC_EXPERIMENT_FEATURE_KEY,
+                ValidProjectConfigV4.EXPERIMENT_BASIC_EXPERIMENT_KEY),
+            new OptimizelyForcedDecision("A")
+        );
+
+        FeatureDecision decision = ds.getVariationForFeature(
+            ValidProjectConfigV4.FEATURE_FLAG_BASIC_EXPERIMENT_FEATURE,
+            userContext,
+            config
+        ).getResult();
+
+        assertNotNull(decision);
+        assertNotEquals(FeatureDecision.DecisionSource.HOLDOUT, decision.decisionSource);
     }
 
     private Experiment createMockCmabExperiment() {

--- a/core-api/src/test/java/com/optimizely/ab/bucketing/DecisionServiceTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/bucketing/DecisionServiceTest.java
@@ -1760,8 +1760,7 @@ public class DecisionServiceTest {
 
         DecisionResponse<FeatureDecision> response = decisionService.evaluateLocalHoldouts(
             targetedRule, localHoldoutConfig,
-            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap()),
-            false
+            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap())
         );
 
         assertNotNull(response.getResult());
@@ -1781,8 +1780,7 @@ public class DecisionServiceTest {
 
         DecisionResponse<FeatureDecision> response = decisionService.evaluateLocalHoldouts(
             untargetedRule, localHoldoutConfig,
-            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap()),
-            false
+            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap())
         );
 
         assertNull(response.getResult());
@@ -1798,8 +1796,7 @@ public class DecisionServiceTest {
 
         DecisionResponse<FeatureDecision> response = decisionService.evaluateLocalHoldouts(
             rule, noHoldoutConfig,
-            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap()),
-            false
+            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap())
         );
 
         assertNull(response.getResult());
@@ -1974,7 +1971,7 @@ public class DecisionServiceTest {
     }
 
     @Test
-    public void excludeTargetedDeliveries_globalHoldoutTrue_blocksExperimentRules() {
+    public void excludeTargetedDeliveries_globalHoldoutTrue_skipsExperimentRules() {
         ProjectConfig config = ValidProjectConfigV4.generateValidProjectConfigV4_globalHoldoutExcludeTargetedDeliveries();
 
         Bucketer bucketer = new Bucketer();
@@ -1986,8 +1983,12 @@ public class DecisionServiceTest {
             config
         ).getResult();
 
-        assertNotNull(decision);
-        assertEquals(FeatureDecision.DecisionSource.HOLDOUT, decision.decisionSource);
+        assertTrue("With excludeTargetedDeliveries=true and no rollout, variation should be null",
+            decision == null || decision.variation == null);
+        if (decision != null) {
+            assertNotNull("holdoutDecision should be attached", decision.holdoutDecision);
+            assertEquals(FeatureDecision.DecisionSource.HOLDOUT, decision.holdoutDecision.decisionSource);
+        }
     }
 
     @Test
@@ -2009,7 +2010,7 @@ public class DecisionServiceTest {
     }
 
     @Test
-    public void excludeTargetedDeliveries_globalHoldoutTrue_noDeliveryMatch_returnsHoldout() {
+    public void excludeTargetedDeliveries_globalHoldoutTrue_noDeliveryMatch_returnsNullWithHoldoutAttached() {
         ProjectConfig config = ValidProjectConfigV4.generateValidProjectConfigV4_globalHoldoutExcludeTargetedDeliveries();
 
         Bucketer bucketer = new Bucketer();
@@ -2021,28 +2022,30 @@ public class DecisionServiceTest {
             config
         ).getResult();
 
-        assertNotNull(decision);
-        assertEquals(FeatureDecision.DecisionSource.HOLDOUT, decision.decisionSource);
-        assertEquals(HOLDOUT_GLOBAL_EXCLUDE_TARGETED_DELIVERIES, decision.experiment);
+        assertTrue("When excludeTargetedDeliveries=true and no delivery match, variation should be null",
+            decision == null || decision.variation == null);
+        if (decision != null) {
+            assertNotNull("holdoutDecision should be attached", decision.holdoutDecision);
+            assertEquals(FeatureDecision.DecisionSource.HOLDOUT, decision.holdoutDecision.decisionSource);
+        }
     }
 
     @Test
-    public void excludeTargetedDeliveries_localHoldoutTrue_skipsHoldoutForDeliveryRules() {
+    public void excludeTargetedDeliveries_localHoldoutTrue_appliesHoldoutForDeliveryRules() {
         ProjectConfig config = ValidProjectConfigV4.generateValidProjectConfigV4_localHoldoutExcludeTargetedDeliveries();
 
         Bucketer bucketer = new Bucketer();
         DecisionService ds = new DecisionService(bucketer, mockErrorHandler, null, mockCmabService);
 
-        Experiment deliveryRule = mock(Experiment.class);
-        when(deliveryRule.getId()).thenReturn(ValidProjectConfigV4.EXPERIMENT_BASIC_EXPERIMENT_KEY);
+        Experiment deliveryRule = config.getExperimentIdMapping().get("1323241596");
 
         DecisionResponse<FeatureDecision> response = ds.evaluateLocalHoldouts(
             deliveryRule, config,
-            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap()),
-            true
+            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap())
         );
 
-        assertNull(response.getResult());
+        assertNotNull(response.getResult());
+        assertEquals(FeatureDecision.DecisionSource.HOLDOUT, response.getResult().decisionSource);
     }
 
     @Test
@@ -2073,8 +2076,7 @@ public class DecisionServiceTest {
 
         DecisionResponse<FeatureDecision> response = ds.evaluateLocalHoldouts(
             targetedRule, config,
-            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap()),
-            true
+            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap())
         );
 
         assertNotNull(response.getResult());
@@ -2103,6 +2105,67 @@ public class DecisionServiceTest {
 
         assertNotNull(decision);
         assertNotEquals(FeatureDecision.DecisionSource.HOLDOUT, decision.decisionSource);
+    }
+
+    //========= local holdout ignores excludeTargetedDeliveries tests =========/
+
+    @Test
+    public void localHoldout_ignoresExcludeTargetedDeliveries() {
+        ProjectConfig config = ValidProjectConfigV4.generateValidProjectConfigV4_localHoldoutExcludeTargetedDeliveries();
+
+        Bucketer bucketer = new Bucketer();
+        DecisionService ds = new DecisionService(bucketer, mockErrorHandler, null, mockCmabService);
+
+        FeatureDecision decision = ds.getVariationForFeature(
+            ValidProjectConfigV4.FEATURE_FLAG_BASIC_EXPERIMENT_FEATURE,
+            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap()),
+            config
+        ).getResult();
+
+        assertNotNull(decision);
+        assertEquals(FeatureDecision.DecisionSource.HOLDOUT, decision.decisionSource);
+        assertEquals(HOLDOUT_LOCAL_EXCLUDE_TARGETED_DELIVERIES, decision.experiment);
+    }
+
+    @Test
+    public void globalHoldout_excludeTD_rolloutReturnsNull_returnsNull() {
+        ProjectConfig config = ValidProjectConfigV4.generateValidProjectConfigV4_globalHoldoutExcludeTargetedDeliveries();
+
+        Bucketer bucketer = new Bucketer();
+        DecisionService ds = new DecisionService(bucketer, mockErrorHandler, null, mockCmabService);
+
+        FeatureDecision decision = ds.getVariationForFeature(
+            FEATURE_FLAG_BOOLEAN_FEATURE,
+            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap()),
+            config
+        ).getResult();
+
+        assertTrue("When excludeTargetedDeliveries=true and rollout returns null, result should be null or have null variation",
+            decision == null || decision.variation == null);
+        if (decision != null) {
+            assertNotEquals(FeatureDecision.DecisionSource.HOLDOUT, decision.decisionSource);
+        }
+    }
+
+    @Test
+    public void globalHoldout_excludeTD_holdoutDecisionAttached() {
+        ProjectConfig config = ValidProjectConfigV4.generateValidProjectConfigV4_globalHoldoutExcludeTargetedDeliveries();
+
+        Bucketer bucketer = new Bucketer();
+        DecisionService ds = new DecisionService(bucketer, mockErrorHandler, null, mockCmabService);
+
+        FeatureDecision decision = ds.getVariationForFeature(
+            FEATURE_FLAG_SINGLE_VARIABLE_INTEGER,
+            optimizely.createUserContext("any_user", Collections.<String, Object>emptyMap()),
+            config
+        ).getResult();
+
+        assertNotNull(decision);
+        assertEquals(FeatureDecision.DecisionSource.ROLLOUT, decision.decisionSource);
+        assertNotNull("holdoutDecision should be attached when user is in holdout with excludeTargetedDeliveries=true",
+            decision.holdoutDecision);
+        assertEquals(FeatureDecision.DecisionSource.HOLDOUT, decision.holdoutDecision.decisionSource);
+        assertEquals(HOLDOUT_GLOBAL_EXCLUDE_TARGETED_DELIVERIES, decision.holdoutDecision.experiment);
     }
 
     private Experiment createMockCmabExperiment() {

--- a/core-api/src/test/java/com/optimizely/ab/config/HoldoutConfigTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/HoldoutConfigTest.java
@@ -52,7 +52,8 @@ public class HoldoutConfigTest {
             null,
             Collections.<Variation>emptyList(),
             Collections.<TrafficAllocation>emptyList(),
-            Arrays.asList("ruleA")
+            Arrays.asList("ruleA"),
+            false
         );
 
         // Local holdout targeting rules "ruleA" and "ruleB"
@@ -63,7 +64,8 @@ public class HoldoutConfigTest {
             null,
             Collections.<Variation>emptyList(),
             Collections.<TrafficAllocation>emptyList(),
-            Arrays.asList("ruleA", "ruleB")
+            Arrays.asList("ruleA", "ruleB"),
+            false
         );
 
         // Local holdout with empty includedRules list — targets no rules
@@ -74,7 +76,8 @@ public class HoldoutConfigTest {
             null,
             Collections.<Variation>emptyList(),
             Collections.<TrafficAllocation>emptyList(),
-            Collections.<String>emptyList()
+            Collections.<String>emptyList(),
+            false
         );
     }
 
@@ -265,7 +268,7 @@ public class HoldoutConfigTest {
     }
 
     // -----------------------------------------------------------------------
-    // Section-aware constructor (FSSDK-12760): localHoldouts datafile section
+    // Section-aware constructor: localHoldouts datafile section
     // -----------------------------------------------------------------------
 
     @Test
@@ -299,7 +302,8 @@ public class HoldoutConfigTest {
             null,
             Collections.<Variation>emptyList(),
             Collections.<TrafficAllocation>emptyList(),
-            Arrays.asList("ruleA")
+            Arrays.asList("ruleA"),
+            false
         );
 
         HoldoutConfig config = new HoldoutConfig(
@@ -335,7 +339,8 @@ public class HoldoutConfigTest {
             null,
             Collections.<Variation>emptyList(),
             Collections.<TrafficAllocation>emptyList(),
-            null  // missing includedRules
+            null,  // missing includedRules
+            false
         );
 
         HoldoutConfig config = new HoldoutConfig(

--- a/core-api/src/test/java/com/optimizely/ab/config/HoldoutTest.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/HoldoutTest.java
@@ -196,6 +196,48 @@ public class HoldoutTest {
         return conditionTestScenarios;
     }
 
+    @Test
+    public void testExcludeTargetedDeliveries_defaultsToFalse() {
+        Holdout holdout = new Holdout("id1", "key1");
+        assertEquals(false, holdout.isExcludeTargetedDeliveries());
+    }
+
+    @Test
+    public void testExcludeTargetedDeliveries_defaultsToFalseWhenNullPassedToConstructor() {
+        Holdout holdout = new Holdout(
+            "id1", "key1", "Running",
+            Collections.<String>emptyList(), null,
+            Collections.<Variation>emptyList(),
+            Collections.<TrafficAllocation>emptyList(),
+            null, null
+        );
+        assertEquals(false, holdout.isExcludeTargetedDeliveries());
+    }
+
+    @Test
+    public void testExcludeTargetedDeliveries_trueWhenSet() {
+        Holdout holdout = new Holdout(
+            "id1", "key1", "Running",
+            Collections.<String>emptyList(), null,
+            Collections.<Variation>emptyList(),
+            Collections.<TrafficAllocation>emptyList(),
+            null, true
+        );
+        assertEquals(true, holdout.isExcludeTargetedDeliveries());
+    }
+
+    @Test
+    public void testExcludeTargetedDeliveries_falseWhenExplicitlySet() {
+        Holdout holdout = new Holdout(
+            "id1", "key1", "Running",
+            Collections.<String>emptyList(), null,
+            Collections.<Variation>emptyList(),
+            Collections.<TrafficAllocation>emptyList(),
+            null, false
+        );
+        assertEquals(false, holdout.isExcludeTargetedDeliveries());
+    }
+
     private Holdout makeMockHoldoutWithStatus(Holdout.HoldoutStatus status, Condition audienceConditions) {
         return new Holdout("12345",
             "mockHoldoutKey",

--- a/core-api/src/test/java/com/optimizely/ab/config/ValidProjectConfigV4.java
+++ b/core-api/src/test/java/com/optimizely/ab/config/ValidProjectConfigV4.java
@@ -609,7 +609,8 @@ public class ValidProjectConfigV4 {
         ),
         DatafileProjectConfigTestUtils.createListOfObjects(
             EXPERIMENT_BASIC_EXPERIMENT_ID
-        )
+        ),
+        false
     );
 
     /**
@@ -647,7 +648,48 @@ public class ValidProjectConfigV4 {
         ),
         DatafileProjectConfigTestUtils.createListOfObjects(
             EXPERIMENT_BASIC_EXPERIMENT_ID  // targets the basic experiment rule
-        )
+        ),
+        false
+    );
+
+    public static final Holdout HOLDOUT_GLOBAL_EXCLUDE_TARGETED_DELIVERIES = new Holdout(
+        "30075323428",
+        "global_holdout_exclude_td",
+        Holdout.HoldoutStatus.RUNNING.toString(),
+        Collections.<String>emptyList(),
+        null,
+        DatafileProjectConfigTestUtils.createListOfObjects(
+            VARIATION_HOLDOUT_VARIATION_OFF
+        ),
+        DatafileProjectConfigTestUtils.createListOfObjects(
+            new TrafficAllocation(
+                "$opt_dummy_variation_id",
+                10000
+            )
+        ),
+        null,
+        true
+    );
+
+    public static final Holdout HOLDOUT_LOCAL_EXCLUDE_TARGETED_DELIVERIES = new Holdout(
+        "30075323429",
+        "local_holdout_exclude_td",
+        Holdout.HoldoutStatus.RUNNING.toString(),
+        Collections.<String>emptyList(),
+        null,
+        DatafileProjectConfigTestUtils.createListOfObjects(
+            VARIATION_HOLDOUT_VARIATION_OFF
+        ),
+        DatafileProjectConfigTestUtils.createListOfObjects(
+            new TrafficAllocation(
+                "$opt_dummy_variation_id",
+                10000
+            )
+        ),
+        DatafileProjectConfigTestUtils.createListOfObjects(
+            EXPERIMENT_BASIC_EXPERIMENT_ID
+        ),
+        true
     );
 
     private static final String LAYER_TYPEDAUDIENCE_EXPERIMENT_ID = "1630555627";
@@ -1764,6 +1806,190 @@ public class ValidProjectConfigV4 {
         groups.add(GROUP_2);
 
         // list rollouts
+        List<Rollout> rollouts = new ArrayList<Rollout>();
+        rollouts.add(ROLLOUT_1);
+        rollouts.add(ROLLOUT_2);
+        rollouts.add(ROLLOUT_3);
+
+        List<Integration> integrations = new ArrayList<>();
+        integrations.add(odpIntegration);
+
+        return new DatafileProjectConfig(
+            ACCOUNT_ID,
+            ANONYMIZE_IP,
+            SEND_FLAG_DECISIONS,
+            BOT_FILTERING,
+            REGION,
+            PROJECT_ID,
+            REVISION,
+            SDK_KEY,
+            ENVIRONMENT_KEY,
+            VERSION,
+            attributes,
+            audiences,
+            typedAudiences,
+            events,
+            experiments,
+            holdouts,
+            featureFlags,
+            groups,
+            rollouts,
+            integrations
+        );
+    }
+
+    public static ProjectConfig generateValidProjectConfigV4_globalHoldoutExcludeTargetedDeliveries() {
+        List<Attribute> attributes = new ArrayList<Attribute>();
+        attributes.add(ATTRIBUTE_HOUSE);
+        attributes.add(ATTRIBUTE_NATIONALITY);
+        attributes.add(ATTRIBUTE_OPT);
+        attributes.add(ATTRIBUTE_BOOLEAN);
+        attributes.add(ATTRIBUTE_INTEGER);
+        attributes.add(ATTRIBUTE_DOUBLE);
+        attributes.add(ATTRIBUTE_EMPTY);
+
+        List<Audience> audiences = new ArrayList<Audience>();
+        audiences.add(AUDIENCE_GRYFFINDOR);
+        audiences.add(AUDIENCE_SLYTHERIN);
+        audiences.add(AUDIENCE_ENGLISH_CITIZENS);
+        audiences.add(AUDIENCE_WITH_MISSING_VALUE);
+
+        List<Audience> typedAudiences = new ArrayList<Audience>();
+        typedAudiences.add(TYPED_AUDIENCE_BOOL);
+        typedAudiences.add(TYPED_AUDIENCE_EXACT_INT);
+        typedAudiences.add(TYPED_AUDIENCE_INT);
+        typedAudiences.add(TYPED_AUDIENCE_DOUBLE);
+        typedAudiences.add(TYPED_AUDIENCE_GRYFFINDOR);
+        typedAudiences.add(TYPED_AUDIENCE_SLYTHERIN);
+        typedAudiences.add(TYPED_AUDIENCE_ENGLISH_CITIZENS);
+        typedAudiences.add(AUDIENCE_WITH_MISSING_VALUE);
+
+        List<EventType> events = new ArrayList<EventType>();
+        events.add(EVENT_BASIC_EVENT);
+        events.add(EVENT_PAUSED_EXPERIMENT);
+        events.add(EVENT_LAUNCHED_EXPERIMENT_ONLY);
+
+        List<Experiment> experiments = new ArrayList<Experiment>();
+        experiments.add(EXPERIMENT_BASIC_EXPERIMENT);
+        experiments.add(EXPERIMENT_TYPEDAUDIENCE_EXPERIMENT);
+        experiments.add(EXPERIMENT_TYPEDAUDIENCE_WITH_AND_EXPERIMENT);
+        experiments.add(EXPERIMENT_TYPEDAUDIENCE_LEAF_EXPERIMENT);
+        experiments.add(EXPERIMENT_MULTIVARIATE_EXPERIMENT);
+        experiments.add(EXPERIMENT_DOUBLE_FEATURE_EXPERIMENT);
+        experiments.add(EXPERIMENT_PAUSED_EXPERIMENT);
+        experiments.add(EXPERIMENT_LAUNCHED_EXPERIMENT);
+        experiments.add(EXPERIMENT_WITH_MALFORMED_AUDIENCE);
+
+        List<Holdout> holdouts = new ArrayList<Holdout>();
+        holdouts.add(HOLDOUT_GLOBAL_EXCLUDE_TARGETED_DELIVERIES);
+
+        List<FeatureFlag> featureFlags = new ArrayList<FeatureFlag>();
+        featureFlags.add(FEATURE_FLAG_BOOLEAN_FEATURE);
+        featureFlags.add(FEATURE_FLAG_SINGLE_VARIABLE_DOUBLE);
+        featureFlags.add(FEATURE_FLAG_SINGLE_VARIABLE_INTEGER);
+        featureFlags.add(FEATURE_FLAG_SINGLE_VARIABLE_BOOLEAN);
+        featureFlags.add(FEATURE_FLAG_SINGLE_VARIABLE_STRING);
+        featureFlags.add(FEATURE_FLAG_MULTI_VARIATE_FEATURE);
+        featureFlags.add(FEATURE_FLAG_MULTI_VARIATE_FUTURE_FEATURE);
+        featureFlags.add(FEATURE_FLAG_MUTEX_GROUP_FEATURE);
+        featureFlags.add(FEATURE_FLAG_BASIC_EXPERIMENT_FEATURE);
+
+        List<Group> groups = new ArrayList<Group>();
+        groups.add(GROUP_1);
+        groups.add(GROUP_2);
+
+        List<Rollout> rollouts = new ArrayList<Rollout>();
+        rollouts.add(ROLLOUT_1);
+        rollouts.add(ROLLOUT_2);
+        rollouts.add(ROLLOUT_3);
+
+        List<Integration> integrations = new ArrayList<>();
+        integrations.add(odpIntegration);
+
+        return new DatafileProjectConfig(
+            ACCOUNT_ID,
+            ANONYMIZE_IP,
+            SEND_FLAG_DECISIONS,
+            BOT_FILTERING,
+            REGION,
+            PROJECT_ID,
+            REVISION,
+            SDK_KEY,
+            ENVIRONMENT_KEY,
+            VERSION,
+            attributes,
+            audiences,
+            typedAudiences,
+            events,
+            experiments,
+            holdouts,
+            featureFlags,
+            groups,
+            rollouts,
+            integrations
+        );
+    }
+
+    public static ProjectConfig generateValidProjectConfigV4_localHoldoutExcludeTargetedDeliveries() {
+        List<Attribute> attributes = new ArrayList<Attribute>();
+        attributes.add(ATTRIBUTE_HOUSE);
+        attributes.add(ATTRIBUTE_NATIONALITY);
+        attributes.add(ATTRIBUTE_OPT);
+        attributes.add(ATTRIBUTE_BOOLEAN);
+        attributes.add(ATTRIBUTE_INTEGER);
+        attributes.add(ATTRIBUTE_DOUBLE);
+        attributes.add(ATTRIBUTE_EMPTY);
+
+        List<Audience> audiences = new ArrayList<Audience>();
+        audiences.add(AUDIENCE_GRYFFINDOR);
+        audiences.add(AUDIENCE_SLYTHERIN);
+        audiences.add(AUDIENCE_ENGLISH_CITIZENS);
+        audiences.add(AUDIENCE_WITH_MISSING_VALUE);
+
+        List<Audience> typedAudiences = new ArrayList<Audience>();
+        typedAudiences.add(TYPED_AUDIENCE_BOOL);
+        typedAudiences.add(TYPED_AUDIENCE_EXACT_INT);
+        typedAudiences.add(TYPED_AUDIENCE_INT);
+        typedAudiences.add(TYPED_AUDIENCE_DOUBLE);
+        typedAudiences.add(TYPED_AUDIENCE_GRYFFINDOR);
+        typedAudiences.add(TYPED_AUDIENCE_SLYTHERIN);
+        typedAudiences.add(TYPED_AUDIENCE_ENGLISH_CITIZENS);
+        typedAudiences.add(AUDIENCE_WITH_MISSING_VALUE);
+
+        List<EventType> events = new ArrayList<EventType>();
+        events.add(EVENT_BASIC_EVENT);
+        events.add(EVENT_PAUSED_EXPERIMENT);
+        events.add(EVENT_LAUNCHED_EXPERIMENT_ONLY);
+
+        List<Experiment> experiments = new ArrayList<Experiment>();
+        experiments.add(EXPERIMENT_BASIC_EXPERIMENT);
+        experiments.add(EXPERIMENT_TYPEDAUDIENCE_EXPERIMENT);
+        experiments.add(EXPERIMENT_TYPEDAUDIENCE_WITH_AND_EXPERIMENT);
+        experiments.add(EXPERIMENT_TYPEDAUDIENCE_LEAF_EXPERIMENT);
+        experiments.add(EXPERIMENT_MULTIVARIATE_EXPERIMENT);
+        experiments.add(EXPERIMENT_DOUBLE_FEATURE_EXPERIMENT);
+        experiments.add(EXPERIMENT_PAUSED_EXPERIMENT);
+        experiments.add(EXPERIMENT_LAUNCHED_EXPERIMENT);
+        experiments.add(EXPERIMENT_WITH_MALFORMED_AUDIENCE);
+
+        List<Holdout> holdouts = new ArrayList<Holdout>();
+        holdouts.add(HOLDOUT_LOCAL_EXCLUDE_TARGETED_DELIVERIES);
+
+        List<FeatureFlag> featureFlags = new ArrayList<FeatureFlag>();
+        featureFlags.add(FEATURE_FLAG_BASIC_EXPERIMENT_FEATURE);
+        featureFlags.add(FEATURE_FLAG_BOOLEAN_FEATURE);
+        featureFlags.add(FEATURE_FLAG_SINGLE_VARIABLE_DOUBLE);
+        featureFlags.add(FEATURE_FLAG_SINGLE_VARIABLE_INTEGER);
+        featureFlags.add(FEATURE_FLAG_SINGLE_VARIABLE_BOOLEAN);
+        featureFlags.add(FEATURE_FLAG_SINGLE_VARIABLE_STRING);
+        featureFlags.add(FEATURE_FLAG_MULTI_VARIATE_FEATURE);
+        featureFlags.add(FEATURE_FLAG_MULTI_VARIATE_FUTURE_FEATURE);
+        featureFlags.add(FEATURE_FLAG_MUTEX_GROUP_FEATURE);
+
+        List<Group> groups = new ArrayList<Group>();
+        groups.add(GROUP_1);
+        groups.add(GROUP_2);
+
         List<Rollout> rollouts = new ArrayList<Rollout>();
         rollouts.add(ROLLOUT_1);
         rollouts.add(ROLLOUT_2);


### PR DESCRIPTION
## Summary

Implements holdout exclusion logic for Targeted Delivery rules. When a holdout's `exclude_targeted_deliveries` flag is set to true, users bucketed into that holdout will still be served Targeted Delivery rules normally, while A/B Test and Multi-Armed Bandit rules continue to respect the holdout.

## Changes

- Added `excludeTargetedDeliveries` field to the Holdout model with parsing support across all four JSON parsers (GSON, Jackson, org.json, json-simple)
- Updated DecisionService to skip holdout enforcement for delivery rules when the exclusion flag is enabled
- Preserved existing decision ordering: forced decisions take priority over local holdouts with the exclude flag

## Jira Ticket

[FSSDK-12735](https://optimizely-ext.atlassian.net/browse/FSSDK-12735)

[FSSDK-12735]: https://optimizely-ext.atlassian.net/browse/FSSDK-12735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ